### PR TITLE
Compressed delta

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,9 @@
 
 
 cmake_minimum_required(VERSION 2.8.10)
-cmake_policy(SET CMP0063 NEW)
+IF (${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION} GREATER 3.4)
+  cmake_policy(SET CMP0063 NEW)
+ENDIF(${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION} GREATER 3.4)
 project(blosc)
 
 # parse the full version numbers from blosc.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,7 @@
 
 
 cmake_minimum_required(VERSION 2.8.10)
+cmake_policy(SET CMP0063 NEW)
 project(blosc)
 
 # parse the full version numbers from blosc.h

--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -1,6 +1,5 @@
-# sources
+# sources for main bench
 set(SOURCES bench.c)
-
 
 # targets
 add_executable(bench ${SOURCES})
@@ -11,6 +10,19 @@ if (UNIX AND NOT APPLE)
     target_link_libraries(bench rt)
 endif (UNIX AND NOT APPLE)
 target_link_libraries(bench blosc_shared)
+
+# sources for delta filter
+set(SOURCES_DELTA delta_schunk.c)
+
+# targets
+add_executable(delta_schunk ${SOURCES_DELTA})
+if (UNIX AND NOT APPLE)
+    # cmake is complaining about LINK_PRIVATE in original PR
+    # and removing it does not seem to hurt, so be it.
+    # target_link_libraries(bench LINK_PRIVATE rt)
+    target_link_libraries(delta_schunk rt)
+endif (UNIX AND NOT APPLE)
+target_link_libraries(delta_schunk blosc_shared)
 
 # have to copy blosc dlls on Windows
 if (MSVC)

--- a/bench/delta_schunk.c
+++ b/bench/delta_schunk.c
@@ -23,7 +23,6 @@
   #include <time.h>
   #include <sys/time.h>
 #elif defined(__unix__)
-  #include <unistd.h>
   #if defined(__linux__)
     #include <time.h>
   #else
@@ -33,7 +32,7 @@
   #error Unable to detect platform.
 #endif
 
-#include "blosc.h"
+#include "../blosc/blosc.h"
 
 #define KB  1024
 #define MB  (1024*KB)
