### PR TITLE
Filter pipeline

### DIFF
--- a/README_HEADER.rst
+++ b/README_HEADER.rst
@@ -2,7 +2,7 @@ Blosc Header Format
 ===================
 
 Blosc (as of Version 1.0.0) has the following 16 byte header that stores
-information about the compressed buffer::
+information about the compressed chunk::
 
     |-0-|-1-|-2-|-3-|-4-|-5-|-6-|-7-|-8-|-9-|-A-|-B-|-C-|-D-|-E-|-F-|
       ^   ^   ^   ^ |     nbytes    |   blocksize   |     cbytes    |
@@ -11,6 +11,17 @@ information about the compressed buffer::
       |   |   +------flags
       |   +----------versionlz
       +--------------version
+
+In addition, starting in Blosc 2.0.0, there is an extension of the header
+above that allows to encode the filter pipeline::
+
+  1+|-0-|-1-|-2-|-3-|-4-|-5-|-6-|-7-|-8-|-9-|-A-|-B-|-C-|-D-|-E-|-F-|
+    |   filter codes    | reserved  |   filter meta     | reserved  |
+
+So there is a complete byte for encoding the filter and another one to encode
+possible metadata associated with the filter.  The filter pipeline has 5
+reserved slots for the filters to be applied sequentially to the chunk.  The
+filters are applied sequentially following the slot order.
 
 Datatypes of the Header Entries
 -------------------------------
@@ -40,6 +51,9 @@ All entries are little endian.
         Part of the enumeration for compressors.
     :bit 7 (``0x80``):
         Part of the enumeration for compressors.
+
+    Note:: If both bit 0 and bit 2 are set at once, that means that an
+        extended header (see above) is used.
 
     The last three bits form an enumeration that allows to use alternative
     compressors.

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -10,15 +10,21 @@
 Changes from 2.0.0a3 to 2.0.0a4
 ===============================
 
-- Internal zstd sources bumbed to 1.3.0.
+- New filter pipeline designed to work inside a chunk.  The pipeline has a
+  current capacity of 5 slots, and is designed to apply different filters
+  sequentially over the same chunk.  For this, a new extended header for the
+  chunk has been put in place (see README_HEADER.rst).
+
+- New delta filter meant to work inside a chunk.  Previously delta was
+  working inside a super-chunk, but the new implementation is both faster and
+  simpler and gets better compression ratios (at least for the tested datasets).
 
 - New re-parametrization of BloscLZ for improved compression ratio
   and also more speed (at least on modern Intel/AMD CPUs).  Version
   for internal BloscLZ codec bumped to 1.0.6.
 
-- New delta filter implemented to work inside a chunk.  Previously it was
-  working inside a super-chunk, but the new implementation is both faster and
-  gets better compression ratios (at least for the tested datasets).
+- Internal zstd sources bumbed to 1.3.0.
+
 
 Changes from 2.0.0a2 to 2.0.0a3
 ===============================

--- a/TODO-refactorization.txt
+++ b/TODO-refactorization.txt
@@ -1,0 +1,3 @@
+compcode -> codec
+
+look into the packed offsets and come with an standard

--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -134,11 +134,17 @@ if (BUILD_TESTS)
 
     option(TEST_INCLUDE_BENCH_SUITE "Include bench suite in the tests" OFF)
     if (TEST_INCLUDE_BENCH_SUITE)
-        add_test(test_hardsuite blosc blosclz shuffle suite)
+        add_test(test_hardsuite bench blosclz shuffle suite)
     endif (TEST_INCLUDE_BENCH_SUITE)
 
     option(TEST_INCLUDE_BENCH_DEBUGSUITE "Include bench debugsuite in the tests" OFF)
     if (TEST_INCLUDE_BENCH_DEBUGSUITE)
         add_test(test_debugsuite bench blosclz shuffle debugsuite)
     endif (TEST_INCLUDE_BENCH_DEBUGSUITE)
+
+    option(TEST_INCLUDE_BENCH_DELTA "Include delta bench in the tests" ON)
+    if (TEST_INCLUDE_BENCH_DELTA)
+        add_test(test_bench_delta delta_schunk)
+    endif (TEST_INCLUDE_BENCH_DELTA)
+
 endif (BUILD_TESTS)

