### PR TITLE
Store the reference chunk in compressed state

### DIFF
--- a/blosc/blosc.c
+++ b/blosc/blosc.c
@@ -2037,9 +2037,9 @@ int blosc_get_complib_info(char* compname, char** complib, char** version) {
   char* clibname;
   char* clibversion = "unknown";
 
-  #if (defined(HAVE_LZ4) && defined(LZ4_VERSION_MAJOR)) || (defined(HAVE_SNAPPY) && defined(SNAPPY_VERSION))
+#if (defined(HAVE_LZ4) && defined(LZ4_VERSION_MAJOR)) || (defined(HAVE_SNAPPY) && defined(SNAPPY_VERSION)) || defined(ZSTD_VERSION_MAJOR)
   char sbuffer[256];
-  #endif
+#endif
 
   clibcode = compname_to_clibcode(compname);
   clibname = clibcode_to_clibname(clibcode);


### PR DESCRIPTION
This is preferred over code in the [cached-delta](https://github.com/Blosc/c-blosc2/tree/cached-delta), where the reference chunk is stored in both compressed and decompressed state.  The reason for choosing this non-cached implementation code is that it uses less memory and that it is  simpler too.