@@ -95,7 +94,7 @@ double getseconds(blosc_timestamp_t last, blosc_timestamp_t current) {
 
 /* Given two timeval stamps, return the time per chunk in usec */
 double get_usec_chunk(blosc_timestamp_t last, blosc_timestamp_t current, int niter, size_t nchunks) {
-  double elapsed_usecs = (double)blosc_elapsed_usecs(last, current);
+  double elapsed_usecs = blosc_elapsed_usecs(last, current);
   return elapsed_usecs / (double)(niter * nchunks);
 }
 
@@ -108,7 +107,7 @@ double get_usec_chunk(blosc_timestamp_t last, blosc_timestamp_t current, int nit
 int main() {
   int32_t *data, *data_dest;
   static blosc2_sparams sparams;
-  schunk_header* schunk;
+  blosc2_sheader* schunk;
   int isize = CHUNKSIZE * sizeof(int32_t);
   int dsize;
   int64_t nbytes, cbytes;

--- a/blosc/blosc.h
+++ b/blosc/blosc.h
@@ -480,7 +480,7 @@ BLOSC_EXPORT blosc2_sheader* blosc2_new_schunk(blosc2_sparams* sparams);
 
 /* Set a delta reference for the super-chunk */
 BLOSC_EXPORT int blosc2_set_delta_ref(blosc2_sheader* sheader,
-    size_t nbytes, void* ref);
+    size_t typesize, size_t nbytes, void* ref);
 
 /* Free all memory from a super-chunk. */
 BLOSC_EXPORT int blosc2_destroy_schunk(blosc2_sheader* sheader);
@@ -663,16 +663,18 @@ BLOSC_EXPORT int blosc_get_blocksize(void);
 /**
   Force the use of a specific blocksize.  If 0, an automatic
   blocksize will be used (the default).
-  */
+*/
 BLOSC_EXPORT void blosc_set_blocksize(size_t blocksize);
 
-/* Set pointer to super-chunk.  If NULL, no super-chunk will be
-   available (the default).
+/**
+  Set pointer to super-chunk.  If NULL, no super-chunk will be
+  available (the default).
 
   The blocksize is a critical parameter with important restrictions in
   the allowed values, so use this with care.
 */
 BLOSC_EXPORT void blosc_set_schunk(blosc2_sheader* schunk);
+
 
 #ifdef __cplusplus
 }

--- a/blosc/delta.c
+++ b/blosc/delta.c
@@ -7,6 +7,7 @@
   See LICENSES/BLOSC.txt for details about copyright and rights to use.
 **********************************************************************/
 
+#include <stdio.h>
 #include <string.h>
 #include "blosc.h"
 #include "delta.h"
@@ -19,15 +20,37 @@
 void delta_encoder8(uint8_t* filters_chunk, int32_t offset, int32_t nbytes,
                     uint8_t* src, uint8_t* dest) {
   int i;
+  uint8_t typesize = *(uint8_t*)(filters_chunk + 3);
   int32_t rbytes = *(int32_t*)(filters_chunk + 4);
   int32_t mbytes;
-  uint8_t* dref = (uint8_t*)filters_chunk + BLOSC_MAX_OVERHEAD;
+  int32_t cpy_bytes;
+  uint8_t* dref;
+  blosc2_context_dparams dparams = BLOSC_DPARAMS_DEFAULTS;
+  blosc_context *dctx;
 
   mbytes = MIN(nbytes, rbytes - offset);
+  if (mbytes > 0) {
+    /* Fetch mbytes from reference frame */
+    dref = malloc((size_t)mbytes);
+    if ((mbytes % typesize) != 0) {
+      printf("nbytes is not a multiple of typesize (delta_decoder8).  Please report this!\n");
+      return;
+    }
+    /* Create a context for decompressing the interesting part of the reference */
+    dparams.nthreads = 1;  /* we don't want to interfere with existing threads */
+    dctx = blosc2_create_dctx(&dparams);
+    cpy_bytes = blosc2_getitem_ctx(dctx, filters_chunk, offset / typesize, mbytes / typesize, dref);
+    blosc2_free_ctx(dctx);
+    if (cpy_bytes != mbytes) {
+      printf("Error in getting items (delta_decoder8).  Please report this!\n");
+      return;
+    }
 
-  /* Encode delta */
-  for (i = 0; i < mbytes; i++) {
-    dest[i] = src[i] - dref[i + offset];
+    /* Encode delta */
+    for (i = 0; i < mbytes; i++) {
+      dest[i] = src[i] - dref[i];
+    }
+    free(dref);
   }
 
   /* Copy the leftovers */
@@ -41,15 +64,37 @@ void delta_encoder8(uint8_t* filters_chunk, int32_t offset, int32_t nbytes,
 /* Undo the delta filter in dest.  This can never fail. */
 void delta_decoder8(uint8_t* filters_chunk, int32_t offset, int32_t nbytes, uint8_t* dest) {
   int i;
-  uint8_t* dref = (uint8_t*)filters_chunk + BLOSC_MAX_OVERHEAD;
+  uint8_t typesize = *(uint8_t*)(filters_chunk + 3);
   int32_t rbytes = *(int32_t*)(filters_chunk + 4);
   int32_t mbytes;
+  int32_t cpy_bytes;
+  uint8_t* dref;
+  blosc2_context_dparams dparams = BLOSC_DPARAMS_DEFAULTS;
+  blosc_context *dctx;
 
   mbytes = MIN(nbytes, rbytes - offset);
+  if (mbytes > 0) {
+    /* Fetch mbytes from reference frame */
+    dref = malloc((size_t)mbytes);
+    if ((mbytes % typesize) != 0) {
+      printf("nbytes is not a multiple of typesize (delta_decoder8).  Please report this!\n");
+      return;
+    }
+    /* Create a context for decompressing the interesting part of the reference */
+    dparams.nthreads = 1;  /* we don't want to interfere with existing threads */
+    dctx = blosc2_create_dctx(&dparams);
+    cpy_bytes = blosc2_getitem_ctx(dctx, filters_chunk, offset / typesize, mbytes / typesize, dref);
+    blosc2_free_ctx(dctx);
+    if (cpy_bytes != mbytes) {
+      printf("Error in getting items (delta_decoder8).  Please report this!\n");
+      return;
+    }
 
-  /* Decode delta */
-  for (i = 0; i < mbytes; i++) {
-    dest[i] += dref[i + offset];
+    /* Decode delta */
+    for (i = 0; i < mbytes; i++) {
+      dest[i] += dref[i];
+    }
+    free(dref);
   }
 
   /* The leftovers are in-place already */


### PR DESCRIPTION
This PR stores the reference chunk in compressed state instead of uncompressed, so requiring less storage.  The drawback is that the reference must be uncompressed every time it is required (i.e. during the append and the retrieval of data).  This additional time can be around ~20% for a fast codec (blosclz or fastlz), but the user can always disable compression for such a reference chunk.

This is preferred over code in the [cached-delta](https://github.com/Blosc/c-blosc2/tree/cached-delta), where the reference chunk is stored in both compressed and decompressed state.  The reason for choosing this non-cached implementation code is that it uses less memory and that it is  simpler too.