--- a/bench/delta_schunk.c
+++ b/bench/delta_schunk.c
@@ -135,7 +135,7 @@ int main() {
 
   /* Create a super-chunk container */
   cparams.filters[0] = BLOSC_DELTA;
-  //sparams.filters[7] = BLOSC_SHUFFLE;
+  //cparams.filters[7] = BLOSC_SHUFFLE;
   cparams.typesize = sizeof(int32_t);
   cparams.compcode = BLOSC_BLOSCLZ;
   cparams.clevel = 1;

--- a/bench/delta_schunk.c
+++ b/bench/delta_schunk.c
@@ -108,8 +108,9 @@ double get_usec_chunk(blosc_timestamp_t last, blosc_timestamp_t current, int nit
 
 int main() {
   int32_t *data, *data_dest;
-  blosc2_sparams sparams = BLOSC_SPARAMS_DEFAULTS;
-  blosc2_sheader* schunk;
+  blosc2_cparams cparams = BLOSC_CPARAMS_DEFAULTS;
+  blosc2_dparams dparams = BLOSC_DPARAMS_DEFAULTS;
+  blosc2_schunk* schunk;
   size_t isize = CHUNKSIZE * sizeof(int32_t);
   int dsize;
   int64_t nbytes, cbytes;
@@ -133,12 +134,12 @@ int main() {
   blosc_set_nthreads(NTHREADS);
 
   /* Create a super-chunk container */
-  sparams.filters[0] = BLOSC_DELTA;
+  cparams.filters[0] = BLOSC_DELTA;
   //sparams.filters[7] = BLOSC_SHUFFLE;
-  sparams.typesize = sizeof(int32_t);
-  sparams.compressor = BLOSC_BLOSCLZ;
-  sparams.clevel = 1;
-  schunk = blosc2_new_schunk(&sparams);
+  cparams.typesize = sizeof(int32_t);
+  cparams.compcode = BLOSC_BLOSCLZ;
+  cparams.clevel = 1;
+  schunk = blosc2_new_schunk(cparams, dparams);
 
   /* Append chunks (the first will be taken as reference for delta) */
   blosc_set_timestamp(&last);

--- a/bench/delta_schunk.c
+++ b/bench/delta_schunk.c
@@ -135,7 +135,7 @@ int main() {
 
   /* Create a super-chunk container */
   cparams.filters[0] = BLOSC_DELTA;
-  //cparams.filters[7] = BLOSC_SHUFFLE;
+  //cparams.filters[BLOSC_MAX_FILTERS - 1] = BLOSC_BITSHUFFLE;
   cparams.typesize = sizeof(int32_t);
   cparams.compcode = BLOSC_BLOSCLZ;
   cparams.clevel = 1;
@@ -160,8 +160,7 @@ int main() {
   /* Retrieve and decompress the chunks */
   blosc_set_timestamp(&last);
   for (nchunk = 0; nchunk < NCHUNKS; nchunk++) {
-    dsize = blosc2_decompress_chunk(schunk, nchunk, (void*)data_dest,
-                                    (int)isize);
+    dsize = blosc2_decompress_chunk(schunk, nchunk, (void*)data_dest, isize);
     if (dsize < 0) {
       printf("Decompression error.  Error code: %d\n", dsize);
       return dsize;

--- a/blosc/blosc.c
+++ b/blosc/blosc.c
@@ -163,6 +163,7 @@ struct thread_context {
   uint8_t* tmp;
   uint8_t* tmp2;
   uint8_t* tmp3;
+  uint8_t* tmp4;
   int32_t tmpblocksize; /* keep track of how big the temporary buffers are */
 #if defined(HAVE_ZSTD)
   /* The contexts for ZSTD */
@@ -656,7 +657,7 @@ static int blosc_c(struct thread_context* thread_context, int32_t blocksize,
   char* compname;
   int accel;
   int bscount;
-  uint8_t *_tmp = tmp, *_tmp2 = tmp2;
+  uint8_t *_tmp = tmp, *_tmp2 = tmp2, *_tmp3 = thread_context->tmp4;
 
   /* Process the filter pipeline */
   for (int i = 0; i < BLOSC_MAX_FILTERS; i++) {
@@ -668,7 +669,7 @@ static int blosc_c(struct thread_context* thread_context, int32_t blocksize,
         break;
       case BLOSC_BITSHUFFLE:
         bscount = bitshuffle((size_t)typesize, (size_t)blocksize,
-                             _src, _tmp, dest);  // treat dest as temporary buf
+                             _src, _tmp, _tmp3);
         if (bscount < 0)
           return bscount;
         _src = _tmp; _tmp = _tmp2; _tmp2 = _tmp;    /* cycle buffers */
@@ -1050,9 +1051,10 @@ static struct thread_context* create_thread_context(
   thread_context->tid = tid;
 
   ebsize = context->blocksize + context->typesize * (int32_t)sizeof(int32_t);
-  thread_context->tmp = my_malloc(2 * context->blocksize + ebsize);
+  thread_context->tmp = my_malloc(3 * context->blocksize + ebsize);
   thread_context->tmp2 = thread_context->tmp + context->blocksize;
   thread_context->tmp3 = thread_context->tmp + context->blocksize + ebsize;
+  thread_context->tmp4 = thread_context->tmp + 2 * context->blocksize + ebsize;
   thread_context->tmpblocksize = context->blocksize;
   #if defined(HAVE_ZSTD)
   thread_context->zstd_cctx = NULL;
@@ -1905,9 +1907,10 @@ int _blosc_getitem(blosc2_context* context, const void* src, int start,
       /* Resize the temporaries in serial context if needed */
       if (blocksize != scontext->tmpblocksize) {
         my_free(scontext->tmp);
-        scontext->tmp = my_malloc(2 * blocksize + ebsize);
+        scontext->tmp = my_malloc(3 * blocksize + ebsize);
         scontext->tmp2 = scontext->tmp + blocksize;
         scontext->tmp3 = scontext->tmp + blocksize + ebsize;
+        scontext->tmp4 = scontext->tmp + 2 * blocksize + ebsize;
         scontext->tmpblocksize = blocksize;
       }
 
@@ -2023,9 +2026,10 @@ static void* t_blosc(void* ctxt) {
     /* Resize the temporaries if needed */
     if (blocksize != context->tmpblocksize) {
       my_free(context->tmp);
-      context->tmp = my_malloc(2 * blocksize + ebsize);
+      context->tmp = my_malloc(3 * blocksize + ebsize);
       context->tmp2 = context->tmp + blocksize;
       context->tmp3 = context->tmp + blocksize + ebsize;
+      context->tmp4 = context->tmp + 2 * blocksize + ebsize;
       context->tmpblocksize = blocksize;
     }
 

--- a/blosc/blosc.c
+++ b/blosc/blosc.c
@@ -1055,7 +1055,6 @@ static int do_job(blosc2_context* context) {
 
   /* Set sentinels */
   context->dref_not_init = 1;
-  //printf("do_job: %d\n", context->nthreads);
 
   /* Run the serial version when nthreads is 1 or when the buffers are
      not larger than blocksize */
@@ -1273,9 +1272,7 @@ static uint8_t get_filter_flags(const uint8_t header_flags,
 
 
 static int initialize_context_decompression(
-    blosc2_context* context, const void* src, void* dest, size_t destsize) {
-
-  int i;
+        blosc2_context* context, const void* src, void* dest, size_t destsize) {
 
   context->compress = 0;
   context->src = (const uint8_t*)src;

--- a/blosc/blosc.c
+++ b/blosc/blosc.c
@@ -1003,14 +1003,13 @@ static int parallel_blosc(blosc2_context* context) {
   /* Synchronization point for all threads (wait for finalization) */
   WAIT_FINISH(-1, context);
 
-  if (context->thread_giveup_code > 0) {
-    /* Return the total bytes (de-)compressed in threads */
-    return context->num_output_bytes;
-  }
-  else {
+  if (context->thread_giveup_code <= 0) {
     /* Compression/decompression gave up.  Return error code. */
     return context->thread_giveup_code;
   }
+
+  /* Return the total bytes (de-)compressed in threads */
+  return context->num_output_bytes;
 }
 
 

--- a/blosc/blosc.c
+++ b/blosc/blosc.c
@@ -1521,8 +1521,6 @@ int blosc_compress(int clevel, int doshuffle, size_t typesize, size_t nbytes,
   int error;
   int result;
   char* envvar;
-  blosc2_context *cctx;
-  blosc2_cparams cparams = BLOSC_CPARAMS_DEFAULTS;
 
   /* Check whether the library should be initialized */
   if (!g_initlib) blosc_init();
@@ -1605,16 +1603,14 @@ int blosc_compress(int clevel, int doshuffle, size_t typesize, size_t nbytes,
   envvar = getenv("BLOSC_NOLOCK");
   if (envvar != NULL) {
     char *compname;
-    uint8_t filters[BLOSC_MAX_FILTERS] = {0, 0, 0, 0, 0, 0, 0, 0};
-    build_filters(doshuffle, g_delta, filters);
+    blosc2_context *cctx;
+    blosc2_cparams cparams = BLOSC_CPARAMS_DEFAULTS;
+
     blosc_compcode_to_compname(g_compressor, &compname);
     /* Create a context for compression */
+    build_filters(doshuffle, g_delta, cparams.filters);
     cparams.typesize = (uint8_t)typesize;
     cparams.compcode = (uint8_t)g_compressor;
-    for (int i = 0; i < BLOSC_MAX_FILTERS; i++) {
-      cparams.filters[i] = filters[i];
-      cparams.filters_meta[i] = 0;
-    }
     cparams.clevel = (uint8_t)clevel;
     cparams.nthreads = (uint8_t)g_nthreads;
     cctx = blosc2_create_cctx(cparams);

--- a/blosc/blosc.c
+++ b/blosc/blosc.c
@@ -1526,7 +1526,7 @@ int blosc_compress_context(blosc2_context* context) {
     if (ntbytes < 0) {
       return -1;
     }
-    if ((ntbytes == 0) && (context->sourcesize + BLOSC_MAX_OVERHEAD <= context->destsize)) {
+    else if (ntbytes == 0) {
       /* Last chance for fitting `src` buffer in `dest`.  Update flags
        and do a memcpy later on. */
       *(context->header_flags) |= BLOSC_MEMCPYED;
@@ -1547,8 +1547,9 @@ int blosc_compress_context(blosc2_context* context) {
         return -1;
       }
     }
-    else {
-      memcpy(context->dest + BLOSC_MAX_OVERHEAD, context->src, context->sourcesize);
+    else if (context->sourcesize + BLOSC_MAX_OVERHEAD <= context->destsize) {
+      memcpy(context->dest + BLOSC_MAX_OVERHEAD, context->src,
+             context->sourcesize);
       ntbytes = (int)context->sourcesize + BLOSC_MAX_OVERHEAD;
     }
   }

--- a/blosc/blosc.h
+++ b/blosc/blosc.h
@@ -38,16 +38,19 @@ enum {
 };
 
 enum {
-  /* Minimum header length */
   BLOSC_MIN_HEADER_LENGTH = 16,
+  /* Minimum header length */
+  BLOSC_EXTENDED_HEADER_LENGTH = 32,
+  /* Extended header length (see README_HEADER) */
+  BLOSC_MAX_OVERHEAD = BLOSC_MIN_HEADER_LENGTH,
   /* The maximum overhead during compression in bytes.  This equals to
      BLOSC_MIN_HEADER_LENGTH now, but can be higher in future
      implementations */
-  BLOSC_MAX_OVERHEAD = BLOSC_MIN_HEADER_LENGTH,
-  /* Maximum source buffer size to be compressed */
   BLOSC_MAX_BUFFERSIZE = (INT_MAX - BLOSC_MAX_OVERHEAD),
+  /* Maximum source buffer size to be compressed */
+  BLOSC_MAX_TYPESIZE = 255,
   /* Maximum typesize before considering source buffer as a stream of bytes */
-  BLOSC_MAX_TYPESIZE = 255,         /* Cannot be larger than 255 */
+  /* Cannot be larger than 255 */
 };
 
 /* Codes for filters (see blosc_compress) */
@@ -62,7 +65,7 @@ enum {
 };
 
 enum {
-  BLOSC_MAX_FILTERS = 8,
+  BLOSC_MAX_FILTERS = 5,
   /* Maximum number of filters in the filter pipeline */
 };
 
@@ -468,28 +471,28 @@ typedef struct blosc2_context_s blosc2_context;   /* uncomplete type */
   (zero) in the fields of the struct is passed to a function.
 */
 typedef struct {
-    int compcode;
-    /* the compressor codec */
-    int clevel;
-    /* the compression level (5) */
-    size_t typesize;
-    /* the type size (8) */
-    uint8_t filters[BLOSC_MAX_FILTERS];
-    /* the (sequence of) filters */
-    uint8_t filters_meta[BLOSC_MAX_FILTERS];
-    /* metadata for filters */
-    uint32_t nthreads;
-    /* the number of threads to use internally (1) */
-    size_t blocksize;
-    /* the requested size of the compressed blocks (0; meaning automatic) */
-    void* schunk;
-    /* the associated schunk, if any (NULL) */
+  int compcode;
+  /* the compressor codec */
+  int clevel;
+  /* the compression level (5) */
+  size_t typesize;
+  /* the type size (8) */
+  uint32_t nthreads;
+  /* the number of threads to use internally (1) */
+  size_t blocksize;
+  /* the requested size of the compressed blocks (0; meaning automatic) */
+  void* schunk;
+  /* the associated schunk, if any (NULL) */
+  uint8_t filters[BLOSC_MAX_FILTERS];
+  /* the (sequence of) filters */
+  uint8_t filters_meta[BLOSC_MAX_FILTERS];
+  /* metadata for filters */
 } blosc2_cparams;
 
 /* Default struct for compression params meant for user initialization */
 static const blosc2_cparams BLOSC_CPARAMS_DEFAULTS = {
-        BLOSC_BLOSCLZ, 5, 8, {0, 0, 0, 0, 0, 0, 0, BLOSC_SHUFFLE},
-        {0, 0, 0, 0, 0, 0, 0, 0}, 1, 0, NULL };
+        BLOSC_BLOSCLZ, 5, 8, 1, 0, NULL,
+        {0, 0, 0, 0, BLOSC_SHUFFLE}, {0, 0, 0, 0, 0} };
 
 /**
   The parameters for creating a context for decompression purposes.
@@ -498,10 +501,10 @@ static const blosc2_cparams BLOSC_CPARAMS_DEFAULTS = {
   (zero) in the fields of the struct is passed to a function.
 */
 typedef struct {
-    int32_t nthreads;
-    /* the number of threads to use internally (1) */
-    void* schunk;
-    /* the associated schunk, if any (NULL) */
+  int32_t nthreads;
+  /* the number of threads to use internally (1) */
+  void* schunk;
+  /* the associated schunk, if any (NULL) */
 } blosc2_dparams;
 
 /* Default struct for compression params meant for user initialization */

--- a/blosc/blosc.h
+++ b/blosc/blosc.h
@@ -668,9 +668,9 @@ BLOSC_EXPORT void* blosc2_packed_append_buffer(void* packed, size_t typesize,
  detected, a negative code is returned instead.
  */
 BLOSC_EXPORT int blosc2_decompress_chunk(blosc2_schunk* sheader,
-     int64_t nchunk, void* dest, int nbytes);
+     int64_t nchunk, void* dest, size_t nbytes);
 
-BLOSC_EXPORT int blosc2_packed_decompress_chunk(void* packed, int nchunk,
+BLOSC_EXPORT int blosc2_packed_decompress_chunk(void* packed, size_t nchunk,
       void** dest);
 
 /* Pack a super-chunk by using the header. */

--- a/blosc/blosc.h
+++ b/blosc/blosc.h
@@ -468,11 +468,11 @@ typedef struct blosc2_context_s blosc2_context;   /* uncomplete type */
   (zero) in the fields of the struct is passed to a function.
 */
 typedef struct {
-    uint8_t compcode;
+    int compcode;
     /* the compressor codec */
-    uint8_t clevel;
+    int clevel;
     /* the compression level (5) */
-    uint32_t typesize;
+    size_t typesize;
     /* the type size (8) */
     uint8_t filters[BLOSC_MAX_FILTERS];
     /* the (sequence of) filters */
@@ -480,7 +480,7 @@ typedef struct {
     /* metadata for filters */
     uint32_t nthreads;
     /* the number of threads to use internally (1) */
-    int32_t blocksize;
+    size_t blocksize;
     /* the requested size of the compressed blocks (0; meaning automatic) */
     void* schunk;
     /* the associated schunk, if any (NULL) */

--- a/blosc/blosc.h
+++ b/blosc/blosc.h
@@ -498,7 +498,7 @@ static const blosc2_cparams BLOSC_CPARAMS_DEFAULTS = {
   (zero) in the fields of the struct is passed to a function.
 */
 typedef struct {
-    uint8_t nthreads;
+    int32_t nthreads;
     /* the number of threads to use internally (1) */
     void* schunk;
     /* the associated schunk, if any (NULL) */

--- a/blosc/delta.c
+++ b/blosc/delta.c
@@ -13,36 +13,37 @@
 
 
 /* Apply the delta filters to src.  This can never fail. */
-void delta_encoder(const uint8_t* dref, const int32_t offset,
-                   const int32_t nbytes, const int32_t typesize,
+void delta_encoder(const uint8_t* dref, const size_t offset,
+                   const size_t nbytes, const size_t typesize,
                    const uint8_t* src, uint8_t* dest) {
+  size_t i;
 
   if (offset == 0) {
     /* This is the reference block, use delta coding in elements */
     switch (typesize) {
       case 1:
         dest[0] = dref[0];
-        for (int i = 1; i < nbytes; i++) {
+        for (i = 1; i < nbytes; i++) {
           dest[i] = src[i] - dref[i-1];
         }
         break;
       case 2:
         ((uint16_t *)dest)[0] = ((uint16_t *)dref)[0];
-        for (int i = 1; i < nbytes / 2; i++) {
+        for (i = 1; i < nbytes / 2; i++) {
           ((uint16_t *)dest)[i] = ((uint16_t *)src)[i] -
                                   ((uint16_t *)dref)[i-1];
         }
         break;
       case 4:
         ((uint32_t *)dest)[0] = ((uint32_t *)dref)[0];
-        for (int i = 1; i < nbytes / 4; i++) {
+        for (i = 1; i < nbytes / 4; i++) {
           ((uint32_t *)dest)[i] = ((uint32_t *)src)[i] -
                                   ((uint32_t *)dref)[i-1];
         }
         break;
       case 8:
         ((uint64_t *)dest)[0] = ((uint64_t *)dref)[0];
-        for (int i = 1; i < nbytes / 8; i++) {
+        for (i = 1; i < nbytes / 8; i++) {
           ((uint64_t *)dest)[i] = ((uint64_t *)src)[i] -
                                   ((uint64_t *)dref)[i-1];
         }
@@ -58,24 +59,24 @@ void delta_encoder(const uint8_t* dref, const int32_t offset,
     /* Use delta coding wrt reference block */
     switch (typesize) {
       case 1:
-        for (int i = 0; i < nbytes; i++) {
+        for (i = 0; i < nbytes; i++) {
           dest[i] = src[i] - dref[i];
         }
         break;
       case 2:
-        for (int i = 0; i < nbytes / 2; i++) {
+        for (i = 0; i < nbytes / 2; i++) {
           ((uint16_t *) dest)[i] =
                   ((uint16_t *) src)[i] - ((uint16_t *) dref)[i];
         }
         break;
       case 4:
-        for (int i = 0; i < nbytes / 4; i++) {
+        for (i = 0; i < nbytes / 4; i++) {
           ((uint32_t *) dest)[i] =
                   ((uint32_t *) src)[i] - ((uint32_t *) dref)[i];
         }
         break;
       case 8:
-        for (int i = 0; i < nbytes / 8; i++) {
+        for (i = 0; i < nbytes / 8; i++) {
           ((uint64_t *) dest)[i] =
                   ((uint64_t *) src)[i] - ((uint64_t *) dref)[i];
         }
@@ -92,30 +93,30 @@ void delta_encoder(const uint8_t* dref, const int32_t offset,
 
 
 /* Undo the delta filter in dest.  This can never fail. */
-void delta_decoder(const uint8_t* dref, const int32_t offset,
-                   const int32_t nbytes, const int32_t typesize,
-                   uint8_t* dest) {
+void delta_decoder(const uint8_t* dref, const size_t offset,
+                   const size_t nbytes, const size_t typesize, uint8_t* dest) {
+  size_t i;
 
   if (offset == 0) {
     /* Decode delta for the reference block */
     switch (typesize) {
       case 1:
-        for (int i = 1; i < nbytes; i++) {
+        for (i = 1; i < nbytes; i++) {
           dest[i] += dref[i-1];
         }
         break;
       case 2:
-        for (int i = 1; i < nbytes / 2; i++) {
+        for (i = 1; i < nbytes / 2; i++) {
           ((uint16_t *)dest)[i] += ((uint16_t *)dref)[i-1];
         }
         break;
       case 4:
-        for (int i = 1; i < nbytes / 4; i++) {
+        for (i = 1; i < nbytes / 4; i++) {
           ((uint32_t *)dest)[i] += ((uint32_t *)dref)[i-1];
         }
         break;
       case 8:
-        for (int i = 1; i < nbytes / 8; i++) {
+        for (i = 1; i < nbytes / 8; i++) {
           ((uint64_t *)dest)[i] += ((uint64_t *)dref)[i-1];
         }
         break;
@@ -130,22 +131,22 @@ void delta_decoder(const uint8_t* dref, const int32_t offset,
     /* Decode delta for the non-reference blocks */
     switch (typesize) {
       case 1:
-        for (int i = 0; i < nbytes; i++) {
+        for (i = 0; i < nbytes; i++) {
           dest[i] += dref[i];
         }
         break;
       case 2:
-        for (int i = 0; i < nbytes / 2; i++) {
+        for (i = 0; i < nbytes / 2; i++) {
           ((uint16_t *)dest)[i] += ((uint16_t *)dref)[i];
         }
         break;
       case 4:
-        for (int i = 0; i < nbytes / 4; i++) {
+        for (i = 0; i < nbytes / 4; i++) {
           ((uint32_t *)dest)[i] += ((uint32_t *)dref)[i];
         }
         break;
       case 8:
-        for (int i = 0; i < nbytes / 8; i++) {
+        for (i = 0; i < nbytes / 8; i++) {
           ((uint64_t *)dest)[i] += ((uint64_t *)dref)[i];
         }
         break;

--- a/blosc/delta.h
+++ b/blosc/delta.h
@@ -9,12 +9,12 @@
 #ifndef BLOSC_DELTA_H
 #define BLOSC_DELTA_H
 
-void delta_encoder(const uint8_t* dref, const int32_t offset,
-                   const int32_t nbytes, const int32_t typesize,
+void delta_encoder(const uint8_t* dref, const size_t offset,
+                   const size_t nbytes, const size_t typesize,
                    const uint8_t* src, uint8_t* dest);
 
-void delta_decoder(const uint8_t* dref, const int32_t offset,
-                   const int32_t nbytes, const int32_t typesize,
+void delta_decoder(const uint8_t* dref, const size_t offset,
+                   const size_t nbytes, const size_t typesize,
                    uint8_t* dest);
 
 #endif //BLOSC_DELTA_H

--- a/blosc/delta.h
+++ b/blosc/delta.h
@@ -9,12 +9,10 @@
 #ifndef BLOSC_DELTA_H
 #define BLOSC_DELTA_H
 
-void delta_encoder(const uint8_t* dref, const size_t offset,
-                   const size_t nbytes, const size_t typesize,
-                   const uint8_t* src, uint8_t* dest);
+void delta_encoder(const uint8_t* dref, size_t offset, size_t nbytes,
+                   size_t typesize, const uint8_t* src, uint8_t* dest);
 
-void delta_decoder(const uint8_t* dref, const size_t offset,
-                   const size_t nbytes, const size_t typesize,
-                   uint8_t* dest);
+void delta_decoder(const uint8_t* dref, size_t offset, size_t nbytes,
+                   size_t typesize, uint8_t* dest);
 
 #endif //BLOSC_DELTA_H

--- a/blosc/schunk.c
+++ b/blosc/schunk.c
@@ -50,13 +50,13 @@ blosc2_schunk* blosc2_new_schunk(blosc2_cparams cparams,
   schunk->blocksize = cparams.blocksize;
   schunk->cbytes = sizeof(blosc2_schunk);
 
+  /* The compression context */
   cparams.schunk = schunk;
   schunk->cctx = blosc2_create_cctx(cparams);
 
+  /* The decompression context */
   dparams.schunk = schunk;
   schunk->dctx = blosc2_create_dctx(dparams);
-
-  /* The rest of the structure will remain zeroed */
 
   return schunk;
 }
@@ -88,8 +88,6 @@ size_t blosc2_append_buffer(blosc2_schunk* schunk, size_t nbytes,
                             void* src) {
   int cbytes;
   void* chunk = malloc(nbytes + BLOSC_MAX_OVERHEAD);
-  int clevel = schunk->clevel;
-  char* compname;
 
   /* Compress the src buffer using super-chunk context */
   cbytes = blosc2_compress_ctx(schunk->cctx, nbytes, src, chunk,
@@ -218,7 +216,7 @@ void* blosc2_pack_schunk(blosc2_schunk* schunk) {
   int64_t nchunks = schunk->nchunks;
   void* packed;
   void* data_chunk;
-  uint64_t* data_pointers;
+  int64_t* data_pointers;
   uint64_t data_offsets_len;
   int32_t chunk_cbytes, chunk_nbytes;
   int64_t packed_len;
@@ -238,7 +236,7 @@ void* blosc2_pack_schunk(blosc2_schunk* schunk) {
 
   /* Finally, setup the data pointers section */
   data_offsets_len = nchunks * sizeof(int64_t);
-  data_pointers = (uint64_t*)((uint8_t*)packed + packed_len - data_offsets_len);
+  data_pointers = (int64_t*)((uint8_t*)packed + packed_len - data_offsets_len);
   *(uint64_t*)((uint8_t*)packed + 72) = packed_len - data_offsets_len;
 
   /* And fill the actual data chunks */

--- a/blosc/schunk.h
+++ b/blosc/schunk.h
@@ -11,6 +11,4 @@
 
 #include "blosc.h"
 
-uint8_t* decode_filters(uint16_t enc_filters);
-
 #endif //BLOSC_SCHUNK_H

--- a/blosc/trunc-prec.c
+++ b/blosc/trunc-prec.c
@@ -8,7 +8,6 @@
 **********************************************************************/
 
 #include <stdio.h>
-#include <string.h>
 #include "blosc.h"
 #include "trunc-prec.h"
 
@@ -45,5 +44,8 @@ void truncate_precision(const uint8_t filter_meta, const size_t typesize,
     case 8:
       truncate_precision64(filter_meta, nbytes / typesize,
                            (int64_t *)src, (int64_t *)dest);
+    default:
+      fprintf(stderr, "Error in trunc-prec filter: Precision for typesize %d "
+              "not handled", (int)typesize);
   }
 }

--- a/blosc/trunc-prec.c
+++ b/blosc/trunc-prec.c
@@ -16,7 +16,7 @@
 #define BITS_MANTISSA_DOUBLE 52
 
 
-void truncate_precision32(const uint16_t filter_meta, const int nelems,
+void truncate_precision32(const uint8_t filter_meta, const size_t nelems,
                           const int32_t* src, int32_t* dest) {
   int zeroed_bits = BITS_MANTISSA_FLOAT - filter_meta;
   int32_t mask = ~((1 << zeroed_bits) - 1);
@@ -25,18 +25,18 @@ void truncate_precision32(const uint16_t filter_meta, const int nelems,
   }
 }
 
-void truncate_precision64(const uint16_t filter_meta, const int nelems,
+void truncate_precision64(const uint8_t filter_meta, const size_t nelems,
                           const int64_t* src, int64_t* dest) {
   int zeroed_bits = BITS_MANTISSA_DOUBLE - filter_meta;
-  uint64_t mask = ~((1LL << zeroed_bits) - 1LL);
+  uint64_t mask = ~((1ULL << zeroed_bits) - 1ULL);
   for (int i = 0; i < nelems; i++) {
     dest[i] = src[i] & mask;
   }
 }
 
 /* Apply the truncate precision to src.  This can never fail. */
-void truncate_precision(const uint16_t filter_meta, const int32_t typesize,
-                        const int32_t nbytes, const uint8_t* src,
+void truncate_precision(const uint8_t filter_meta, const size_t typesize,
+                        const size_t nbytes, const uint8_t* src,
                         uint8_t* dest) {
   switch (typesize) {
     case 4:

--- a/blosc/trunc-prec.h
+++ b/blosc/trunc-prec.h
@@ -10,8 +10,8 @@
 #ifndef BLOSC_TRUNC_PREC_H
 #define BLOSC_TRUNC_PREC_H
 
-void truncate_precision(const uint8_t filters_meta, const size_t typesize,
-                        const size_t nbytes, const uint8_t* src,
+void truncate_precision(uint8_t filters_meta, size_t typesize,
+                        size_t nbytes, const uint8_t* src,
                         uint8_t* dest);
 
 #endif //BLOSC_TRUNC_PREC_H

--- a/blosc/trunc-prec.h
+++ b/blosc/trunc-prec.h
@@ -10,8 +10,8 @@
 #ifndef BLOSC_TRUNC_PREC_H
 #define BLOSC_TRUNC_PREC_H
 
-void truncate_precision(const uint16_t filters_meta, const int32_t typesize,
-                        const int32_t nbytes, const uint8_t* src,
+void truncate_precision(const uint8_t filters_meta, const size_t typesize,
+                        const size_t nbytes, const uint8_t* src,
                         uint8_t* dest);
 
 #endif //BLOSC_TRUNC_PREC_H

--- a/examples/delta_schunk.c
+++ b/examples/delta_schunk.c
@@ -58,8 +58,9 @@ int main() {
   const int isize = CHUNKSIZE * sizeof(int64_t);
   int dsize;
   int32_t nbytes, cbytes;
-  blosc2_sparams sparams = BLOSC_SPARAMS_DEFAULTS;
-  blosc2_sheader* schunk;
+  blosc2_cparams cparams = BLOSC_CPARAMS_DEFAULTS;
+  blosc2_dparams dparams = BLOSC_DPARAMS_DEFAULTS;
+  blosc2_schunk* schunk;
   int i, nchunk, nchunks;
   blosc_timestamp_t last, current;
   double ttotal;
@@ -72,13 +73,13 @@ int main() {
   blosc_set_nthreads(4);
 
   /* Create a super-chunk container */
-  sparams.typesize = 8;
-  sparams.filters[0] = BLOSC_DELTA;
+  cparams.typesize = 8;
+  cparams.filters[0] = BLOSC_DELTA;
   //sparams.filters[7] = BLOSC_SHUFFLE;
-  sparams.compressor = BLOSC_BLOSCLZ;
+  cparams.compcode = BLOSC_BLOSCLZ;
   //sparams.blocksize = 1 <<20;
-  sparams.clevel = 1;
-  schunk = blosc2_new_schunk(&sparams);
+  cparams.clevel = 1;
+  schunk = blosc2_new_schunk(cparams, dparams);
 
   blosc_set_timestamp(&last);
   for (nchunk = 1; nchunk <= NCHUNKS; nchunk++) {

--- a/examples/delta_schunk.c
+++ b/examples/delta_schunk.c
@@ -75,9 +75,7 @@ int main() {
   /* Create a super-chunk container */
   cparams.typesize = 8;
   cparams.filters[0] = BLOSC_DELTA;
-  //sparams.filters[7] = BLOSC_SHUFFLE;
   cparams.compcode = BLOSC_BLOSCLZ;
-  //sparams.blocksize = 1 <<20;
   cparams.clevel = 1;
   schunk = blosc2_new_schunk(cparams, dparams);
 

--- a/examples/delta_schunk.c
+++ b/examples/delta_schunk.c
@@ -29,7 +29,8 @@
 #define GB  (1024*MB)
 
 #define CHUNKSIZE 200 * 1000
-#define NCHUNKS 500
+//#define NCHUNKS 500
+#define NCHUNKS 1
 
 /* The type of timestamp used on this system. */
 #define blosc_timestamp_t struct timespec
@@ -71,8 +72,8 @@ int main() {
   blosc_set_nthreads(4);
 
   /* Create a super-chunk container */
-  sparams.filters[0] = BLOSC_DELTA;
-  sparams.filters[1] = BLOSC_SHUFFLE;
+  //sparams.filters[0] = BLOSC_DELTA;
+  //sparams.filters[1] = BLOSC_SHUFFLE;
   sparams.compressor = BLOSC_BLOSCLZ;
   sparams.clevel = 1;
   sheader = blosc2_new_schunk(&sparams);

--- a/new-delta-filter.rst
+++ b/new-delta-filter.rst
@@ -1,0 +1,15 @@
+.. title: The Delta filter
+.. author: Francesc Alted
+.. slug: new-delta-filter
+.. date: 2017-08-16 17:32:20 UTC
+.. tags: delta filter
+.. category:
+.. link:
+.. description:
+.. type: text
+
+The Delta Filter
+================
+
+Today I have introduced official support for a delta filter in C-Blosc2.  The
+ delta

--- a/tests/test_contexts.c
+++ b/tests/test_contexts.c
@@ -21,8 +21,8 @@ int main() {
   size_t isize = SIZE * sizeof(int32_t), osize = SIZE * sizeof(int32_t);
   int dsize = SIZE * sizeof(int32_t), csize;
   int i, ret;
-  blosc2_context_cparams cparams = BLOSC_CPARAMS_DEFAULTS;
-  blosc2_context_dparams dparams = BLOSC_DPARAMS_DEFAULTS;
+  blosc2_cparams cparams = BLOSC_CPARAMS_DEFAULTS;
+  blosc2_dparams dparams = BLOSC_DPARAMS_DEFAULTS;
   blosc2_context *cctx, *dctx;
 
   /* Initialize dataset */
@@ -39,7 +39,7 @@ int main() {
   cparams.filters[7] = BLOSC_DOSHUFFLE;
   cparams.clevel = 5;
   cparams.nthreads = NTHREADS;
-  cctx = blosc2_create_cctx(&cparams);
+  cctx = blosc2_create_cctx(cparams);
 
   /* Compress with clevel=5 and shuffle active  */
   csize = blosc2_compress_ctx(cctx, isize, data, data_out, osize);
@@ -54,7 +54,7 @@ int main() {
 
   /* Create a context for decompression */
   dparams.nthreads = NTHREADS;
-  dctx = blosc2_create_dctx(&dparams);
+  dctx = blosc2_create_dctx(dparams);
 
   ret = blosc2_getitem_ctx(dctx, data_out, 5, 5, data_subset);
   if (ret < 0) {

--- a/tests/test_contexts.c
+++ b/tests/test_contexts.c
@@ -18,12 +18,12 @@ int main() {
   static int32_t data_dest[SIZE];
   int32_t data_subset[5];
   int32_t data_subset_ref[5] = {5, 6, 7, 8, 9};
-  int isize = SIZE * sizeof(int32_t), osize = SIZE * sizeof(int32_t);
+  size_t isize = SIZE * sizeof(int32_t), osize = SIZE * sizeof(int32_t);
   int dsize = SIZE * sizeof(int32_t), csize;
   int i, ret;
   blosc2_context_cparams cparams = BLOSC_CPARAMS_DEFAULTS;
   blosc2_context_dparams dparams = BLOSC_DPARAMS_DEFAULTS;
-  blosc_context *cctx, *dctx;
+  blosc2_context *cctx, *dctx;
 
   /* Initialize dataset */
   for (i = 0; i < SIZE; i++) {
@@ -36,7 +36,7 @@ int main() {
   /* Create a context for compression */
   cparams.typesize = sizeof(int32_t);
   cparams.compcode = BLOSC_BLOSCLZ;
-  cparams.filters = BLOSC_DOSHUFFLE;
+  cparams.filters[7] = BLOSC_DOSHUFFLE;
   cparams.clevel = 5;
   cparams.nthreads = NTHREADS;
   cctx = blosc2_create_cctx(&cparams);
@@ -47,7 +47,7 @@ int main() {
     printf("Buffer is uncompressible.  Giving up.\n");
     return EXIT_FAILURE;
   }
-  else if (csize < 0) {
+  if (csize < 0) {
     printf("Compression error.  Error code: %d\n", csize);
     return EXIT_FAILURE;
   }
@@ -70,7 +70,7 @@ int main() {
   }
 
   /* Decompress  */
-  dsize = blosc2_decompress_ctx(dctx, data_out, data_dest, dsize);
+  dsize = blosc2_decompress_ctx(dctx, data_out, data_dest, (size_t)dsize);
   if (dsize < 0) {
     printf("Decompression error.  Error code: %d\n", dsize);
     return EXIT_FAILURE;

--- a/tests/test_delta.c
+++ b/tests/test_delta.c
@@ -14,7 +14,7 @@
 int tests_run = 0;
 
 /* Global vars */
-void *src, *srccpy, *dest;
+uint8_t *src, *srccpy, *dest;
 int nbytes, cbytes;
 int clevel = 5;
 int doshuffle = 1;

--- a/tests/test_delta.c
+++ b/tests/test_delta.c
@@ -30,7 +30,7 @@ static char *test_delta() {
   switch (typesize) {
     case 1:
       for (int i = 0; i < size / typesize; i++) {
-        ((uint8_t*)src)[i] = (uint8_t)i;
+        src[i] = (uint8_t)i;
       }
       break;
     case 2:
@@ -84,7 +84,7 @@ static char *test_delta() {
       break;
     default:
       for (int i = 0; i < size / typesize; i++) {
-        ((uint8_t*)src)[i] = (uint8_t)i;
+        src[i] = (uint8_t)i;
       }
   }
   memcpy(srccpy, src, size);

--- a/tests/test_delta.c
+++ b/tests/test_delta.c
@@ -19,7 +19,7 @@ int nbytes, cbytes;
 int clevel = 5;
 int doshuffle = 1;
 int typesize;
-size_t size = 7 * 12 * 13 * 16 * 24 * 100;  /* must be divisible by typesize */
+size_t size = 7 * 12 * 13 * 16 * 24 * 10;  /* must be divisible by typesize */
 
 
 /* Check compressor */

--- a/tests/test_delta_schunk.c
+++ b/tests/test_delta_schunk.c
@@ -33,7 +33,7 @@ int main() {
 
   /* Create a super-chunk container */
   cparams.filters[0] = BLOSC_DELTA;
-  cparams.filters[7] = BLOSC_BITSHUFFLE;
+  cparams.filters[BLOSC_MAX_FILTERS - 1] = BLOSC_BITSHUFFLE;
   cparams.compcode = BLOSC_BLOSCLZ;
   cparams.clevel = 5;
   schunk = blosc2_new_schunk(cparams, dparams);

--- a/tests/test_delta_schunk.c
+++ b/tests/test_delta_schunk.c
@@ -32,7 +32,7 @@ int main() {
 
   /* Create a super-chunk container */
   sparams.filters[0] = BLOSC_DELTA;
-  sparams.filters[1] = BLOSC_BITSHUFFLE;
+  sparams.filters[7] = BLOSC_BITSHUFFLE;
   sparams.compressor = BLOSC_BLOSCLZ;
   sparams.clevel = 5;
   sc_header = blosc2_new_schunk(&sparams);


### PR DESCRIPTION
This is a full implementation of the new filter pipeline.  This allows to apply different filters (up to 5 currently) sequentially before the compression stage.  It is implemented at chunk level, and that means that one can select a different set of filters per every chunk.  The way in which the user can populate the pipeline via a C array is still preliminary and one may devise a new way in the future.