### PR TITLE
omit msvc warnings, mostly by casting to the required types

### DIFF
--- a/bench/delta_schunk.c
+++ b/bench/delta_schunk.c
@@ -37,7 +37,7 @@ int main() {
   size_t nchunks = 0;
   blosc_timestamp_t last, current;
   double totaltime;
-  float totalsize = isize * NCHUNKS;
+  float totalsize = (float)(isize * NCHUNKS);
 
   data = malloc(CHUNKSIZE * sizeof(int32_t));
   data_dest = malloc(CHUNKSIZE * sizeof(int32_t));
@@ -87,7 +87,7 @@ int main() {
   }
   blosc_set_timestamp(&current);
   totaltime = blosc_elapsed_secs(last, current);
-  totalsize = isize * nchunks;
+  totalsize = (float)(isize * nchunks);
   printf("[Decompr] Elapsed time:\t %6.3f s.  Processed data: %.3f GB (%.3f GB/s)\n",
          totaltime, totalsize / GB, totalsize / (GB * totaltime));
 

--- a/bench/trunc_prec_schunk.c
+++ b/bench/trunc_prec_schunk.c
@@ -48,7 +48,7 @@ int main() {
   int nchunk, nchunks = 0;
   blosc_timestamp_t last, current;
   double totaltime;
-  float totalsize = isize * NCHUNKS;
+  float totalsize = (float)(isize * NCHUNKS);
   double *data_buffer = malloc(CHUNKSIZE * sizeof(double));
   double *rec_buffer = malloc(CHUNKSIZE * sizeof(double));
 
@@ -108,7 +108,7 @@ int main() {
   }
   blosc_set_timestamp(&current);
   totaltime = blosc_elapsed_secs(last, current);
-  totalsize = isize * nchunks;
+  totalsize = (float)(isize * nchunks);
   printf("[Decompr] Elapsed time:\t %6.3f s."
                  "  Processed data: %.3f GB (%.3f GB/s)\n",
          totaltime, totalsize / GB, totalsize / (GB * totaltime));

--- a/blosc/bitshuffle-generic.c
+++ b/blosc/bitshuffle-generic.c
@@ -8,6 +8,10 @@
 
 #include "bitshuffle-generic.h"
 
+#ifdef _MSC_VER
+#pragma warning (push)
+#pragma warning (disable: 4146)
+#endif
 
 /* Transpose bytes within elements, starting partway through input. */
 int64_t bshuf_trans_byte_elem_remainder(const void* in, void* out, const size_t size,
@@ -77,7 +81,7 @@ int64_t bshuf_trans_bit_byte_remainder(const void* in, void* out, const size_t s
             TRANS_BIT_8X8_BE(x, t);
         }
         for (kk = 0; kk < 8; kk ++) {
-            out_b[bit_row_offset + kk * bit_row_skip + ii] = x;
+            out_b[bit_row_offset + kk * bit_row_skip + ii] = (uint8_t)x;
             x = x >> 8;
         }
     }
@@ -196,7 +200,7 @@ int64_t bshuf_shuffle_bit_eightelem_scal(const void* in, void* out, \
             }
             for (kk = 0; kk < 8; kk++) {
                 out_index = ii + jj / 8 + elem_offset + kk * elem_skip;
-                *((uint8_t*) &out_b[out_index]) = x;
+                *((uint8_t*) &out_b[out_index]) = (uint8_t)x;
                 x = x >> 8;
             }
         }
@@ -219,3 +223,7 @@ int64_t bshuf_untrans_bit_elem_scal(const void* in, void* out, const size_t size
 
     return count;
 }
+
+#ifdef _MSC_VER
+#pragma warning (pop)
+#endif

--- a/blosc/blosc.c
+++ b/blosc/blosc.c
@@ -1013,7 +1013,9 @@ static int serial_blosc(struct thread_context* thread_context) {
 
 /* Threaded version for compression/decompression */
 static int parallel_blosc(blosc2_context* context) {
-
+#ifdef BLOSC_POSIX_BARRIERS
+  int rc;
+#endif
   /* Set sentinels */
   context->thread_giveup_code = 1;
   context->thread_nblock = -1;
@@ -2019,6 +2021,9 @@ static void* t_blosc(void* ctxt) {
   uint8_t* tmp;
   uint8_t* tmp2;
   uint8_t* tmp3;
+#ifdef BLOSC_POSIX_BARRIERS
+  int rc;
+#endif
 
   while (1) {
     /* Synchronization point for all threads (wait for initialization) */

--- a/blosc/delta.c
+++ b/blosc/delta.c
@@ -13,10 +13,10 @@
 
 
 /* Apply the delta filters to src.  This can never fail. */
-void delta_encoder(const uint8_t* dref, size_t offset, int32_t nbytes, size_t typesize,
+void delta_encoder(const uint8_t* dref, size_t offset, int32_t inbytes, size_t typesize,
                    const uint8_t* src, uint8_t* dest) {
   uint32_t i;
-
+  uint32_t nbytes = (uint32_t)inbytes;
   if (offset == 0) {
     /* This is the reference block, use delta coding in elements */
     switch (typesize) {

--- a/blosc/schunk.c
+++ b/blosc/schunk.c
@@ -176,7 +176,7 @@ int blosc2_schunk_decompress_chunk(blosc2_schunk *schunk, int nchunk,
     int nbytes_ = sw32_(src + 4);
     if (nbytes < nbytes_) {
       fprintf(stderr, "Buffer size is too small for the decompressed buffer "
-                      "('%ld' bytes, but '%d' are needed)\n", nbytes, nbytes_);
+                      "('%zd' bytes, but '%d' are needed)\n", nbytes, nbytes_);
       return -11;
     }
 

--- a/examples/contexts.c
+++ b/examples/contexts.c
@@ -42,7 +42,7 @@ int main() {
 
   /* Initialize dataset */
   for (i = 0; i < SIZE; i++) {
-    data[i] = i;
+    data[i] = (float)i;
   }
 
   printf("Blosc version info: %s (%s)\n",

--- a/examples/find_roots.c
+++ b/examples/find_roots.c
@@ -97,7 +97,7 @@ int compute_vectors(void) {
     for (nchunk = 0; nchunk < NCHUNKS; nchunk++) {
         fill_buffer(buffer_x, nchunk);
         blosc2_schunk_append_buffer(sc_x, buffer_x, isize);
-        nbytes += isize;
+        nbytes += (long)isize;
     }
     blosc_set_timestamp(&current);
     ttotal = blosc_elapsed_secs(last, current);

--- a/examples/multithread.c
+++ b/examples/multithread.c
@@ -56,7 +56,7 @@ int main() {
   int nthreads, pnthreads, i;
 
   for (i = 0; i < SIZE; i++) {
-    data[i] = i;
+    data[i] = (float)i;
   }
 
   /* Register the filter with the library */

--- a/examples/noinit.c
+++ b/examples/noinit.c
@@ -43,7 +43,7 @@ int main(){
   int i;
 
   for(i=0; i<SIZE; i++){
-    data[i] = i;
+    data[i] = (float)i;
   }
 
   /* Register the filter with the library */

--- a/examples/simple.c
+++ b/examples/simple.c
@@ -38,7 +38,7 @@ int main() {
   int i, ret;
 
   for (i = 0; i < SIZE; i++) {
-    data[i] = i;
+    data[i] = (float)i;
   }
 
   printf("Blosc version info: %s (%s)\n",

--- a/tests/test_common.h
+++ b/tests/test_common.h
@@ -103,7 +103,7 @@ static void blosc_test_fill_seq(void* const ptr, const size_t size) {
   size_t k;
   uint8_t* const byte_ptr = (uint8_t*)ptr;
   for (k = 0; k < size; k++) {
-    byte_ptr[k] = k;
+    byte_ptr[k] = (uint8_t)k;
   }
 }
 

--- a/tests/test_nthreads.c
+++ b/tests/test_nthreads.c
@@ -82,7 +82,7 @@ int main(int argc, char **argv) {
   int32_t *_src;
   char *result;
   size_t i;
-  int pid, nchildren = 4;
+  int nchildren = 4;
 
   printf("STARTING TESTS for %s", argv[0]);
 


### PR DESCRIPTION
* By applying these changes all warnings from the Visual Studio Compiler (2017) are gone
* Most of the warnings are due to type mismatches.
* Most of the mismatches are not problematic in real world applications, however it always better to avoid the warnings by resolving the type conflicts without casting.