### PR TITLE
Make blosc2 build without zstd

### DIFF
--- a/blosc/blosc.c
+++ b/blosc/blosc.c
@@ -933,20 +933,24 @@ static struct thread_context* create_thread_context(
   thread_context->tmp2 = thread_context->tmp + context->blocksize;
   thread_context->tmp3 = thread_context->tmp + context->blocksize + ebsize;
   thread_context->tmpblocksize = context->blocksize;
+  #if defined(HAVE_ZSTD)
   thread_context->zstd_cctx = NULL;
   thread_context->zstd_dctx = NULL;
+  #endif
 
   return thread_context;
 }
 
 void free_thread_context(struct thread_context* thread_context) {
   my_free(thread_context->tmp);
+  #if defined(HAVE_ZSTD)
   if (thread_context->zstd_cctx != NULL) {
     ZSTD_freeCCtx(thread_context->zstd_cctx);
   }
   if (thread_context->zstd_dctx != NULL) {
     ZSTD_freeDCtx(thread_context->zstd_dctx);
   }
+  #endif
   my_free(thread_context);
 }
 


### PR DESCRIPTION
This just adds in some missing ifdef's I needed this to build this https://github.com/jcftang/go-blosc/commit/8be85d0a64164f1586021beba2177cae98b38916