### PR TITLE
Thread contexts

### DIFF
--- a/blosc/blosc.c
+++ b/blosc/blosc.c
@@ -905,6 +905,7 @@ static struct thread_context* create_thread_context(
 
   thread_context = (struct thread_context*)my_malloc(sizeof(struct thread_context));
   thread_context->parent_context = context;
+  context->tids[tid] = tid;
   thread_context->tid = tid;
 
   ebsize = context->blocksize + context->typesize * (int32_t)sizeof(int32_t);
@@ -926,12 +927,8 @@ static int do_job(struct blosc_context* context) {
   /* Run the serial version when nthreads is 1 or when the buffers are
      not larger than blocksize */
   if (context->nthreads == 1 || (context->sourcesize / context->blocksize) <= 1) {
-    if (context->tids[0] == -1) {
-      printf("Creant buffers de threads! // ");
-      /* The context for this 'thread' has no been initialized yet */
-      thread_context = create_thread_context(context, 0);
-      printf("Context tids[0]: %d", context->tids[0]);
-    }
+    /* The context for this 'thread' has no been initialized yet */
+    thread_context = create_thread_context(context, 0);
     ntbytes = serial_blosc(thread_context);
   }
   else {
@@ -1114,9 +1111,6 @@ static int initialize_context_decompression(struct blosc_context* context,
   context->nthreads = nthreads;
   context->end_threads = 0;
   context->schunk = schunk;
-  for (i = 0; i < BLOSC_MAX_THREADS; i++) {
-    context->tids[i] = -1;
-  }
 
   context->header_flags = (uint8_t*)(context->src + 2);           /* flags */
   context->typesize = (int32_t)context->src[3];      /* typesize */
@@ -1950,6 +1944,7 @@ void blosc_set_schunk(schunk_header* schunk) {
 
 struct blosc_context* create_context(int nthreads) {
   struct blosc_context* context = (struct blosc_context*)my_malloc(sizeof(struct blosc_context));
+
   return context;
 }
 

--- a/blosc/blosc.c
+++ b/blosc/blosc.c
@@ -1559,11 +1559,13 @@ static void* t_blosc(void* ctxt) {
     src = context->parent_context->src;
     dest = context->parent_context->dest;
 
-    if (blocksize > context->tmpblocksize) {
+    /* Resize the temporaries if needed */
+    if (blocksize != context->tmpblocksize) {
       my_free(context->tmp);
       context->tmp = my_malloc(blocksize + ebsize + blocksize);
       context->tmp2 = context->tmp + blocksize;
       context->tmp3 = context->tmp + blocksize + ebsize;
+      context->tmpblocksize = blocksize;
     }
 
     tmp = context->tmp;

--- a/blosc/blosc.c
+++ b/blosc/blosc.c
@@ -951,7 +951,7 @@ static int32_t compute_blocksize(struct blosc_context* context,
                                  int32_t typesize,
                                  int32_t nbytes,
                                  int32_t forced_blocksize) {
-  int32_t blocksize;
+  int32_t blocksize = nbytes;
 
   /* Protection against very small buffers */
   if (nbytes < (int32_t)typesize) {

--- a/blosc/blosc.c
+++ b/blosc/blosc.c
@@ -125,7 +125,7 @@ struct blosc_context {
   /* Super-chunk (if available) */
 
   /* Cache for temporaries for serial operation */
-  struct thread_context* serial_tmps;
+  struct thread_context* serial_context;
 
   /* Threading */
   int32_t nthreads;
@@ -928,14 +928,14 @@ static int do_job(struct blosc_context* context) {
      not larger than blocksize */
   if (context->nthreads == 1 || (context->sourcesize / context->blocksize) <= 1) {
     /* The context for this 'thread' has no been initialized yet */
-    if (context->serial_tmps == NULL) {
-      context->serial_tmps = create_thread_context(context, 0);
+    if (context->serial_context == NULL) {
+      context->serial_context = create_thread_context(context, 0);
     }
-    else if (context->blocksize != context->serial_tmps->tmpblocksize) {
-      my_free(context->serial_tmps);
-      context->serial_tmps = create_thread_context(context, 0);
+    else if (context->blocksize != context->serial_context->tmpblocksize) {
+      my_free(context->serial_context);
+      context->serial_context = create_thread_context(context, 0);
     }
-    ntbytes = serial_blosc(context->serial_tmps);
+    ntbytes = serial_blosc(context->serial_context);
   }
   else {
     /* Check whether we need to restart threads */
@@ -1489,13 +1489,13 @@ int blosc_getitem(const void* src, int start, int nitems, void* dest) {
       context.blocksize = blocksize;
       context.header_flags = &flags;
       context.schunk = g_schunk;
-      context.serial_tmps = create_thread_context(&context, 0);
-      tmp = context.serial_tmps->tmp;
-      tmp2 = context.serial_tmps->tmp2;
-      tmp3 = context.serial_tmps->tmp3;
+      context.serial_context = create_thread_context(&context, 0);
+      tmp = context.serial_context->tmp;
+      tmp2 = context.serial_context->tmp2;
+      tmp3 = context.serial_context->tmp3;
 
       /* Regular decompression.  Put results in tmp2. */
-      cbytes = blosc_d(context.serial_tmps, bsize, leftoverblock,
+      cbytes = blosc_d(context.serial_context, bsize, leftoverblock,
                        (uint8_t*)src + sw32_(bstarts + j * 4),
                        tmp2, 0, tmp, tmp3);
       if (cbytes < 0) {
@@ -1506,7 +1506,7 @@ int blosc_getitem(const void* src, int start, int nitems, void* dest) {
       memcpy((uint8_t*)dest + ntbytes, tmp2 + startb, bsize2);
       cbytes = bsize2;
 
-      my_free(context.serial_tmps);
+      my_free(context.serial_context);
     }
     ntbytes += cbytes;
   }
@@ -1950,7 +1950,7 @@ struct blosc_context* create_context(int nthreads) {
   struct blosc_context* context = (struct blosc_context*)my_malloc(sizeof(struct blosc_context));
 
   /* Initialize some struct components */
-  context->serial_tmps = NULL;
+  context->serial_context = NULL;
   context->threads = NULL;
 
   return context;
@@ -1966,8 +1966,8 @@ void blosc_init(void) {
 void blosc_destroy(void) {
   g_initlib = 0;
   blosc_release_threadpool(g_global_context);
-  if (g_global_context->serial_tmps != NULL) {
-    my_free(g_global_context->serial_tmps);
+  if (g_global_context->serial_context != NULL) {
+    my_free(g_global_context->serial_context);
   }
   my_free(g_global_context);
   pthread_mutex_destroy(&global_comp_mutex);

--- a/blosc/blosc.c
+++ b/blosc/blosc.c
@@ -2010,13 +2010,10 @@ int blosc_release_threadpool(struct blosc_context* context) {
     pthread_attr_destroy(&context->ct_attr);
   #endif
 
+    /* Release thread handlers */
+    my_free(context->threads);
   }
 
-  /* Release thread handlers */
-  if (context->threads != NULL) {
-    my_free(context->threads);
-    context->threads = NULL;
-  }
   context->threads_started = 0;
 
   return 0;

--- a/blosc/blosc.h
+++ b/blosc/blosc.h
@@ -45,9 +45,6 @@ extern "C" {
 /* Maximum typesize before considering source buffer as a stream of bytes */
 #define BLOSC_MAX_TYPESIZE 255         /* Cannot be larger than 255 */
 
-/* The maximum number of threads (for some static arrays) */
-#define BLOSC_MAX_THREADS 256
-
 /* Codes for filters (see blosc_compress) */
 #define BLOSC_NOSHUFFLE   0  /* no shuffle (for compatibility with Blosc1) */
 #define BLOSC_NOFILTER    0  /* no filter */


### PR DESCRIPTION
This allows to use contexts for codecs of filters on a per-thread basis.  This accelerates ztsd operation significantly (up to 1.5x).