### PR TITLE
Support for prefilters

### DIFF
--- a/README_HEADER.rst
+++ b/README_HEADER.rst
@@ -95,4 +95,4 @@ All entries are little endian.
     (``bitfield``) The flags for a Blosc2 buffer.
 
     :bit 0 (``0x01``):
-        Whether the codec use dictionaries or not.
+        Whether the codec uses dictionaries or not.

--- a/blosc/blosc.c
+++ b/blosc/blosc.c
@@ -613,7 +613,7 @@ uint8_t* pipeline_c(blosc2_context* context, const int32_t bsize,
       fprintf(stderr, "Execution of prefilter function failed\n");
       return NULL;
     };
-    // Cycle filters
+    // Cycle buffers
     _src = _dest;
     _dest = _tmp;
     _tmp = _src;

--- a/blosc/blosc.c
+++ b/blosc/blosc.c
@@ -603,8 +603,12 @@ uint8_t* pipeline_c(blosc2_context* context, const int32_t bsize,
     pparams.out_size = (size_t)bsize;
     pparams.out_typesize = typesize;
     pparams.ninputs = context->pparams->ninputs;
-    pparams.user_data = malloc(context->pparams->user_data_size);
-    memcpy(pparams.user_data, context->pparams->user_data, context->pparams->user_data_size);
+    if (context->pparams->user_data != NULL && context->pparams->user_data_size != 0) {
+      // Provide the user with a copy of the user_data per thread
+      // TODO: do we really need a copy, or just a pointer would be enough?
+      pparams.user_data = malloc(context->pparams->user_data_size);
+      memcpy(pparams.user_data, context->pparams->user_data, context->pparams->user_data_size);
+    }
     int ninputs = context->pparams->ninputs;
     for (int i = 0; i < ninputs; i++) {
       pparams.input_typesizes[i] = context->pparams->input_typesizes[i];
@@ -2683,6 +2687,9 @@ blosc2_context* blosc2_create_cctx(blosc2_cparams cparams) {
     context->prefilter = cparams.prefilter;
     context->pparams = (blosc2_prefilter_params*)malloc(sizeof(blosc2_prefilter_params));
     memcpy(context->pparams, cparams.pparams, sizeof(blosc2_prefilter_params));
+    // Do not expect the user to always pass user_data
+    context->pparams->user_data = NULL;
+    context->pparams->user_data_size = 0;
   }
 
   return context;

--- a/blosc/blosc.c
+++ b/blosc/blosc.c
@@ -1571,7 +1571,9 @@ int blosc_compress_context(blosc2_context* context) {
       }
     }
     else {
-      // TODO: context->src is not defined when using prefilters.  Think about a workaround.
+      if (context->src == NULL) {
+        return -10;  // cannot compress the output from prefilter (context->src == NULL)
+      }
       fastcopy(context->dest + BLOSC_MAX_OVERHEAD, context->src, (unsigned int)context->sourcesize);
       ntbytes = (int)context->sourcesize + BLOSC_MAX_OVERHEAD;
     }

--- a/blosc/blosc.c
+++ b/blosc/blosc.c
@@ -686,7 +686,7 @@ static int blosc_c(struct thread_context* thread_context, int32_t bsize,
   uint8_t *_tmp = tmp, *_tmp2 = tmp2, *_tmp3 = thread_context->tmp4;
   int last_filter_index = last_filter(context->filters, 'c');
 
-  if (last_filter_index >= 0) {
+  if (last_filter_index >= 0 || context->prefilter != NULL) {
     /* Apply filter pipleline */
     _src = pipeline_c(context, bsize, src, offset, _tmp, _tmp2, _tmp3);
     if (_src == NULL)
@@ -1497,14 +1497,16 @@ static int write_compression_header(blosc2_context* context,
                             sizeof(int32_t) * context->nblocks;
   }
 
-  if (context->clevel == 0) {
-    /* Compression level 0 means buffer to be memcpy'ed */
-    *(context->header_flags) |= BLOSC_MEMCPYED;
-  }
+  if (context->prefilter == NULL) {
+    if (context->clevel == 0) {
+      /* Compression level 0 means buffer to be memcpy'ed */
+      *(context->header_flags) |= BLOSC_MEMCPYED;
+    }
 
-  if (context->sourcesize < BLOSC_MIN_BUFFERSIZE) {
-    /* Buffer is too small.  Try memcpy'ing. */
-    *(context->header_flags) |= BLOSC_MEMCPYED;
+    if (context->sourcesize < BLOSC_MIN_BUFFERSIZE) {
+      /* Buffer is too small.  Try memcpy'ing. */
+      *(context->header_flags) |= BLOSC_MEMCPYED;
+    }
   }
 
   if (context->filter_flags & BLOSC_DOSHUFFLE) {

--- a/blosc/blosc.c
+++ b/blosc/blosc.c
@@ -601,17 +601,22 @@ uint8_t* pipeline_c(blosc2_context* context, const int32_t bsize,
     prefilter_params pparams;
     pparams.out = dest;
     pparams.out_size = (size_t)bsize;
+    pparams.out_typesize = typesize;
     pparams.ninputs = context->pparams->ninputs;
     int ninputs = context->pparams->ninputs;
     for (int i = 0; i < ninputs; i++) {
-      pparams.typesizes[i] = context->pparams->typesizes[i];
-      int32_t offset_i = (offset / typesize) * pparams.typesizes[i];
+      pparams.input_typesizes[i] = context->pparams->input_typesizes[i];
+      int32_t offset_i = (offset / typesize) * pparams.input_typesizes[i];
       pparams.inputs[i] = context->pparams->inputs[i] + offset_i;
     }
     if (context->prefilter(&pparams) != 0) {
       fprintf(stderr, "Execution of prefilter function failed\n");
       return NULL;
     };
+    // Cycle filters
+    _src = _dest;
+    _dest = _tmp;
+    _tmp = _src;
   }
 
   /* Process the filter pipeline */

--- a/blosc/blosc.c
+++ b/blosc/blosc.c
@@ -598,7 +598,7 @@ uint8_t* pipeline_c(blosc2_context* context, const int32_t bsize,
   /* Prefilter function */
   if (context->prefilter != NULL) {
     // Create new prefilter parameters for this block
-    prefilter_params pparams;
+    blosc2_prefilter_params pparams;
     pparams.out = dest;
     pparams.out_size = (size_t)bsize;
     pparams.out_typesize = typesize;
@@ -2674,8 +2674,8 @@ blosc2_context* blosc2_create_cctx(blosc2_cparams cparams) {
 
   if (cparams.prefilter != NULL) {
     context->prefilter = cparams.prefilter;
-    context->pparams = (prefilter_params*)malloc(sizeof(prefilter_params));
-    memcpy(context->pparams, cparams.pparams, sizeof(prefilter_params));
+    context->pparams = (blosc2_prefilter_params*)malloc(sizeof(blosc2_prefilter_params));
+    memcpy(context->pparams, cparams.pparams, sizeof(blosc2_prefilter_params));
   }
 
   return context;

--- a/blosc/blosc.c
+++ b/blosc/blosc.c
@@ -603,14 +603,7 @@ uint8_t* pipeline_c(blosc2_context* context, const int32_t bsize,
     pparams.out_size = (size_t)bsize;
     pparams.out_typesize = typesize;
     pparams.ninputs = context->pparams->ninputs;
-    if (context->pparams->user_data != NULL && context->pparams->user_data_size != 0) {
-      // Provide the user with a copy of the user_data per thread
-      // TODO: do we really need a copy, or just a pointer would be enough?
-      // Followup: apparently a copy does not fix the tinyexpr evaluator in parallel
-      //pparams.user_data = malloc(context->pparams->user_data_size);
-      //memcpy(pparams.user_data, context->pparams->user_data, context->pparams->user_data_size);
-      pparams.user_data = context->pparams->user_data;
-    }
+    pparams.user_data = context->pparams->user_data;
     int ninputs = context->pparams->ninputs;
     for (int i = 0; i < ninputs; i++) {
       pparams.input_typesizes[i] = context->pparams->input_typesizes[i];
@@ -2728,10 +2721,6 @@ void blosc2_free_ctx(blosc2_context* context) {
     btune_free(context);
   }
   if (context->prefilter != NULL) {
-    if (context->pparams->user_data != NULL) {
-      // TODO: check if we should copy user_data internally, and free it here if necessary...
-      //my_free(context->pparams->user_data);
-    }
     my_free(context->pparams);
   }
 

--- a/blosc/blosc.c
+++ b/blosc/blosc.c
@@ -2729,7 +2729,8 @@ void blosc2_free_ctx(blosc2_context* context) {
   }
   if (context->prefilter != NULL) {
     if (context->pparams->user_data != NULL) {
-      my_free(context->pparams->user_data);
+      // TODO: check if we should copy user_data internally, and free it here if necessary...
+      //my_free(context->pparams->user_data);
     }
     my_free(context->pparams);
   }

--- a/blosc/blosc.c
+++ b/blosc/blosc.c
@@ -606,8 +606,10 @@ uint8_t* pipeline_c(blosc2_context* context, const int32_t bsize,
     if (context->pparams->user_data != NULL && context->pparams->user_data_size != 0) {
       // Provide the user with a copy of the user_data per thread
       // TODO: do we really need a copy, or just a pointer would be enough?
-      pparams.user_data = malloc(context->pparams->user_data_size);
-      memcpy(pparams.user_data, context->pparams->user_data, context->pparams->user_data_size);
+      // Followup: apparently a copy does not fix the tinyexpr evaluator in parallel
+      //pparams.user_data = malloc(context->pparams->user_data_size);
+      //memcpy(pparams.user_data, context->pparams->user_data, context->pparams->user_data_size);
+      pparams.user_data = context->pparams->user_data;
     }
     int ninputs = context->pparams->ninputs;
     for (int i = 0; i < ninputs; i++) {
@@ -2687,9 +2689,6 @@ blosc2_context* blosc2_create_cctx(blosc2_cparams cparams) {
     context->prefilter = cparams.prefilter;
     context->pparams = (blosc2_prefilter_params*)malloc(sizeof(blosc2_prefilter_params));
     memcpy(context->pparams, cparams.pparams, sizeof(blosc2_prefilter_params));
-    // Do not expect the user to always pass user_data
-    context->pparams->user_data = NULL;
-    context->pparams->user_data_size = 0;
   }
 
   return context;

--- a/blosc/blosc.c
+++ b/blosc/blosc.c
@@ -603,6 +603,8 @@ uint8_t* pipeline_c(blosc2_context* context, const int32_t bsize,
     pparams.out_size = (size_t)bsize;
     pparams.out_typesize = typesize;
     pparams.ninputs = context->pparams->ninputs;
+    pparams.user_data = malloc(context->pparams->user_data_size);
+    memcpy(pparams.user_data, context->pparams->user_data, context->pparams->user_data_size);
     int ninputs = context->pparams->ninputs;
     for (int i = 0; i < ninputs; i++) {
       pparams.input_typesizes[i] = context->pparams->input_typesizes[i];
@@ -2713,6 +2715,9 @@ void blosc2_free_ctx(blosc2_context* context) {
     btune_free(context);
   }
   if (context->prefilter != NULL) {
+    if (context->pparams->user_data != NULL) {
+      my_free(context->pparams->user_data);
+    }
     my_free(context->pparams);
   }
 

--- a/blosc/blosc.h
+++ b/blosc/blosc.h
@@ -683,9 +683,11 @@ BLOSC_EXPORT void blosc2_free_ctx(blosc2_context* context);
  * @param dest The buffer where the compressed data will be put.
  * @param destsize The size in bytes of the @p dest buffer.
  *
- * @return The number of bytes compressed. A negative return value means
- * that an internal error happened. It could happen that context is
- * not meant for compression (which is stated in stderr).
+ * @return The number of bytes compressed.
+ * If @p src buffer cannot be compressed into @p destsize, the return
+ * value is zero and you should discard the contents of the @p dest
+ * buffer.  A negative return value means that an internal error happened.
+ * It could happen that context is not meant for compression (which is stated in stderr).
  * Otherwise, please report it back together with the buffer data causing this
  * and compression settings.
  */
@@ -837,7 +839,8 @@ BLOSC_EXPORT int blosc2_free_schunk(blosc2_schunk *schunk);
  * @brief Append an existing @p chunk o a super-chunk.
  *
  * @param schunk The super-chunk where the chunk will be appended.
- * @param chunk The chunk to append.
+ * @param chunk The @p chunk to append.  An internal copy is made, so @p chunk can be reused or
+ * freed if desired.
  *
  * @return The number of chunks in super-chunk. If some problem is
  * detected, this number will be negative.

--- a/blosc/blosc.h
+++ b/blosc/blosc.h
@@ -573,7 +573,6 @@ typedef struct {
   uint8_t* inputs[BLOSC2_PREFILTER_INPUTS_MAX];  // the data inputs
   int32_t input_typesizes[BLOSC2_PREFILTER_INPUTS_MAX];  // the typesizes for data inputs
   void *user_data;  // user-provided info (optional)
-  size_t user_data_size;  // size for user-provided info (optional)
   uint8_t *out;  // automatically filled
   size_t out_size;  // automatically filled
   int32_t out_typesize;  // automatically filled

--- a/blosc/blosc.h
+++ b/blosc/blosc.h
@@ -565,24 +565,25 @@ typedef struct blosc2_context_s blosc2_context;   /* opaque type */
  *
  * There can be many inputs and a single output.
  * The number of elements of each input and the output should be the same.
- * The user only needs to fill the `ninputs` , `inputs` and `input_typesizes`;
+ * Strictly, the user only needs to fill the `ninputs` , `inputs` and `input_typesizes`.
  * The other fields will be filled by the library itself.
  */
 typedef struct {
-  int ninputs;
-  uint8_t* inputs[BLOSC2_PREFILTER_INPUTS_MAX];
-  int32_t input_typesizes[BLOSC2_PREFILTER_INPUTS_MAX];
+  int ninputs;  // number of data inputs
+  uint8_t* inputs[BLOSC2_PREFILTER_INPUTS_MAX];  // the data inputs
+  int32_t input_typesizes[BLOSC2_PREFILTER_INPUTS_MAX];  // the typesizes for data inputs
+  void *user_data;  // user-provided info.  Optional
   uint8_t *out;  // automatically filled
   size_t out_size;  // automatically filled
   int32_t out_typesize;  // automatically filled
-} prefilter_params;
+} blosc2_prefilter_params;
 
 /**
  * @brief The type of the prefilter function.
  *
  * If the function call is successful, the return value should be 0; else, a negative value.
  */
-typedef int (*prefilter_fn)(prefilter_params* params);
+typedef int (*blosc2_prefilter_fn)(blosc2_prefilter_params* params);
 
 /**
  * @brief The parameters for creating a context for compression purposes.
@@ -609,9 +610,9 @@ typedef struct {
   //!< The (sequence of) filters.
   uint8_t filters_meta[BLOSC_MAX_FILTERS];
   //!< The metadata for filters.
-  prefilter_fn prefilter;
+  blosc2_prefilter_fn prefilter;
   //!< The prefilter function.
-  prefilter_params *pparams;
+  blosc2_prefilter_params *pparams;
   //!< The prefilter parameters.
 } blosc2_cparams;
 

--- a/blosc/blosc.h
+++ b/blosc/blosc.h
@@ -572,9 +572,9 @@ typedef struct {
   int ninputs;
   uint8_t* inputs[BLOSC2_PREFILTER_INPUTS_MAX];
   int32_t input_typesizes[BLOSC2_PREFILTER_INPUTS_MAX];
-  uint8_t *out;  // no need to fill
-  size_t out_size;  // no need to fill
-  int32_t out_typesize;  // no need to fill
+  uint8_t *out;  // automatically filled
+  size_t out_size;  // automatically filled
+  int32_t out_typesize;  // automatically filled
 } prefilter_params;
 
 /**

--- a/blosc/blosc.h
+++ b/blosc/blosc.h
@@ -565,13 +565,16 @@ typedef struct blosc2_context_s blosc2_context;   /* opaque type */
  *
  * There can be many inputs and a single output.
  * The number of elements of each input and the output should be the same.
+ * The user only needs to fill the `ninputs` , `inputs` and `input_typesizes`;
+ * The other fields will be filled by the library itself.
  */
 typedef struct {
-  void *out;
-  size_t out_size;
   int ninputs;
-  int32_t typesizes[BLOSC2_PREFILTER_INPUTS_MAX];
   uint8_t* inputs[BLOSC2_PREFILTER_INPUTS_MAX];
+  int32_t input_typesizes[BLOSC2_PREFILTER_INPUTS_MAX];
+  uint8_t *out;  // no need to fill
+  size_t out_size;  // no need to fill
+  int32_t out_typesize;  // no need to fill
 } prefilter_params;
 
 /**

--- a/blosc/blosc.h
+++ b/blosc/blosc.h
@@ -572,7 +572,8 @@ typedef struct {
   int ninputs;  // number of data inputs
   uint8_t* inputs[BLOSC2_PREFILTER_INPUTS_MAX];  // the data inputs
   int32_t input_typesizes[BLOSC2_PREFILTER_INPUTS_MAX];  // the typesizes for data inputs
-  void *user_data;  // user-provided info.  Optional
+  void *user_data;  // user-provided info (optional)
+  size_t user_data_size;  // size for user-provided info (optional)
   uint8_t *out;  // automatically filled
   size_t out_size;  // automatically filled
   int32_t out_typesize;  // automatically filled
@@ -831,6 +832,17 @@ blosc2_new_schunk(blosc2_cparams cparams, blosc2_dparams dparams, blosc2_frame *
  * @return 0 if succeeds.
  */
 BLOSC_EXPORT int blosc2_free_schunk(blosc2_schunk *schunk);
+
+/**
+ * @brief Append an existing @p chunk o a super-chunk.
+ *
+ * @param schunk The super-chunk where the chunk will be appended.
+ * @param chunk The chunk to append.
+ *
+ * @return The number of chunks in super-chunk. If some problem is
+ * detected, this number will be negative.
+ */
+BLOSC_EXPORT int blosc2_schunk_append_chunk(blosc2_schunk *schunk, uint8_t *chunk);
 
 /**
  * @brief Append a @p src data buffer to a super-chunk.

--- a/blosc/blosc.h
+++ b/blosc/blosc.h
@@ -558,6 +558,29 @@ BLOSC_EXPORT char* blosc_cbuffer_complib(const void* cbuffer);
 
 typedef struct blosc2_context_s blosc2_context;   /* opaque type */
 
+#define BLOSC2_PREFILTER_INPUTS_MAX (128)
+
+/**
+ * @brief The parameters for a prefilter function.
+ *
+ * There can be many inputs and a single output.
+ * The number of elements of each input and the output should be the same.
+ */
+typedef struct {
+  void *out;
+  size_t out_size;
+  int ninputs;
+  int32_t typesizes[BLOSC2_PREFILTER_INPUTS_MAX];
+  uint8_t* inputs[BLOSC2_PREFILTER_INPUTS_MAX];
+} prefilter_params;
+
+/**
+ * @brief The type of the prefilter function.
+ *
+ * If the function call is successful, the return value should be 0; else, a negative value.
+ */
+typedef int (*prefilter_fn)(prefilter_params* params);
+
 /**
  * @brief The parameters for creating a context for compression purposes.
  *
@@ -583,6 +606,10 @@ typedef struct {
   //!< The (sequence of) filters.
   uint8_t filters_meta[BLOSC_MAX_FILTERS];
   //!< The metadata for filters.
+  prefilter_fn prefilter;
+  //!< The prefilter function.
+  prefilter_params *pparams;
+  //!< The prefilter parameters.
 } blosc2_cparams;
 
 /**
@@ -590,7 +617,8 @@ typedef struct {
  */
 static const blosc2_cparams BLOSC_CPARAMS_DEFAULTS = {
         BLOSC_BLOSCLZ, 5, 0, 8, 1, 0, NULL,
-        {0, 0, 0, 0, BLOSC_SHUFFLE}, {0, 0, 0, 0, 0} };
+        {0, 0, 0, 0, BLOSC_SHUFFLE}, {0, 0, 0, 0, 0},
+        NULL, NULL };
 
 /**
   @brief The parameters for creating a context for decompression purposes.

--- a/blosc/context.h
+++ b/blosc/context.h
@@ -75,6 +75,12 @@ struct blosc2_context_s {
   uint8_t filters[BLOSC_MAX_FILTERS];
   /* the (sequence of) filters */
   uint8_t filters_meta[BLOSC_MAX_FILTERS];
+  /* the metainfo for filters */
+  prefilter_fn prefilter;
+  /* prefilter function */
+  prefilter_params *pparams;
+  /* prefilter params */
+
   /* metadata for filters */
   blosc2_schunk* schunk;
   /* Associated super-chunk (if available) */

--- a/blosc/context.h
+++ b/blosc/context.h
@@ -76,9 +76,9 @@ struct blosc2_context_s {
   /* the (sequence of) filters */
   uint8_t filters_meta[BLOSC_MAX_FILTERS];
   /* the metainfo for filters */
-  prefilter_fn prefilter;
+  blosc2_prefilter_fn prefilter;
   /* prefilter function */
-  prefilter_params *pparams;
+  blosc2_prefilter_params *pparams;
   /* prefilter params */
 
   /* metadata for filters */

--- a/blosc/schunk.c
+++ b/blosc/schunk.c
@@ -115,7 +115,7 @@ blosc2_schunk *blosc2_new_schunk(blosc2_cparams cparams, blosc2_dparams dparams,
 
 
 /* Append an existing chunk into a super-chunk. */
-int append_chunk(blosc2_schunk* schunk, uint8_t* chunk) {
+int blosc2_schunk_append_chunk(blosc2_schunk *schunk, uint8_t *chunk) {
   int32_t nchunks = schunk->nchunks;
   /* The uncompressed and compressed sizes start at byte 4 and 12 */
   // TODO: update for extended headers
@@ -180,7 +180,7 @@ int blosc2_schunk_append_buffer(blosc2_schunk *schunk, void *src, size_t nbytes)
   }
   // TODO: use a realloc to get rid of unused space in chunk
 
-  int nchunks = append_chunk(schunk, chunk);
+  int nchunks = blosc2_schunk_append_chunk(schunk, chunk);
   return nchunks;
 }
 

--- a/blosc/schunk.c
+++ b/blosc/schunk.c
@@ -15,6 +15,7 @@
 #include "blosc.h"
 #include "blosc-private.h"
 #include "context.h"
+#include "fastcopy.h"
 
 #include "zstd.h"
 #include "zstd_errors.h"
@@ -153,7 +154,7 @@ int blosc2_schunk_append_chunk(blosc2_schunk *schunk, uint8_t *chunk) {
 
     // Make a copy of the chunk
     uint8_t* chunk_copy = malloc(cbytes);
-    memcpy(chunk_copy, chunk, cbytes);
+    fastcopy(chunk_copy, chunk, cbytes);
 
     /* Make space for appending the copy of the chunk and do it */
     schunk->data = realloc(schunk->data, (nchunks + 1) * sizeof(void *));

--- a/examples/zstd_dict.c
+++ b/examples/zstd_dict.c
@@ -27,7 +27,7 @@
 #define GB  (1024*MB)
 
 #define CHUNKSIZE (200 * 1000)
-#define NCHUNKS 500
+#define NCHUNKS 20
 #define NTHREADS 4
 
 

--- a/tests/test_dict_schunk.c
+++ b/tests/test_dict_schunk.c
@@ -12,7 +12,7 @@
 #include "test_common.h"
 
 #define CHUNKSIZE (200 * 1000)
-#define NCHUNKS 100
+#define NCHUNKS 20
 #define NTHREADS 4
 
 /* Global vars */
@@ -109,23 +109,23 @@ static char* test_dict() {
     switch (blocksize) {
       case 1 * KB:
         mu_assert("ERROR: Dict does not reach expected compression ratio",
-                  15 * cbytes < nbytes);
+                  10 * cbytes < nbytes);
         break;
       case 4 * KB:
         mu_assert("ERROR: Dict does not reach expected compression ratio",
-                  40 * cbytes < nbytes);
+                  20 * cbytes < nbytes);
         break;
       case 32 * KB:
         mu_assert("ERROR: Dict does not reach expected compression ratio",
-                  70 * cbytes < nbytes);
+                  150 * cbytes < nbytes);
         break;
       case 256 * KB:
         mu_assert("ERROR: Dict does not reach expected compression ratio",
-                  210 * cbytes < nbytes);
+                  300 * cbytes < nbytes);
         break;
       default:
         mu_assert("ERROR: Dict does not reach expected compression ratio",
-                  120 * cbytes < nbytes);
+                  300 * cbytes < nbytes);
     }
   }
 

--- a/tests/test_prefilter.c
+++ b/tests/test_prefilter.c
@@ -24,7 +24,7 @@ size_t isize = SIZE * sizeof(int32_t), osize = SIZE * sizeof(int32_t);
 int dsize = SIZE * sizeof(int32_t), csize;
 
 
-int prefilter_func(prefilter_params *pparams) {
+int prefilter_func(blosc2_prefilter_params *pparams) {
   int nelems = pparams->out_size / pparams->out_typesize;
   if (pparams->ninputs == 1) {
     for (int i = 0; i < nelems; i++) {
@@ -45,8 +45,8 @@ int prefilter_func(prefilter_params *pparams) {
 
 static char *test_prefilter1() {
   // Set some prefilter parameters and function
-  cparams.prefilter = (prefilter_fn)prefilter_func;
-  prefilter_params pparams;
+  cparams.prefilter = (blosc2_prefilter_fn)prefilter_func;
+  blosc2_prefilter_params pparams;
   pparams.ninputs = 1;
   pparams.inputs[0] = (uint8_t*)data;
   pparams.input_typesizes[0] = cparams.typesize;
@@ -76,8 +76,8 @@ static char *test_prefilter1() {
 
 static char *test_prefilter2() {
   // Set some prefilter parameters and function
-  cparams.prefilter = (prefilter_fn)prefilter_func;
-  prefilter_params pparams;
+  cparams.prefilter = (blosc2_prefilter_fn)prefilter_func;
+  blosc2_prefilter_params pparams;
   pparams.ninputs = 2;
   pparams.inputs[0] = (uint8_t*)data;
   pparams.inputs[1] = (uint8_t*)data2;

--- a/tests/test_prefilter.c
+++ b/tests/test_prefilter.c
@@ -1,0 +1,109 @@
+/*
+  Copyright (C) 2019  The Blosc Developers
+  http://blosc.org
+  License: BSD (see LICENSE.txt)
+
+*/
+
+#include <stdio.h>
+#include "test_common.h"
+
+#define SIZE 500 * 1000
+#define NTHREADS 2
+
+int prefilter_example(prefilter_params* pparams) {
+  if (pparams->ninputs == 1) {
+    memcpy(pparams->out, pparams->inputs[0], pparams->out_size);
+  }
+  else {
+    return 1;
+  }
+  return 0;
+}
+
+int main() {
+  static int32_t data[SIZE];
+  static int32_t data_out[SIZE];
+  static int32_t data_dest[SIZE];
+  int32_t data_subset[5];
+  int32_t data_subset_ref[5] = {5, 6, 7, 8, 9};
+  size_t isize = SIZE * sizeof(int32_t), osize = SIZE * sizeof(int32_t);
+  int dsize = SIZE * sizeof(int32_t), csize;
+  int i, ret;
+  blosc2_cparams cparams = BLOSC_CPARAMS_DEFAULTS;
+  blosc2_dparams dparams = BLOSC_DPARAMS_DEFAULTS;
+  blosc2_context *cctx, *dctx;
+
+  /* Initialize dataset */
+  for (i = 0; i < SIZE; i++) {
+    data[i] = i;
+  }
+
+  printf("Blosc version info: %s (%s)\n",
+         BLOSC_VERSION_STRING, BLOSC_VERSION_DATE);
+
+  /* Create a context for compression */
+  cparams.typesize = sizeof(int32_t);
+  cparams.compcode = BLOSC_BLOSCLZ;
+  cparams.filters[BLOSC_MAX_FILTERS - 1] = BLOSC_SHUFFLE;
+  cparams.clevel = 5;
+  cparams.nthreads = NTHREADS;
+
+  // Set some prefilter parameters and function
+  cparams.prefilter = (prefilter_fn)prefilter_example;
+  prefilter_params pparams;
+  pparams.ninputs = 1;
+  pparams.inputs[0] = (uint8_t*)data;
+  pparams.typesizes[0] = cparams.typesize;
+  cparams.pparams = &pparams;
+
+  cctx = blosc2_create_cctx(cparams);
+
+  /* Compress with clevel=5 and shuffle active  */
+  csize = blosc2_compress_ctx(cctx, isize, data, data_out, osize);
+  if (csize == 0) {
+    printf("Buffer is uncompressible.  Giving up.\n");
+    return EXIT_FAILURE;
+  }
+  if (csize < 0) {
+    printf("Compression error.  Error code: %d\n", csize);
+    return EXIT_FAILURE;
+  }
+
+  /* Create a context for decompression */
+  dparams.nthreads = NTHREADS;
+  dctx = blosc2_create_dctx(dparams);
+
+  ret = blosc2_getitem_ctx(dctx, data_out, 5, 5, data_subset);
+  if (ret < 0) {
+    printf("Error in blosc2_getitem_ctx().  Giving up.\n");
+    return EXIT_FAILURE;
+  }
+
+  for (i = 0; i < 5; i++) {
+    if (data_subset[i] != data_subset_ref[i]) {
+      printf("blosc2_getitem_ctx() fetched data differs from original!\n");
+      return EXIT_FAILURE;
+    }
+  }
+
+  /* Decompress  */
+  dsize = blosc2_decompress_ctx(dctx, data_out, data_dest, (size_t)dsize);
+  if (dsize < 0) {
+    printf("Decompression error.  Error code: %d\n", dsize);
+    return EXIT_FAILURE;
+  }
+
+  for (i = 0; i < SIZE; i++) {
+    if (data[i] != data_dest[i]) {
+      printf("Decompressed data differs from original!\n");
+      return EXIT_FAILURE;
+    }
+  }
+
+  /* Free resources */
+  blosc2_free_ctx(cctx);
+  blosc2_free_ctx(dctx);
+
+  return EXIT_SUCCESS;
+}

--- a/tests/test_prefilter.c
+++ b/tests/test_prefilter.c
@@ -47,8 +47,7 @@ static char *test_prefilter1() {
   // Set some prefilter parameters and function
   cparams.prefilter = (blosc2_prefilter_fn)prefilter_func;
   // We need to zero the contents of the pparams.  TODO: make a constructor for ppparams.
-  blosc2_prefilter_params pparams;
-  memset(&pparams, 0, sizeof(blosc2_prefilter_params));
+  blosc2_prefilter_params pparams = {0};
   pparams.ninputs = 1;
   pparams.inputs[0] = (uint8_t*)data;
   pparams.input_typesizes[0] = cparams.typesize;
@@ -83,7 +82,8 @@ static char *test_prefilter1() {
 static char *test_prefilter2() {
   // Set some prefilter parameters and function
   cparams.prefilter = (blosc2_prefilter_fn)prefilter_func;
-  blosc2_prefilter_params pparams;
+  // We need to zero the contents of the pparams.  TODO: make a constructor for ppparams.
+  blosc2_prefilter_params pparams = {0};
   pparams.ninputs = 2;
   pparams.inputs[0] = (uint8_t*)data;
   pparams.inputs[1] = (uint8_t*)data2;

--- a/tests/test_prefilter.c
+++ b/tests/test_prefilter.c
@@ -46,7 +46,9 @@ int prefilter_func(blosc2_prefilter_params *pparams) {
 static char *test_prefilter1() {
   // Set some prefilter parameters and function
   cparams.prefilter = (blosc2_prefilter_fn)prefilter_func;
+  // We need to zero the contents of the pparams.  TODO: make a constructor for ppparams.
   blosc2_prefilter_params pparams;
+  memset(&pparams, 0, sizeof(blosc2_prefilter_params));
   pparams.ninputs = 1;
   pparams.inputs[0] = (uint8_t*)data;
   pparams.input_typesizes[0] = cparams.typesize;

--- a/tests/test_prefilter.c
+++ b/tests/test_prefilter.c
@@ -10,7 +10,7 @@
 int tests_run = 0;
 
 #define SIZE 500 * 1000
-#define NTHREADS 2
+#define NTHREADS 1
 
 // Global vars
 blosc2_cparams cparams;
@@ -70,6 +70,10 @@ static char *test_prefilter1() {
     mu_assert("Decompressed data differs from original!", data[i] == data_dest[i]);
   }
 
+  /* Free resources */
+  blosc2_free_ctx(cctx);
+  blosc2_free_ctx(dctx);
+
   return 0;
 }
 
@@ -105,6 +109,10 @@ static char *test_prefilter2() {
     }
     mu_assert("Decompressed data differs from original!", (data[i] + data2[i]) == data_dest[i]);
   }
+
+  /* Free resources */
+  blosc2_free_ctx(cctx);
+  blosc2_free_ctx(dctx);
 
   return 0;
 }
@@ -142,11 +150,6 @@ int main() {
     printf(" ALL TESTS PASSED");
   }
   printf("\tTests run: %d\n", tests_run);
-
-
-  /* Free resources */
-  blosc2_free_ctx(cctx);
-  blosc2_free_ctx(dctx);
 
   return result != 0;
 }


### PR DESCRIPTION
Prefilters are user-provided functions that are meant to be executed previously to any filter. As these functions are executed in the same pipeline than the filters, the memory usage is optimal; in addition, we get parallelism for free. 