### PR TITLE
Metalayers moved to schunk

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ What is it?
 `Blosc <http://blosc.org/pages/blosc-in-depth/>`_ is a high performance compressor optimized for binary data.  It has been designed to transmit data to the processor cache faster than the traditional, non-compressed, direct memory fetch approach via a memcpy() OS call.  Blosc is the first compressor (that I'm aware of) that is meant not only to reduce the size of large datasets on-disk or
 in-memory, but also to accelerate memory-bound computations.
 
-C-Blosc2 is the new major version of C-Blosc, with a revamped API and support for new filters (including filter pipelining), new compressors, but most importantly new data containers that are meant to overcome the 32-bit limitation of the original C-Blosc.  These new data containers will be available in various forms, including in-memory and on-disk implementations (frames).  Finally, the frames can be annotated with metainfo (metalayers) that is provided by the user.
+C-Blosc2 is the new major version of C-Blosc, with a revamped API and support for new filters (including filter pipelining), new compressors, but most importantly new data containers that are meant to overcome the 32-bit limitation of the original C-Blosc.  These new data containers will be available in various forms, including in-memory and on-disk implementations (frames).  Finally, the frames can be annotated with metainfo (metalayers, usermeta) that is provided by the user.
 
 C-Blosc2 tries to be backward compatible with both the C-Blosc1 API and format.  Furthermore, if you just use the C-Blosc1 API you are guaranteed to generate compressed data containers that can be read with a Blosc1 library, but getting the benefit of better performance, like for example leveraging the accelerated versions of codecs present in Intel's IPP (LZ4 now and maybe others later on).
 
@@ -40,9 +40,6 @@ Meta-compression and other advantages over existing compressors
 
 C-Blosc2 is not like other compressors: it should rather be called a meta-compressor.  This is so because it can use different compressors and filters (programs that generally improve compression ratio).  At any rate, it can also be called a compressor because it happens that it already comes with several compressor and filters, so it can actually work like so.
 
-Another important aspect of C-Blosc2 is that it is meant to host blocks of data in smaller containers.  These containers are called *chunks* in C-Blosc2 jargon (they are basically `Blosc1 containers <https://github.com/Blosc/c-blosc>`_). For achieving maximum speed, these chunks are meant to fit in the LLC (Last Level Cache) of modern CPUs.  In practice, this means that in order to leverage C-Blosc2 containers effectively, the user should ask for C-Blosc2 to uncompress the chunks, consume them before they hit
-main memory and then proceed with the new chunk (as in any streaming operation).  We call this process *Streamed Compressed Computing* and it effectively avoids uncompressed data to travel to RAM, saving precious time in modern architectures where RAM access is very expensive compared with CPU speeds (most specially when those cores are working cooperatively to solve some computational task).
-
 Currently C-Blosc2 comes with support of BloscLZ, a compressor heavily based on FastLZ (http://fastlz.org/), LZ4 and LZ4HC
 (https://github.com/Cyan4973/lz4), Zstd (https://github.com/facebook/zstd), Lizard (https://github.com/inikep/lizard) and Zlib (via miniz: https://github.com/richgel999/miniz), as well as a highly optimized (it can use SSE2, AVX2, NEON or ALTIVEC instructions, if available) shuffle and bitshuffle filters (for info on how shuffling works, see slide 17 of http://www.slideshare.net/PyData/blosc-py-data-2014).  However, different compressors or filters may be added in the future.
 
@@ -50,6 +47,8 @@ C-Blosc2 is in charge of coordinating the different compressor and filters so th
 above) as well as multi-threaded execution (if several cores are available) automatically. That makes that every compressor and filter
 will work at very high speeds, even if it was not initially designed for doing blocking or multi-threading.
 
+Another important aspect of C-Blosc2 is that it is meant to host blocks of data in smaller containers.  These containers are called *chunks* in C-Blosc2 jargon (they are basically `Blosc1 containers <https://github.com/Blosc/c-blosc>`_). For achieving maximum speed, these chunks are meant to fit in the LLC (Last Level Cache) of modern CPUs.  In practice, this means that in order to leverage C-Blosc2 containers effectively, the user should ask for C-Blosc2 to uncompress the chunks, consume them before they hit
+main memory and then proceed with the new chunk (as in any streaming operation).  We call this process *Streamed Compressed Computing* and it effectively avoids uncompressed data to travel to RAM, saving precious time in modern architectures where RAM access is very expensive compared with CPU speeds (most specially when those cores are working cooperatively to solve some computational task).
 
 Compiling the C-Blosc2 library with CMake
 =========================================
@@ -110,8 +109,7 @@ You can also disable support for some compression libraries:
 Supported platforms
 ~~~~~~~~~~~~~~~~~~~
 
-C-Blosc2 is meant to support all platforms where a C99 compliant C compiler can be found.  The ones that are mostly tested are Intel
-(Linux, Mac OSX and Windows) and ARM (Linux), but exotic ones as IBM Blue Gene Q embedded "A2" processor are reported to work too.
+C-Blosc2 is meant to support all platforms where a C99 compliant C compiler can be found.  The ones that are mostly tested are Intel (Linux, Mac OSX and Windows) and ARM (Linux), but exotic ones as IBM Blue Gene Q embedded "A2" processor are reported to work too.
 
 For Windows, you will need at least VS2015 or higher on x86 and x64 targets (i.e. ARM is not supported on Windows).
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -9,7 +9,7 @@ Changes from 2.0.0-beta.1 to 2.0.0-beta.2
 * A new `usermeta` chunk in `schunk` allows to store arbitrary meta-information
   that is up to the user.  If the `schunk` has an attached `frame`, the later
   will be updated accordingly too.  See docstrings of new
-  `blosc2_schunk_update_usermeta()` function for more info.
+  `blosc2_update_usermeta()` function for more info.
 
 
 Changes from 2.0.0a5 to 2.0.0-beta.1

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -8,8 +8,31 @@ Changes from 2.0.0-beta.1 to 2.0.0-beta.2
 
 * A new `usermeta` chunk in `schunk` allows to store arbitrary meta-information
   that is up to the user.  If the `schunk` has an attached `frame`, the later
-  will be updated accordingly too.  See docstrings of new
-  `blosc2_update_usermeta()` function for more info.
+  will be updated accordingly too.  For more info, see PR #74 and docstrings of
+  new `blosc2_update_usermeta()` and `blosc2_get_usermeta()` functions.
+
+* Metalayers must now be attached to super-chunks, not frames.  The reason is
+  that frames are increasingly treated as a storage specifier (in-memory or disk
+  now, but can be other means in the future), whereas the actual API for I/O
+  (including metainfo) goes into super-chunks.  See PR #75.
+
+* New frame format documented in
+  [README_FRAME_FORMAT.rst](README_FRAME_FORMAT.rst). Remember that the frame
+  format is not written in stone yet, so some changes may be introduced before
+  getting out of beta.
+
+* BREAKING CHANGE: the next APIs have been renamed:
+  + blosc2_frame_has_metalayer -> blosc2_has_metalayer
+  + blosc2_frame_add_metalayer -> blosc2_add_metalayer
+  + blosc2_frame_update_metalayer -> blosc2_update_metalayer
+  + blosc2_frame_metalayer -> blosc2_get_metalayer
+
+  Although the API was declared stable in beta.1, the fact that metalayers are
+  attached now to super-chunks directly, made this change completely necessary.
+
+* BREAKING CHANGE: the next symbols have been renamed:
+  + BLOSC_CPARAMS_DEFAULTS -> BLOSC2_CPARAMS_DEFAULTS
+  + BLOSC_DPARAMS_DEFAULTS -> BLOSC2_DPARAMS_DEFAULTS
 
 
 Changes from 2.0.0a5 to 2.0.0-beta.1

--- a/THANKS.rst
+++ b/THANKS.rst
@@ -1,35 +1,27 @@
-I'd like to thank the PyTables community that have collaborated in the
-exhaustive testing of Blosc.  With an aggregate amount of more than
-300 TB of different datasets compressed *and* decompressed
-successfully, I can say that Blosc is pretty safe now and ready for
-production purposes.
+I'd like to thank the PyTables community that have collaborated in the exhaustive testing of Blosc.  With an aggregate amount of more than
+300 TB of different datasets compressed *and* decompressed successfully, I can say that Blosc is pretty safe now and ready for production purposes.
 
 Other important contributions:
 
-* Valentin Haenel did a terrific work implementing the support for the
-  Snappy compression, fixing typos and improving docs and the plotting
-  script.
+* Valentin Haenel did a terrific work implementing the support for the Snappy compression, fixing typos and improving docs and the plotting script.
 
-* Thibault North, with ideas from Oscar Villellas, contributed a way
-  to call Blosc from different threads in a safe way.  Christopher
-  Speller introduced contexts so that a global lock is not necessary
-  anymore.
+* Thibault North, with ideas from Oscar Villellas, contributed a way to call Blosc from different threads in a safe way.  Christopher
+  Speller introduced contexts so that a global lock is not necessary anymore.
 
-* The CMake support was initially contributed by Thibault North, and
-  Antonio Valentino and Mark Wiebe made great enhancements to it.
+* The CMake support was initially contributed by Thibault North, and Antonio Valentino and Mark Wiebe made great enhancements to it.
 
-* Christopher Speller also introduced the two new '_ctx' calls to
-  avoid the use of the blosc_init() and blosc_destroy().
+* Christopher Speller also introduced the two new '_ctx' calls to avoid the use of the blosc_init() and blosc_destroy().
 
-* Jack Pappas contributed important portability enhancements,
-  specially runtime and cross-platform detection of SSE2/AVX2 as well
-  as high precision timers (HPET) for the benchmark program.
+* Jack Pappas contributed important portability enhancements, specially runtime and cross-platform detection of SSE2/AVX2 as well as high precision timers (HPET) for the benchmark program.
 
 * @littlezhou implemented the AVX2 version of shuffle routines.
 
-* Julian Taylor contributed a way to detect AVX2 in runtime and
-  calling the appropriate routines only if the undelying hardware
-  supports it.
+* Julian Taylor contributed a way to detect AVX2 in runtime and calling the appropriate routines only if the undelying hardware supports it.
 
-* Kiyo Masui for relicensing his bitshuffle project for allowing the
-  inclusion of part of his code in Blosc.
+* Lucian Marc provided the support for ARM/NEON for the shuffle filter.
+
+* Jerome Kieffer contributed support for PowerPC/ALTIVEC for the shuffle/bitshuffle filter.
+
+* Alberto Sabater, for his great efforts on producing really nice Blosc2 docs, among other aspects.
+
+* Kiyo Masui for relicensing his bitshuffle project for allowing the inclusion of part of his code in Blosc.

--- a/blosc/blosc2.h
+++ b/blosc/blosc2.h
@@ -768,7 +768,6 @@ BLOSC_EXPORT int blosc2_getitem_ctx(blosc2_context* context, const void* src,
 #define BLOSC2_MAX_METALAYERS 16
 #define BLOSC2_METALAYER_NAME_MAXLEN 31
 
-// TODO: make this opaque
 typedef struct {
   char* fname;     //!< The name of the file; if NULL, this is in-memory
   uint8_t* sdata;  //!< The in-memory serialized data
@@ -782,8 +781,8 @@ typedef struct {
  * the contents included in the schunk.
  */
 typedef struct blosc2_metalayer {
-  char* name;  //!< The metalayer identifier for Blosc client (e.g. caterva).
-  uint8_t* content;  //!< The serialized (msgpack preferably) content of the metalayer.
+  char* name;          //!< The metalayer identifier for Blosc client (e.g. Caterva).
+  uint8_t* content;    //!< The serialized (msgpack preferably) content of the metalayer.
   int32_t content_len; //!< The length in bytes of the content.
 } blosc2_metalayer;
 
@@ -1072,9 +1071,6 @@ BLOSC_EXPORT int blosc2_has_metalayer(blosc2_schunk *schunk, char *name);
  * @param content The content of the metalayer.
  * @param content_len The length of the content.
  *
- * @note The contents are not serialized into a possible attached frame.
- * You need to call #blosc2_metalayer_flush so as to do this.
- *
  * @return If successful, the index of the new metalayer. Else, return a negative value.
  */
 BLOSC_EXPORT int blosc2_add_metalayer(blosc2_schunk *schunk, char *name, uint8_t *content,
@@ -1111,15 +1107,6 @@ BLOSC_EXPORT int blosc2_update_metalayer(blosc2_schunk *schunk, char *name, uint
  */
 BLOSC_EXPORT int blosc2_get_metalayer(blosc2_schunk *schunk, char *name, uint8_t **content,
                                       uint32_t *content_len);
-
-/**
- * @brief Flush metalayers content into a possible attached frame.
- *
- * @param schunk The super-chunk to which the flush should be applied.
- *
- * @return If successful, a 1 is returned. Else, return a negative value.
- */
-BLOSC_EXPORT int blosc2_metalayer_flush(blosc2_schunk* schunk);
 
 
 /*********************************************************************

--- a/blosc/blosc2.h
+++ b/blosc/blosc2.h
@@ -1050,6 +1050,10 @@ BLOSC_EXPORT blosc2_frame* blosc2_frame_from_file(const char *fname);
  */
 BLOSC_EXPORT blosc2_schunk* blosc2_schunk_from_frame(blosc2_frame* frame, bool copy);
 
+/*********************************************************************
+  Functions related with metalayers.
+*********************************************************************/
+
 /**
  * @brief Find whether the schunk has a metalayer or not.
  *
@@ -1058,7 +1062,7 @@ BLOSC_EXPORT blosc2_schunk* blosc2_schunk_from_frame(blosc2_frame* frame, bool c
  *
  * @return If successful, return the index of the metalayer. Else, return a negative value.
  */
-BLOSC_EXPORT int blosc2_schunk_has_metalayer(blosc2_schunk *schunk, char *name);
+BLOSC_EXPORT int blosc2_has_metalayer(blosc2_schunk *schunk, char *name);
 
 /**
  * @brief Add content into a new metalayer.
@@ -1073,8 +1077,8 @@ BLOSC_EXPORT int blosc2_schunk_has_metalayer(blosc2_schunk *schunk, char *name);
  *
  * @return If successful, the index of the new metalayer. Else, return a negative value.
  */
-BLOSC_EXPORT int blosc2_schunk_add_metalayer(blosc2_schunk *schunk, char *name, uint8_t *content,
-                                             uint32_t content_len);
+BLOSC_EXPORT int blosc2_add_metalayer(blosc2_schunk *schunk, char *name, uint8_t *content,
+                                      uint32_t content_len);
 
 /**
  * @brief Update the content of an existing metalayer.
@@ -1084,13 +1088,13 @@ BLOSC_EXPORT int blosc2_schunk_add_metalayer(blosc2_schunk *schunk, char *name, 
  * @param content The new content of the metalayer.
  * @param content_len The length of the content.
  *
- * @note Contrarily to #blosc2_schunk_add_metalayer the updates to metalayers
+ * @note Contrarily to #blosc2_add_metalayer the updates to metalayers
  * are automatically serialized into a possible attached frame.
  *
  * @return If successful, the index of the metalayer. Else, return a negative value.
  */
-BLOSC_EXPORT int blosc2_schunk_update_metalayer(blosc2_schunk *schunk, char *name, uint8_t *content,
-                                                uint32_t content_len);
+BLOSC_EXPORT int blosc2_update_metalayer(blosc2_schunk *schunk, char *name, uint8_t *content,
+                                         uint32_t content_len);
 
 /**
  * @brief Get the content out of a metalayer.
@@ -1105,9 +1109,8 @@ BLOSC_EXPORT int blosc2_schunk_update_metalayer(blosc2_schunk *schunk, char *nam
  *
  * @return If successful, the index of the new metalayer. Else, return a negative value.
  */
-BLOSC_EXPORT int blosc2_schunk_get_metalayer(blosc2_schunk *schunk, char *name, uint8_t **content,
-                                             uint32_t *content_len);
-
+BLOSC_EXPORT int blosc2_get_metalayer(blosc2_schunk *schunk, char *name, uint8_t **content,
+                                      uint32_t *content_len);
 
 /**
  * @brief Flush metalayers content into a possible attached frame.

--- a/blosc/blosc2.h
+++ b/blosc/blosc2.h
@@ -945,6 +945,66 @@ BLOSC_EXPORT int blosc2_schunk_get_dparams(blosc2_schunk *schunk, blosc2_dparams
 
 
 /*********************************************************************
+  Functions related with metalayers.
+*********************************************************************/
+
+/**
+ * @brief Find whether the schunk has a metalayer or not.
+ *
+ * @param schunk The super-chunk from which the metalayer will be checked.
+ * @param name The name of the metalayer to be checked.
+ *
+ * @return If successful, return the index of the metalayer. Else, return a negative value.
+ */
+BLOSC_EXPORT int blosc2_has_metalayer(blosc2_schunk *schunk, char *name);
+
+/**
+ * @brief Add content into a new metalayer.
+ *
+ * @param schunk The super-chunk to which the metalayer should be added.
+ * @param name The name of the metalayer.
+ * @param content The content of the metalayer.
+ * @param content_len The length of the content.
+ *
+ * @return If successful, the index of the new metalayer. Else, return a negative value.
+ */
+BLOSC_EXPORT int blosc2_add_metalayer(blosc2_schunk *schunk, char *name, uint8_t *content,
+                                      uint32_t content_len);
+
+/**
+ * @brief Update the content of an existing metalayer.
+ *
+ * @param schunk The frame containing the metalayer.
+ * @param name The name of the metalayer to be updated.
+ * @param content The new content of the metalayer.
+ * @param content_len The length of the content.
+ *
+ * @note Contrarily to #blosc2_add_metalayer the updates to metalayers
+ * are automatically serialized into a possible attached frame.
+ *
+ * @return If successful, the index of the metalayer. Else, return a negative value.
+ */
+BLOSC_EXPORT int blosc2_update_metalayer(blosc2_schunk *schunk, char *name, uint8_t *content,
+                                         uint32_t content_len);
+
+/**
+ * @brief Get the content out of a metalayer.
+ *
+ * @param schunk The frame containing the metalayer.
+ * @param name The name of the metalayer.
+ * @param content The pointer where the content will be put.
+ * @param content_len The length of the content.
+ *
+ * @warning The @p **content receives a malloc'ed copy of the content.
+ * The user is responsible of freeing it.
+ *
+ * @return If successful, the index of the new metalayer. Else, return a negative value.
+ */
+BLOSC_EXPORT int blosc2_get_metalayer(blosc2_schunk *schunk, char *name, uint8_t **content,
+                                      uint32_t *content_len);
+
+
+/*********************************************************************
   Usermeta functions.
 *********************************************************************/
 
@@ -1047,66 +1107,6 @@ BLOSC_EXPORT blosc2_frame* blosc2_frame_from_file(const char *fname);
  * @return The super-chunk corresponding to the frame.
  */
 BLOSC_EXPORT blosc2_schunk* blosc2_schunk_from_frame(blosc2_frame* frame, bool copy);
-
-
-/*********************************************************************
-  Functions related with metalayers.
-*********************************************************************/
-
-/**
- * @brief Find whether the schunk has a metalayer or not.
- *
- * @param schunk The super-chunk from which the metalayer will be checked.
- * @param name The name of the metalayer to be checked.
- *
- * @return If successful, return the index of the metalayer. Else, return a negative value.
- */
-BLOSC_EXPORT int blosc2_has_metalayer(blosc2_schunk *schunk, char *name);
-
-/**
- * @brief Add content into a new metalayer.
- *
- * @param schunk The super-chunk to which the metalayer should be added.
- * @param name The name of the metalayer.
- * @param content The content of the metalayer.
- * @param content_len The length of the content.
- *
- * @return If successful, the index of the new metalayer. Else, return a negative value.
- */
-BLOSC_EXPORT int blosc2_add_metalayer(blosc2_schunk *schunk, char *name, uint8_t *content,
-                                      uint32_t content_len);
-
-/**
- * @brief Update the content of an existing metalayer.
- *
- * @param schunk The frame containing the metalayer.
- * @param name The name of the metalayer to be updated.
- * @param content The new content of the metalayer.
- * @param content_len The length of the content.
- *
- * @note Contrarily to #blosc2_add_metalayer the updates to metalayers
- * are automatically serialized into a possible attached frame.
- *
- * @return If successful, the index of the metalayer. Else, return a negative value.
- */
-BLOSC_EXPORT int blosc2_update_metalayer(blosc2_schunk *schunk, char *name, uint8_t *content,
-                                         uint32_t content_len);
-
-/**
- * @brief Get the content out of a metalayer.
- *
- * @param schunk The frame containing the metalayer.
- * @param name The name of the metalayer.
- * @param content The pointer where the content will be put.
- * @param content_len The length of the content.
- *
- * @warning The @p **content receives a malloc'ed copy of the content.
- * The user is responsible of freeing it.
- *
- * @return If successful, the index of the new metalayer. Else, return a negative value.
- */
-BLOSC_EXPORT int blosc2_get_metalayer(blosc2_schunk *schunk, char *name, uint8_t **content,
-                                      uint32_t *content_len);
 
 
 /*********************************************************************

--- a/blosc/blosc2.h
+++ b/blosc/blosc2.h
@@ -573,9 +573,7 @@ BLOSC_EXPORT char* blosc_cbuffer_complib(const void* cbuffer);
 
 
 /*********************************************************************
-
   Structures and functions related with contexts.
-
 *********************************************************************/
 
 typedef struct blosc2_context_s blosc2_context;   /* opaque type */
@@ -760,9 +758,7 @@ BLOSC_EXPORT int blosc2_getitem_ctx(blosc2_context* context, const void* src,
 
 
 /*********************************************************************
-
   Super-chunk related structures and functions.
-
 *********************************************************************/
 
 #define BLOSC2_MAX_METALAYERS 16
@@ -947,6 +943,11 @@ BLOSC_EXPORT int blosc2_schunk_get_cparams(blosc2_schunk *schunk, blosc2_cparams
  */
 BLOSC_EXPORT int blosc2_schunk_get_dparams(blosc2_schunk *schunk, blosc2_dparams **dparams);
 
+
+/*********************************************************************
+  Usermeta functions.
+*********************************************************************/
+
 /**
  * @brief Update content into a usermeta chunk.
  *
@@ -963,8 +964,8 @@ BLOSC_EXPORT int blosc2_schunk_get_dparams(blosc2_schunk *schunk, blosc2_dparams
  * @return If successful, return the number of compressed bytes that takes the content.
  * Else, a negative value.
  */
-BLOSC_EXPORT int blosc2_schunk_update_usermeta(blosc2_schunk *schunk, uint8_t *content,
-                                               int32_t content_len, blosc2_cparams cparams);
+BLOSC_EXPORT int blosc2_update_usermeta(blosc2_schunk *schunk, uint8_t *content,
+                                        int32_t content_len, blosc2_cparams cparams);
 
 /* @brief Retrieve the usermeta chunk in a decompressed form.
  *
@@ -976,13 +977,11 @@ BLOSC_EXPORT int blosc2_schunk_update_usermeta(blosc2_schunk *schunk, uint8_t *c
  * @return If successful, return the size of the (decompressed) chunk.
  * Else, a negative value.
  */
-BLOSC_EXPORT int blosc2_schunk_get_usermeta(blosc2_schunk* schunk, uint8_t** content);
+BLOSC_EXPORT int blosc2_get_usermeta(blosc2_schunk* schunk, uint8_t** content);
 
 
 /*********************************************************************
-
   Frame related structures and functions.
-
 *********************************************************************/
 
 /**
@@ -1048,6 +1047,7 @@ BLOSC_EXPORT blosc2_frame* blosc2_frame_from_file(const char *fname);
  * @return The super-chunk corresponding to the frame.
  */
 BLOSC_EXPORT blosc2_schunk* blosc2_schunk_from_frame(blosc2_frame* frame, bool copy);
+
 
 /*********************************************************************
   Functions related with metalayers.
@@ -1156,9 +1156,7 @@ BLOSC_EXPORT double blosc_elapsed_secs(blosc_timestamp_t start_time,
 
 
 /*********************************************************************
-
   Low-level functions follows.  Use them only if you are an expert!
-
 *********************************************************************/
 
 /**

--- a/blosc/frame.c
+++ b/blosc/frame.c
@@ -194,7 +194,8 @@ void* new_header2_frame(blosc2_schunk *schunk, blosc2_frame *frame, bool update)
       // Build a new metalayer for filters just if we are not updating the frame; otherwise it is already there
       void *metafilters = NULL;
       int metafilters_len = filters_to_metalayer(schunk->filters, schunk->filters_meta, &metafilters);
-      int res = blosc2_schunk_add_metalayer(schunk, FRAME_FILTER_PIPELINE_NAME, metafilters, metafilters_len);
+      int res = blosc2_add_metalayer(schunk, FRAME_FILTER_PIPELINE_NAME, metafilters,
+                                     metafilters_len);
       if (res < 0) {
         fprintf(stderr, "Error: problems adding the filter pipeline as a metalayer\n");
         return NULL;
@@ -756,11 +757,11 @@ int filters_from_metalayer(blosc2_schunk* schunk, char* mlname,
                            uint8_t* filters, uint8_t* filters_meta) {
   uint8_t* metalayer;
   uint32_t metalayer_len;
-  int nmetalayer = blosc2_schunk_has_metalayer(schunk, mlname);
+  int nmetalayer = blosc2_has_metalayer(schunk, mlname);
   if (nmetalayer < 0) {
     return 0;
   }
-  int rc = blosc2_schunk_get_metalayer(schunk, mlname, &metalayer, &metalayer_len);
+  int rc = blosc2_get_metalayer(schunk, mlname, &metalayer, &metalayer_len);
   if (rc < 0) {
     return rc;
   }

--- a/blosc/frame.c
+++ b/blosc/frame.c
@@ -776,7 +776,7 @@ int filters_from_metalayer(blosc2_schunk* schunk, char* mlname,
 }
 
 
-int frame_update_metalayers(blosc2_frame* frame, blosc2_schunk* schunk, bool new) {
+int frame_update_header(blosc2_frame* frame, blosc2_schunk* schunk, bool new) {
   uint8_t* header = frame->sdata;
 
   assert(frame->len > 0);
@@ -1196,9 +1196,9 @@ void* frame_append_chunk(blosc2_frame* frame, void* chunk, blosc2_schunk* schunk
   int64_t cbytes;
   int32_t chunksize;
   int32_t nchunks;
-  int ret = get_header_info(frame, &header_len, &frame_len, &nbytes, &cbytes, &chunksize, &nchunks,
+  int rc = get_header_info(frame, &header_len, &frame_len, &nbytes, &cbytes, &chunksize, &nchunks,
                             NULL, NULL, NULL, NULL);
-  if (ret < 0) {
+  if (rc < 0) {
     fprintf(stderr, "unable to get meta info from frame");
     return NULL;
   }
@@ -1300,14 +1300,12 @@ void* frame_append_chunk(blosc2_frame* frame, void* chunk, blosc2_schunk* schunk
   free(off_chunk);
 
   frame->len = new_frame_len;
-  // TODO: replace by a new update_frame_len()
-  ret = frame_update_metalayers(frame, schunk, false);
-  if (ret < 0) {
-    fprintf(stderr, "Error: unable to update meta info from frame");
+  rc = frame_update_header(frame, schunk, false);
+  if (rc < 0) {
     return NULL;
   }
 
-  int rc = frame_update_trailer(frame, schunk);
+  rc = frame_update_trailer(frame, schunk);
   if (rc < 0) {
     return NULL;
   }

--- a/blosc/frame.c
+++ b/blosc/frame.c
@@ -135,14 +135,6 @@ int blosc2_free_frame(blosc2_frame *frame) {
   if (frame->sdata != NULL) {
     free(frame->sdata);
   }
-  if (frame->nmetalayers > 0) {
-    for (int i = 0; i < frame->nmetalayers; i++) {
-      free(frame->metalayers[i]->name);
-      free(frame->metalayers[i]->content);
-      free(frame->metalayers[i]);
-    }
-    frame->nmetalayers = 0;
-  }
 
   if (frame->fname != NULL) {
     free(frame->fname);
@@ -195,13 +187,14 @@ void* new_header2_frame(blosc2_schunk *schunk, blosc2_frame *frame, bool update)
 
   // Filter flags
   int nfilters = get_nfilters(schunk->filters);
-  bool need_metafilters = nfilters > 1;
-  if (need_metafilters) {
+  // Remove the false below when a proper pipeline could be serialized properly inside the header
+  // Rational: creating a new metalayer in the middle of the header creation is not a good idea.
+  if (false && (nfilters > 1)) {
     if (!update) {
       // Build a new metalayer for filters just if we are not updating the frame; otherwise it is already there
       void *metafilters = NULL;
       int metafilters_len = filters_to_metalayer(schunk->filters, schunk->filters_meta, &metafilters);
-      int res = blosc2_frame_add_metalayer(frame, "_filter_pipeline", metafilters, metafilters_len);
+      int res = blosc2_schunk_add_metalayer(schunk, FRAME_FILTER_PIPELINE_NAME, metafilters, metafilters_len);
       if (res < 0) {
         fprintf(stderr, "Error: problems adding the filter pipeline as a metalayer\n");
         return NULL;
@@ -276,7 +269,7 @@ void* new_header2_frame(blosc2_schunk *schunk, blosc2_frame *frame, bool update)
   assert(h2p - h2 < FRAME_HEADER2_MINLEN);
 
   // Now, deal with metalayers
-  int16_t nmetalayers = frame->nmetalayers;
+  int16_t nmetalayers = schunk->nmetalayers;
   // The msgpack header will start as a fix array of 11 or 12 elements (if it has metalayers)
   *h2 = 0x90;
   *h2 += (nmetalayers > 0) ? FRAME_HEADER_NFIELDS_METALAYER : FRAME_HEADER_NFIELDS_NOMETALAYER;
@@ -311,7 +304,7 @@ void* new_header2_frame(blosc2_schunk *schunk, blosc2_frame *frame, bool update)
   int32_t *offtooff = malloc(nmetalayers * sizeof(int32_t));
   for (int nmetalayer = 0; nmetalayer < nmetalayers; nmetalayer++) {
     assert(frame != NULL);
-    blosc2_frame_metalayer *metalayer = frame->metalayers[nmetalayer];
+    blosc2_metalayer *metalayer = schunk->metalayers[nmetalayer];
     uint8_t namelen = (uint8_t) strlen(metalayer->name);
     h2 = realloc(h2, (size_t)current_header_len + 1 + namelen + 1 + 4);
     h2p = h2 + current_header_len;
@@ -349,7 +342,7 @@ void* new_header2_frame(blosc2_schunk *schunk, blosc2_frame *frame, bool update)
   current_header_len = (int32_t)(h2p - h2);
   for (int nmetalayer = 0; nmetalayer < nmetalayers; nmetalayer++) {
     assert(frame != NULL);
-    blosc2_frame_metalayer *metalayer = frame->metalayers[nmetalayer];
+    blosc2_metalayer *metalayer = schunk->metalayers[nmetalayer];
     h2 = realloc(h2, (size_t)current_header_len + 1 + 4 + metalayer->content_len);
     h2p = h2 + current_header_len;
     // Store the serialized contents for this metalayer
@@ -372,6 +365,211 @@ void* new_header2_frame(blosc2_schunk *schunk, blosc2_frame *frame, bool update)
   swap_store(h2 + FRAME_HEADER2_LEN, &hsize, sizeof(hsize));
 
   return h2;
+}
+
+
+int get_header_info(blosc2_frame *frame, int32_t *header_len, int64_t *frame_len, int64_t *nbytes,
+                    int64_t *cbytes, int32_t *chunksize, int32_t *nchunks, int32_t *typesize,
+                    uint8_t *compcode, uint8_t *clevel, uint8_t *filters) {
+  uint8_t* framep = frame->sdata;
+  uint8_t* header = NULL;
+
+  assert(frame->len > 0);
+
+  if (frame->sdata == NULL) {
+    header = malloc(FRAME_HEADER2_MINLEN);
+    FILE* fp = fopen(frame->fname, "rb");
+    size_t rbytes = fread(header, 1, FRAME_HEADER2_MINLEN, fp);
+    assert(rbytes == FRAME_HEADER2_MINLEN);
+    framep = header;
+    fclose(fp);
+  }
+
+  // Fetch some internal lengths
+  swap_store(header_len, framep + FRAME_HEADER2_LEN, sizeof(*header_len));
+  swap_store(frame_len, framep + FRAME_LEN, sizeof(*frame_len));
+  swap_store(nbytes, framep + FRAME_NBYTES, sizeof(*nbytes));
+  swap_store(cbytes, framep + FRAME_CBYTES, sizeof(*cbytes));
+  swap_store(chunksize, framep + FRAME_CHUNKSIZE, sizeof(*chunksize));
+  if (typesize != NULL) {
+    swap_store(typesize, framep + FRAME_TYPESIZE, sizeof(*typesize));
+  }
+
+  // Codecs and filters
+  uint8_t frame_codecs = framep[FRAME_CODECS];
+  if (clevel != NULL) {
+    *clevel = frame_codecs >> 4u;
+  }
+  if (compcode != NULL) {
+    *compcode = frame_codecs & 0xFu;
+  }
+
+  uint8_t filter_flags = framep[FRAME_FILTERS];
+  if (filters != NULL) {
+    if (filter_flags & FRAME_FILTERS_PIPE_DESCRIBED_HERE) {
+      filter_flags = (filter_flags & FRAME_FILTER_PIPE_DESCRIPTION) >> FRAME_FILTERS_PIPE_START_BIT;
+      flags_to_filters(filter_flags, filters);
+    }
+  }
+
+  if (*nbytes > 0) {
+    // We can compute the chunks only when the frame has actual data
+    *nchunks = (int32_t) (*nbytes / *chunksize);
+    if (*nchunks * *chunksize < *nbytes) {
+      *nchunks += 1;
+    }
+  } else {
+    *nchunks = 0;
+  }
+
+  if (frame->sdata == NULL) {
+    free(header);
+  }
+
+  return 0;
+}
+
+// Get the offset to the usermeta chunk
+int64_t get_trailer_offset(blosc2_frame *frame, int32_t header_len, int64_t cbytes) {
+  uint8_t* coffsets;
+
+  if (cbytes == 0) {
+    // No data chunks yet
+    return header_len;
+  }
+
+  if (frame->sdata != NULL) {
+    coffsets = frame->sdata + header_len + cbytes;
+  } else {
+    size_t bytes_to_read = BLOSC_MIN_HEADER_LENGTH;
+    coffsets = malloc(bytes_to_read);
+    FILE* fp = fopen(frame->fname, "rb");
+    fseek(fp, header_len + cbytes, SEEK_SET);
+    size_t rbytes = fread(coffsets, 1, bytes_to_read, fp);
+    if (rbytes != bytes_to_read) {
+      fprintf(stderr, "Error: cannot access the offsets out of the fileframe\n");
+      fclose(fp);
+      return -1;
+    }
+    fclose(fp);
+  }
+
+  int32_t off_cbytes = sw32_(coffsets + 12);
+
+  if (frame->sdata == NULL) {
+    free(coffsets);
+  }
+
+  // Now we know all the necessary offsets to reach the trailer section
+  return header_len + cbytes + off_cbytes;
+}
+
+
+// Update the length in the header
+int update_frame_len(blosc2_frame* frame, int64_t len) {
+  int rc = 1;
+  if (frame->sdata != NULL) {
+    swap_store(frame->sdata + FRAME_LEN, &len, sizeof(int64_t));
+  }
+  else {
+    FILE* fp = fopen(frame->fname, "rb+");
+    fseek(fp, FRAME_LEN, SEEK_SET);
+    int64_t swap_len;
+    swap_store(&swap_len, &len, sizeof(int64_t));
+    size_t wbytes = fwrite(&swap_len, 1, sizeof(int64_t), fp);
+    if (wbytes != sizeof(int64_t)) {
+      fprintf(stderr, "Error: cannot write the frame length in header");
+      return -1;
+    }
+    fclose(fp);
+  }
+  return rc;
+}
+
+
+int frame_update_trailer(blosc2_frame* frame, blosc2_schunk* schunk) {
+  if (frame->len == 0) {
+    fprintf(stderr, "Error: the trailer cannot be updated on empty frames");
+  }
+
+  // Create the trailer in msgpack (see the frame format document)
+  uint32_t trailer_len = FRAME_TRAILER_MIN_LENGTH + schunk->usermeta_len;
+  uint8_t* trailer = calloc((size_t)trailer_len, 1);
+  uint8_t* ptrailer = trailer;
+  *ptrailer = 0x09 + 4;  // fixarray with 4 elements
+  ptrailer += 1;
+  // Trailer format version
+  *ptrailer = FRAME_TRAILER_VERSION;
+  ptrailer += 1;
+  // usermeta
+  *ptrailer = 0xc6;     // bin32
+  ptrailer += 1;
+  swap_store(ptrailer, &(schunk->usermeta_len), 4);
+  ptrailer += 4;
+  memcpy(ptrailer, schunk->usermeta, schunk->usermeta_len);
+  ptrailer += schunk->usermeta_len;
+  // Trailer length
+  *ptrailer = 0xce;  // uint32
+  ptrailer += 1;
+  swap_store(ptrailer, &(trailer_len), sizeof(uint32_t));
+  ptrailer += sizeof(uint32_t);
+  // Up to 16 bytes for frame fingerprint (using XXH3 included in https://github.com/Cyan4973/xxHash)
+  // Maybe someone would need 256-bit in the future, but for the time being 128-bit seems like a good tradeoff
+  *ptrailer = 0xd8;  // fixext 16
+  ptrailer += 1;
+  *ptrailer = 0;  // fingerprint type: 0 -> no fp; 1 -> 32-bit; 2 -> 64-bit; 3 -> 128-bit
+  ptrailer += 1;
+  // Uncomment this when we compute an actual fingerprint
+  // memcpy(ptrailer, xxh3_fingerprint, sizeof(xxh3_fingerprint));
+  ptrailer += 16;
+  // Sanity check
+  assert(ptrailer - trailer == trailer_len);
+
+  int32_t header_len;
+  int64_t frame_len;
+  int64_t nbytes;
+  int64_t cbytes;
+  int32_t chunksize;
+  int32_t nchunks;
+  int ret = get_header_info(frame, &header_len, &frame_len, &nbytes, &cbytes, &chunksize, &nchunks,
+                            NULL, NULL, NULL, NULL);
+  if (ret < 0) {
+    fprintf(stderr, "unable to get meta info from frame");
+    return -1;
+  }
+
+  int64_t trailer_offset = get_trailer_offset(frame, header_len, cbytes);
+
+  // Update the trailer.  As there are no internal offsets to the trailer section,
+  // and it is always at the end of the frame, we can just write (or overwrite) it
+  // at the end of the frame.
+  if (frame->sdata != NULL) {
+    frame->sdata = realloc(frame->sdata, (size_t)(trailer_offset + trailer_len));
+    if (frame->sdata == NULL) {
+      fprintf(stderr, "Error: cannot realloc space for the frame.");
+      return -1;
+    }
+    memcpy(frame->sdata + trailer_offset, trailer, trailer_len);
+  }
+  else {
+    FILE* fp = fopen(frame->fname, "rb+");
+    fseek(fp, trailer_offset, SEEK_SET);
+    size_t wbytes = fwrite(trailer, 1, trailer_len, fp);
+    if (wbytes != (size_t)trailer_len) {
+      fprintf(stderr, "Error: cannot write the trailer length in trailer");
+      return -2;
+    }
+    fclose(fp);
+  }
+  free(trailer);
+
+  int rc = update_frame_len(frame, trailer_offset + trailer_len);
+  if (rc < 0) {
+    return rc;
+  }
+  frame->len = trailer_offset + trailer_len;
+
+  return 1;
 }
 
 
@@ -508,122 +706,10 @@ blosc2_frame* blosc2_frame_from_file(const char *fname) {
   int64_t frame_len;
   swap_store(&frame_len, header + FRAME_LEN, sizeof(frame_len));
   frame->len = frame_len;
-
-  bool has_metalayers = ((header[0] & 0xFu) == FRAME_HEADER_NFIELDS_METALAYER) ? true : false;
+  fclose(fp);
   free(header);
 
-  if (!has_metalayers) {
-    goto out;
-  }
-
-  // Get the size for the index of metalayers
-  uint16_t idx_size;
-  fseek(fp, FRAME_IDX_SIZE, SEEK_SET);
-  rbytes = fread(&idx_size, 1, sizeof(uint16_t), fp);
-  assert(rbytes == sizeof(uint16_t));
-
-  swap_store(&idx_size, &idx_size, sizeof(idx_size));
-
-  // Read the index of metalayers for metalayers
-  uint8_t* metalayers_idx = malloc(idx_size);
-  fseek(fp, FRAME_IDX_SIZE + 2, SEEK_SET);
-  rbytes = fread(metalayers_idx, 1, idx_size, fp);
-  assert(rbytes == idx_size);
-  assert(metalayers_idx[0] == 0xde);   // sanity check
-  uint8_t* idxp = metalayers_idx + 1;
-  uint16_t nmetalayers;
-  swap_store(&nmetalayers, idxp, sizeof(uint16_t));
-  idxp += 2;
-  frame->nmetalayers = nmetalayers;
-
-  // Populate the metalayers and its serialized values
-  for (int nmetalayer = 0; nmetalayer < nmetalayers; nmetalayer++) {
-    assert((*idxp & 0xe0u) == 0xa0u);   // sanity check
-    blosc2_frame_metalayer* metalayer = calloc(sizeof(blosc2_frame_metalayer), 1);
-    frame->metalayers[nmetalayer] = metalayer;
-
-    // Populate the metalayer string
-    int8_t nslen = *idxp & (uint8_t)0x1fu;
-    idxp += 1;
-    char* ns = malloc((size_t)nslen + 1);
-    memcpy(ns, idxp, nslen);
-    ns[nslen] = '\0';
-    idxp += nslen;
-    metalayer->name = ns;
-
-    // Populate the serialized value for this metalayer
-    // Get the offset
-    assert((*idxp & 0xffu) == 0xd2u);   // sanity check
-    idxp += 1;
-    int32_t offset;
-    swap_store(&offset, idxp, sizeof(offset));
-    idxp += 4;
-
-    // Go to offset and see if we have the correct marker
-    uint8_t content_marker;
-    fseek(fp, offset, SEEK_SET);
-    rbytes = fread(&content_marker, 1, 1, fp);
-    assert(rbytes == 1);
-    assert(content_marker == 0xc6);
-
-    // Read the size of the content
-    int32_t content_len;
-    fseek(fp, offset + 1, SEEK_SET);
-    rbytes = fread(&content_len, 1, 4, fp);
-    assert(rbytes == 4);
-    swap_store(&content_len, &content_len, sizeof(content_len));
-    metalayer->content_len = content_len;
-
-    // Finally, read the content
-    char* content = malloc((size_t)content_len);
-    fseek(fp, offset + 1 + 4, SEEK_SET);
-    rbytes = fread(content, 1, (size_t)content_len, fp);
-    assert(rbytes == (size_t)content_len);
-    metalayer->content = (uint8_t*)content;
-  }
-
-  free(metalayers_idx);
-
-out:
-  fclose(fp);
-
   return frame;
-}
-
-
-// Get the offset to the usermeta chunk
-int64_t get_trailer_offset(blosc2_frame *frame, int32_t header_len, int64_t cbytes) {
-  uint8_t* coffsets;
-
-  if (cbytes == 0) {
-    // No data chunks yet
-    return header_len;
-  }
-
-  if (frame->sdata != NULL) {
-    coffsets = frame->sdata + header_len + cbytes;
-  } else {
-    size_t bytes_to_read = BLOSC_MIN_HEADER_LENGTH;
-    coffsets = malloc(bytes_to_read);
-    FILE* fp = fopen(frame->fname, "rb");
-    fseek(fp, header_len + cbytes, SEEK_SET);
-    size_t rbytes = fread(coffsets, 1, bytes_to_read, fp);
-    if (rbytes != bytes_to_read) {
-      fprintf(stderr, "Cannot access the offsets out of the fileframe.\n");
-      fclose(fp);
-      return -1;
-    }
-    fclose(fp);
-  }
-
-  int32_t off_cbytes = sw32_(coffsets + 12);
-
-  if (frame->sdata == NULL) {
-    free(coffsets);
-  }
-
-  // Now we know all the necessary offsets to reach the trailer section
-  return header_len + cbytes + off_cbytes;
 }
 
 
@@ -666,11 +752,15 @@ int get_offsets(blosc2_frame *frame, int32_t header_len, int64_t cbytes, int32_t
 
 
 // Get the filter pipeline from the associated metalayer
-int filters_from_metalayer(blosc2_frame* frame, char* mlname,
+int filters_from_metalayer(blosc2_schunk* schunk, char* mlname,
                            uint8_t* filters, uint8_t* filters_meta) {
   uint8_t* metalayer;
   uint32_t metalayer_len;
-  int rc = blosc2_frame_get_metalayer(frame, mlname, &metalayer, &metalayer_len);
+  int nmetalayer = blosc2_schunk_has_metalayer(schunk, mlname);
+  if (nmetalayer < 0) {
+    return 0;
+  }
+  int rc = blosc2_schunk_get_metalayer(schunk, mlname, &metalayer, &metalayer_len);
   if (rc < 0) {
     return rc;
   }
@@ -685,78 +775,15 @@ int filters_from_metalayer(blosc2_frame* frame, char* mlname,
 }
 
 
-int frame_get_meta(blosc2_frame* frame, int32_t* header_len, int64_t* frame_len,
-                   int64_t* nbytes, int64_t* cbytes, int32_t* chunksize, int32_t* nchunks,
-                   int32_t* typesize, uint8_t* compcode, uint8_t* clevel,
-                   uint8_t* filters, uint8_t* filters_meta) {
-  uint8_t* framep = frame->sdata;
-  uint8_t* header = NULL;
-
-  assert(frame->len > 0);
-
-  if (frame->sdata == NULL) {
-    header = malloc(FRAME_HEADER2_MINLEN);
-    FILE* fp = fopen(frame->fname, "rb");
-    size_t rbytes = fread(header, 1, FRAME_HEADER2_MINLEN, fp);
-    assert(rbytes == FRAME_HEADER2_MINLEN);
-    framep = header;
-    fclose(fp);
-  }
-
-  // Fetch some internal lengths
-  swap_store(header_len, framep + FRAME_HEADER2_LEN, sizeof(*header_len));
-  swap_store(frame_len, framep + FRAME_LEN, sizeof(*frame_len));
-  swap_store(nbytes, framep + FRAME_NBYTES, sizeof(*nbytes));
-  swap_store(cbytes, framep + FRAME_CBYTES, sizeof(*cbytes));
-  swap_store(chunksize, framep + FRAME_CHUNKSIZE, sizeof(*chunksize));
-  if (typesize != NULL) {
-    swap_store(typesize, framep + FRAME_TYPESIZE, sizeof(*typesize));
-  }
-
-  // Codecs and filters
-  uint8_t frame_codecs = framep[FRAME_CODECS];
-  if (clevel != NULL) {
-    *clevel = frame_codecs >> 4u;
-  }
-  if (compcode != NULL) {
-    *compcode = frame_codecs & 0xFu;
-  }
-
-  uint8_t filter_flags = framep[FRAME_FILTERS];
-  if (filters != NULL) {
-    if (filter_flags & FRAME_FILTERS_PIPE_DESCRIBED_HERE) {
-      filter_flags = (filter_flags & FRAME_FILTER_PIPE_DESCRIPTION) >> FRAME_FILTERS_PIPE_START_BIT;
-      flags_to_filters(filter_flags, filters);
-    } else {
-      int rc = filters_from_metalayer(frame, "_filter_pipeline", filters, filters_meta);
-      if (rc < 0) {
-        return rc;
-      }
-    }
-  }
-
-  if (*nbytes > 0) {
-    // We can compute the chunks only when the frame has actual data
-    *nchunks = (int32_t) (*nbytes / *chunksize);
-    if (*nchunks * *chunksize < *nbytes) {
-      *nchunks += 1;
-    }
-  } else {
-    *nchunks = 0;
-  }
-
-  if (frame->sdata == NULL) {
-    free(header);
-  }
-
-  return 0;
-}
-
-// TODO: we should not need the schunk for updating metalayers
-int frame_update_metalayers(blosc2_frame* frame, blosc2_schunk* schunk) {
+int frame_update_metalayers(blosc2_frame* frame, blosc2_schunk* schunk, bool new) {
   uint8_t* header = frame->sdata;
 
   assert(frame->len > 0);
+
+  if (new && schunk->cbytes > 0) {
+    fprintf(stderr, "Error: new metalayers cannot be added after actual data has been appended\n");
+    return -1;
+  }
 
   if (frame->sdata == NULL) {
     header = malloc(FRAME_HEADER2_MINLEN);
@@ -773,9 +800,16 @@ int frame_update_metalayers(blosc2_frame* frame, blosc2_schunk* schunk) {
   uint32_t h2len;
   swap_store(&h2len, h2 + FRAME_HEADER2_LEN, sizeof(h2len));
 
-  if (prev_h2len != h2len) {
-    fprintf(stderr, "Error: the new header size should be equal the existing one");
-    return -1;
+  // The frame length is outdated when adding a new metalayer, so update it
+  if (new) {
+    int64_t frame_len = h2len;  // at adding time, we only have to worry of the header for now
+    swap_store(h2 + FRAME_LEN, &frame_len, sizeof(frame_len));
+    frame->len = frame_len;
+  }
+
+  if (!new && prev_h2len != h2len) {
+    fprintf(stderr, "Error: the new metalayer sizes should be equal the existing ones");
+    return -2;
   }
 
   if (frame->sdata == NULL) {
@@ -786,85 +820,13 @@ int frame_update_metalayers(blosc2_frame* frame, blosc2_schunk* schunk) {
     free(header);
   }
   else {
+    if (new) {
+      frame->sdata = realloc(frame->sdata, h2len);
+    }
     memcpy(frame->sdata, h2, h2len);
   }
   free(h2);
 
-  return 1;
-}
-
-
-int frame_update_trailer(blosc2_frame* frame, blosc2_schunk* schunk) {
-  if (frame->len == 0) {
-    fprintf(stderr, "Error: the trailer cannot be updated on empty frames");
-  }
-
-  // Create the trailer in msgpack (see the frame format document)
-  uint32_t trailer_len = FRAME_TRAILER_MIN_LENGTH + schunk->usermeta_len;
-  uint8_t* trailer = calloc((size_t)trailer_len, 1);
-  uint8_t* ptrailer = trailer;
-  *ptrailer = 0x09 + 4;  // fixarray with 4 elements
-  ptrailer += 1;
-  // Trailer format version
-  *ptrailer = FRAME_TRAILER_VERSION;
-  ptrailer += 1;
-  // usermeta
-  *ptrailer = 0xc6;     // bin32
-  ptrailer += 1;
-  swap_store(ptrailer, &(schunk->usermeta_len), 4);
-  ptrailer += 4;
-  memcpy(ptrailer, schunk->usermeta, schunk->usermeta_len);
-  ptrailer += schunk->usermeta_len;
-  // Trailer length
-  *ptrailer = 0xce;  // uint32
-  ptrailer += 1;
-  swap_store(ptrailer, &(trailer_len), sizeof(uint32_t));
-  ptrailer += sizeof(uint32_t);
-  // Up to 16 bytes for frame fingerprint (using XXH3 included in https://github.com/Cyan4973/xxHash)
-  // Maybe someone would need 256-bit in the future, but for the time being 128-bit seems like a good tradeoff
-  *ptrailer = 0xd8;  // fixext 16
-  ptrailer += 1;
-  *ptrailer = 0;  // fingerprint type: 0 -> no fp; 1 -> 32-bit; 2 -> 64-bit; 3 -> 128-bit
-  ptrailer += 1;
-  // Uncomment this when we compute an actual fingerprint
-  // memcpy(ptrailer, xxh3_fingerprint, sizeof(xxh3_fingerprint));
-  ptrailer += 16;
-  // Sanity check
-  assert(ptrailer - trailer == trailer_len);
-
-  int32_t header_len;
-  int64_t frame_len;
-  int64_t nbytes;
-  int64_t cbytes;
-  int32_t chunksize;
-  int32_t nchunks;
-  int ret = frame_get_meta(frame, &header_len, &frame_len, &nbytes, &cbytes, &chunksize, &nchunks,
-                           NULL, NULL, NULL, NULL, NULL);
-  if (ret < 0) {
-    fprintf(stderr, "unable to get meta info from frame");
-    return -1;
-  }
-
-  int64_t trailer_offset = get_trailer_offset(frame, header_len, cbytes);
-
-  // Update the trailer.  As there are no internal offsets to the trailer section,
-  // and it is always at the end of the frame, we can just write (or overwrite) it
-  // at the end of the frame.
-  if (frame->sdata != NULL) {
-    frame->sdata = realloc(frame->sdata, (size_t)(trailer_offset + trailer_len));
-    if (frame->sdata == NULL) {
-      fprintf(stderr, "Error: cannot realloc space for the frame.");
-      return -1;
-    }
-    memcpy(frame->sdata + trailer_offset, trailer, trailer_len);
-  }
-  else {
-    FILE* fp = fopen(frame->fname, "rb+");
-    fseek(fp, trailer_offset, SEEK_SET);
-    fwrite(trailer, trailer_len, 1, fp);
-    fclose(fp);
-  }
-  free(trailer);
   return 1;
 }
 
@@ -877,13 +839,17 @@ int32_t frame_get_usermeta(blosc2_frame* frame, uint8_t** usermeta) {
   int64_t cbytes;
   int32_t chunksize;
   int32_t nchunks;
-  int ret = frame_get_meta(frame, &header_len, &frame_len, &nbytes, &cbytes, &chunksize, &nchunks,
-                           NULL, NULL, NULL, NULL, NULL);
+  int ret = get_header_info(frame, &header_len, &frame_len, &nbytes, &cbytes, &chunksize, &nchunks,
+                            NULL, NULL, NULL, NULL);
   if (ret < 0) {
-    fprintf(stderr, "unable to get meta info from frame");
+    fprintf(stderr, "Unable to get the header info from frame");
     return -1;
   }
   int64_t trailer_offset = get_trailer_offset(frame, header_len, cbytes);
+  if (trailer_offset < 0) {
+    fprintf(stderr, "Unable to get the trailer offset from frame");
+    return -1;
+  }
 
   // Get the size of usermeta (inside the trailer)
   int32_t usermeta_len_network;
@@ -927,6 +893,101 @@ int32_t frame_get_usermeta(blosc2_frame* frame, uint8_t** usermeta) {
   return usermeta_len;
 }
 
+
+int frame_get_metalayers(blosc2_frame* frame, blosc2_schunk* schunk) {
+  int32_t header_len;
+  int64_t frame_len;
+  int64_t nbytes;
+  int64_t cbytes;
+  int32_t chunksize;
+  int32_t nchunks;
+  int ret = get_header_info(frame, &header_len, &frame_len, &nbytes, &cbytes, &chunksize, &nchunks,
+                            NULL, NULL, NULL, NULL);
+  if (ret < 0) {
+    fprintf(stderr, "Unable to get the header info from frame");
+    return -1;
+  }
+
+  // Get the header
+  uint8_t* header = NULL;
+  if (frame->sdata != NULL) {
+    header = frame->sdata;
+  } else {
+    header = malloc(header_len);
+    FILE* fp = fopen(frame->fname, "rb");
+    size_t rbytes = fread(header, 1, header_len, fp);
+    if (rbytes != header_len) {
+      fprintf(stderr, "Cannot access the header out of the fileframe.\n");
+      fclose(fp);
+      return -2;
+    }
+    fclose(fp);
+  }
+
+  bool has_metalayers = ((header[0] & 0xFu) == FRAME_HEADER_NFIELDS_METALAYER) ? true : false;
+  if (!has_metalayers) {
+    goto out;
+  }
+
+  // Get the size for the index of metalayers
+  uint16_t idx_size;
+  swap_store(&idx_size, header + FRAME_IDX_SIZE, sizeof(idx_size));
+
+  // Get the actual index of metalayers
+  uint8_t* metalayers_idx = header + FRAME_IDX_SIZE + 2;
+  assert(metalayers_idx[0] == 0xde);   // sanity check
+  uint8_t* idxp = metalayers_idx + 1;
+  uint16_t nmetalayers;
+  swap_store(&nmetalayers, idxp, sizeof(uint16_t));
+  idxp += 2;
+  schunk->nmetalayers = nmetalayers;
+
+  // Populate the metalayers and its serialized values
+  for (int nmetalayer = 0; nmetalayer < nmetalayers; nmetalayer++) {
+    assert((*idxp & 0xe0u) == 0xa0u);   // sanity check
+    blosc2_metalayer* metalayer = calloc(sizeof(blosc2_metalayer), 1);
+    schunk->metalayers[nmetalayer] = metalayer;
+
+    // Populate the metalayer string
+    int8_t nslen = *idxp & (uint8_t)0x1fu;
+    idxp += 1;
+    char* ns = malloc((size_t)nslen + 1);
+    memcpy(ns, idxp, nslen);
+    ns[nslen] = '\0';
+    idxp += nslen;
+    metalayer->name = ns;
+
+    // Populate the serialized value for this metalayer
+    // Get the offset
+    assert((*idxp & 0xffu) == 0xd2u);   // sanity check
+    idxp += 1;
+    int32_t offset;
+    swap_store(&offset, idxp, sizeof(offset));
+    idxp += 4;
+
+    // Go to offset and see if we have the correct marker
+    uint8_t* content_marker = header + offset;
+    assert(*content_marker == 0xc6);
+
+    // Read the size of the content
+    int32_t content_len;
+    swap_store(&content_len, content_marker + 1, sizeof(content_len));
+    metalayer->content_len = content_len;
+
+    // Finally, read the content
+    char* content = malloc((size_t)content_len);
+    memcpy(content, content_marker + 1 + 4, (size_t)content_len);
+    metalayer->content = (uint8_t*)content;
+  }
+
+  out:
+  if (frame->sdata == NULL) {
+    free(header);
+  }
+  return 1;
+}
+
+
 /* Get a super-chunk out of a frame */
 blosc2_schunk* blosc2_schunk_from_frame(blosc2_frame* frame, bool copy) {
   int32_t header_len;
@@ -934,9 +995,9 @@ blosc2_schunk* blosc2_schunk_from_frame(blosc2_frame* frame, bool copy) {
 
   blosc2_schunk* schunk = calloc(1, sizeof(blosc2_schunk));
   schunk->frame = frame;
-  int ret = frame_get_meta(frame, &header_len, &frame_len, &schunk->nbytes, &schunk->cbytes,
-                           &schunk->chunksize, &schunk->nchunks, &schunk->typesize,
-                           &schunk->compcode, &schunk->clevel, schunk->filters, schunk->filters_meta);
+  int ret = get_header_info(frame, &header_len, &frame_len, &schunk->nbytes, &schunk->cbytes,
+                            &schunk->chunksize, &schunk->nchunks, &schunk->typesize,
+                            &schunk->compcode, &schunk->clevel, schunk->filters);
   if (ret < 0) {
     fprintf(stderr, "unable to get meta info from frame");
     return NULL;
@@ -1028,8 +1089,20 @@ blosc2_schunk* blosc2_schunk_from_frame(blosc2_frame* frame, bool copy) {
 
   uint8_t* usermeta;
   int32_t usermeta_len;
+
   out:
-  // Get the usermeta chunk
+  rc = frame_get_metalayers(frame, schunk);
+  if (rc < 0) {
+    fprintf(stderr, "Error: cannot access the metalayers");
+    return NULL;
+  }
+  // Now that we have access to metalayers, go and try with a possible filter pipeline metalayer
+  rc = filters_from_metalayer(schunk, FRAME_FILTER_PIPELINE_NAME, schunk->filters, schunk->filters_meta);
+  if (rc < 0) {
+    fprintf(stderr, "Error: cannot access the metalayers");
+    return NULL;
+  }
+
   usermeta_len = frame_get_usermeta(frame, &usermeta);
   if (usermeta_len < 0) {
     fprintf(stderr, "Error: cannot access the usermeta chunk");
@@ -1062,8 +1135,8 @@ int frame_get_chunk(blosc2_frame *frame, int nchunk, uint8_t **chunk, bool *need
 
   *chunk = NULL;
   *needs_free = false;
-  int ret = frame_get_meta(frame, &header_len, &frame_len, &nbytes, &cbytes, &chunksize, &nchunks,
-                           NULL, NULL, NULL, NULL, NULL);
+  int ret = get_header_info(frame, &header_len, &frame_len, &nbytes, &cbytes, &chunksize, &nchunks,
+                            NULL, NULL, NULL, NULL);
   if (ret < 0) {
     fprintf(stderr, "unable to get meta info from frame");
     return -1;
@@ -1122,8 +1195,8 @@ void* frame_append_chunk(blosc2_frame* frame, void* chunk, blosc2_schunk* schunk
   int64_t cbytes;
   int32_t chunksize;
   int32_t nchunks;
-  int ret = frame_get_meta(frame, &header_len, &frame_len, &nbytes, &cbytes, &chunksize, &nchunks,
-                           NULL, NULL, NULL, NULL, NULL);
+  int ret = get_header_info(frame, &header_len, &frame_len, &nbytes, &cbytes, &chunksize, &nchunks,
+                            NULL, NULL, NULL, NULL);
   if (ret < 0) {
     fprintf(stderr, "unable to get meta info from frame");
     return NULL;
@@ -1210,13 +1283,13 @@ void* frame_append_chunk(blosc2_frame* frame, void* chunk, blosc2_schunk* schunk
     // fileframe
     fp = fopen(frame->fname, "rb+");
     fseek(fp, header_len + cbytes, SEEK_SET);
-    size_t wbytes = fwrite(chunk, (size_t)cbytes_chunk, 1, fp);  // the new chunk
-    if (wbytes != 1) {
+    size_t wbytes = fwrite(chunk, 1, (size_t)cbytes_chunk, fp);  // the new chunk
+    if (wbytes != (size_t)cbytes_chunk) {
       fprintf(stderr, "cannot write the full chunk to fileframe.");
       return NULL;
     }
-    wbytes = fwrite(off_chunk, (size_t)new_off_cbytes, 1, fp);  // the new offsets
-    if (wbytes != 1) {
+    wbytes = fwrite(off_chunk, 1, (size_t)new_off_cbytes, fp);  // the new offsets
+    if (wbytes != (size_t)new_off_cbytes) {
       fprintf(stderr, "cannot write the offsets to fileframe.");
       return NULL;
     }
@@ -1226,7 +1299,8 @@ void* frame_append_chunk(blosc2_frame* frame, void* chunk, blosc2_schunk* schunk
   free(off_chunk);
 
   frame->len = new_frame_len;
-  ret = frame_update_metalayers(frame, schunk);
+  // TODO: replace by a new update_frame_len()
+  ret = frame_update_metalayers(frame, schunk, false);
   if (ret < 0) {
     fprintf(stderr, "Error: unable to update meta info from frame");
     return NULL;
@@ -1266,95 +1340,4 @@ int frame_decompress_chunk(blosc2_frame *frame, int nchunk, void *dest, size_t n
     free(src);
   }
   return (int)chunksize;
-}
-
-
-/* Find whether the frame has a metalayer or not.
- *
- * If successful, return the index of the metalayer.  Else, return a negative value.
- */
-int blosc2_frame_has_metalayer(blosc2_frame *frame, char *name) {
-    if (strlen(name) > BLOSC2_METALAYER_NAME_MAXLEN) {
-        fprintf(stderr, "metalayers cannot be larger than %d chars\n", BLOSC2_METALAYER_NAME_MAXLEN);
-        return -1;
-    }
-
-    for (int nmetalayer = 0; nmetalayer < frame->nmetalayers; nmetalayer++) {
-        if (strcmp(name, frame->metalayers[nmetalayer]->name) == 0) {
-            return nmetalayer;  // Found
-        }
-    }
-    return -1;  // Not found
-}
-
-
-/* Add content into a new metalayer.
- *
- * If successful, return the index of the new metalayer.  Else, return a negative value.
- */
-int blosc2_frame_add_metalayer(blosc2_frame *frame, char *name, uint8_t *content,
-                               uint32_t content_len) {
-    int nmetalayer = blosc2_frame_has_metalayer(frame, name);
-    if (nmetalayer >= 0) {
-        fprintf(stderr, "metalayer \"%s\" already exists", name);
-        return -2;
-    }
-
-    // Add the metalayer
-    blosc2_frame_metalayer *metalayer = malloc(sizeof(blosc2_frame_metalayer));
-    char* name_ = malloc(strlen(name) + 1);
-    strcpy(name_, name);
-    metalayer->name = name_;
-    uint8_t* content_buf = malloc((size_t)content_len);
-    memcpy(content_buf, content, content_len);
-    metalayer->content = content_buf;
-    metalayer->content_len = content_len;
-    frame->metalayers[frame->nmetalayers] = metalayer;
-    frame->nmetalayers += 1;
-
-    return frame->nmetalayers - 1;
-}
-
-
-/* Update the content of an existing metalayer.
- *
- * If successful, return the index of the new metalayer.  Else, return a negative value.
- */
-int blosc2_frame_update_metalayer(blosc2_frame *frame, char *name, uint8_t *content,
-                                  uint32_t content_len) {
-  int nmetalayer = blosc2_frame_has_metalayer(frame, name);
-  if (nmetalayer < 0) {
-    fprintf(stderr, "metalayer \"%s\" not found\n", name);
-    return nmetalayer;
-  }
-
-  blosc2_frame_metalayer *metalayer = frame->metalayers[nmetalayer];
-  if (content_len > (uint32_t)metalayer->content_len) {
-    fprintf(stderr, "`content_len` cannot exceed the existing size of %d bytes", metalayer->content_len);
-    return nmetalayer;
-  }
-
-  // Update the contents of the metalayer
-  memcpy(metalayer->content, content, content_len);
-  return nmetalayer;
-}
-
-
-/* Get the content out of a metalayer.
- *
- * The `**content` receives a malloc'ed copy of the content.  The user is responsible of freeing it.
- *
- * If successful, return the index of the new metalayer.  Else, return a negative value.
- */
-int blosc2_frame_get_metalayer(blosc2_frame *frame, char *name, uint8_t **content,
-                               uint32_t *content_len) {
-    int nmetalayer = blosc2_frame_has_metalayer(frame, name);
-    if (nmetalayer < 0) {
-        fprintf(stderr, "metalayer \"%s\" not found\n", name);
-        return nmetalayer;
-    }
-    *content_len = (uint32_t)frame->metalayers[nmetalayer]->content_len;
-    *content = malloc((size_t)*content_len);
-    memcpy(*content, frame->metalayers[nmetalayer]->content, (size_t)*content_len);
-    return nmetalayer;
 }

--- a/blosc/frame.h
+++ b/blosc/frame.h
@@ -41,10 +41,12 @@
 #define FRAME_TRAILER_USERMETA_OFFSET (7)  // offset to usermeta chunk
 #define FRAME_TRAILER_MIN_LENGTH (30)  // minimum length for the trailer (msgpack overhead)
 
+#define FRAME_FILTER_PIPELINE_NAME "_filter_pipeline"
 
 void* frame_append_chunk(blosc2_frame* frame, void* chunk, blosc2_schunk* schunk);
 int frame_get_chunk(blosc2_frame *frame, int nchunk, uint8_t **chunk, bool *needs_free);
 int frame_decompress_chunk(blosc2_frame *frame, int nchunk, void *dest, size_t nbytes);
+int frame_update_metalayers(blosc2_frame* frame, blosc2_schunk* schunk, bool new);
 int frame_update_trailer(blosc2_frame* frame, blosc2_schunk* schunk);
 
 #endif //BLOSC_FRAME_H

--- a/blosc/frame.h
+++ b/blosc/frame.h
@@ -46,7 +46,7 @@
 void* frame_append_chunk(blosc2_frame* frame, void* chunk, blosc2_schunk* schunk);
 int frame_get_chunk(blosc2_frame *frame, int nchunk, uint8_t **chunk, bool *needs_free);
 int frame_decompress_chunk(blosc2_frame *frame, int nchunk, void *dest, size_t nbytes);
-int frame_update_metalayers(blosc2_frame* frame, blosc2_schunk* schunk, bool new);
+int frame_update_header(blosc2_frame* frame, blosc2_schunk* schunk, bool new);
 int frame_update_trailer(blosc2_frame* frame, blosc2_schunk* schunk);
 
 #endif //BLOSC_FRAME_H

--- a/blosc/schunk.c
+++ b/blosc/schunk.c
@@ -471,5 +471,5 @@ int32_t blosc2_get_usermeta(blosc2_schunk* schunk, uint8_t** content) {
   if (usermeta_nbytes < 0) {
     return -1;
   }
-  return nbytes;
+  return (int32_t)nbytes;
 }

--- a/blosc/schunk.c
+++ b/blosc/schunk.c
@@ -422,8 +422,8 @@ int blosc2_get_metalayer(blosc2_schunk *schunk, char *name, uint8_t **content,
 
 
 /* Update the content of the usermeta chunk. */
-int blosc2_schunk_update_usermeta(blosc2_schunk *schunk, uint8_t *content, int32_t content_len,
-                                  blosc2_cparams cparams) {
+int blosc2_update_usermeta(blosc2_schunk *schunk, uint8_t *content, int32_t content_len,
+                           blosc2_cparams cparams) {
   if (content_len > (1u << 31u)) {
     fprintf(stderr, "Error: content_len cannot exceed 2 GB");
     return -1;
@@ -461,7 +461,7 @@ int blosc2_schunk_update_usermeta(blosc2_schunk *schunk, uint8_t *content, int32
 
 
 /* Retrieve the usermeta chunk */
-int32_t blosc2_schunk_get_usermeta(blosc2_schunk* schunk, uint8_t** content) {
+int32_t blosc2_get_usermeta(blosc2_schunk* schunk, uint8_t** content) {
   size_t nbytes, cbytes, blocksize;
   blosc_cbuffer_sizes(schunk->usermeta, &nbytes, &cbytes, &blocksize);
   *content = malloc(nbytes);

--- a/blosc/schunk.c
+++ b/blosc/schunk.c
@@ -338,7 +338,7 @@ int blosc2_metalayer_flush(blosc2_schunk* schunk) {
   if (schunk->frame == NULL) {
     return rc;
   }
-  rc = frame_update_metalayers(schunk->frame, schunk, true);
+  rc = frame_update_header(schunk->frame, schunk, true);
   if (rc < 0) {
     fprintf(stderr, "Error: unable to update metalayers into frame\n");
     return -1;
@@ -374,7 +374,7 @@ int blosc2_update_metalayer(blosc2_schunk *schunk, char *name, uint8_t *content,
 
   // Update the metalayers in frame (as size has not changed, we don't need to update the trailer)
   if (schunk->frame != NULL) {
-    int rc = frame_update_metalayers(schunk->frame, schunk, false);
+    int rc = frame_update_header(schunk->frame, schunk, false);
     if (rc < 0) {
       fprintf(stderr, "Error: unable to update meta info from frame");
       return -1;

--- a/blosc/schunk.c
+++ b/blosc/schunk.c
@@ -290,7 +290,7 @@ int blosc2_schunk_get_chunk(blosc2_schunk *schunk, int nchunk, uint8_t **chunk, 
  *
  * If successful, return the index of the metalayer.  Else, return a negative value.
  */
-int blosc2_schunk_has_metalayer(blosc2_schunk *schunk, char *name) {
+int blosc2_has_metalayer(blosc2_schunk *schunk, char *name) {
   if (strlen(name) > BLOSC2_METALAYER_NAME_MAXLEN) {
     fprintf(stderr, "metalayers cannot be larger than %d chars\n", BLOSC2_METALAYER_NAME_MAXLEN);
     return -1;
@@ -309,8 +309,8 @@ int blosc2_schunk_has_metalayer(blosc2_schunk *schunk, char *name) {
  *
  * If successful, return the index of the new metalayer.  Else, return a negative value.
  */
-int blosc2_schunk_add_metalayer(blosc2_schunk *schunk, char *name, uint8_t *content, uint32_t content_len) {
-  int nmetalayer = blosc2_schunk_has_metalayer(schunk, name);
+int blosc2_add_metalayer(blosc2_schunk *schunk, char *name, uint8_t *content, uint32_t content_len) {
+  int nmetalayer = blosc2_has_metalayer(schunk, name);
   if (nmetalayer >= 0) {
     fprintf(stderr, "metalayer \"%s\" already exists", name);
     return -2;
@@ -356,8 +356,8 @@ int blosc2_metalayer_flush(blosc2_schunk* schunk) {
  *
  * If successful, return the index of the new metalayer.  Else, return a negative value.
  */
-int blosc2_schunk_update_metalayer(blosc2_schunk *schunk, char *name, uint8_t *content, uint32_t content_len) {
-  int nmetalayer = blosc2_schunk_has_metalayer(schunk, name);
+int blosc2_update_metalayer(blosc2_schunk *schunk, char *name, uint8_t *content, uint32_t content_len) {
+  int nmetalayer = blosc2_has_metalayer(schunk, name);
   if (nmetalayer < 0) {
     fprintf(stderr, "metalayer \"%s\" not found\n", name);
     return nmetalayer;
@@ -391,9 +391,9 @@ int blosc2_schunk_update_metalayer(blosc2_schunk *schunk, char *name, uint8_t *c
  *
  * If successful, return the index of the new metalayer.  Else, return a negative value.
  */
-int blosc2_schunk_get_metalayer(blosc2_schunk *schunk, char *name, uint8_t **content,
-                                uint32_t *content_len) {
-  int nmetalayer = blosc2_schunk_has_metalayer(schunk, name);
+int blosc2_get_metalayer(blosc2_schunk *schunk, char *name, uint8_t **content,
+                         uint32_t *content_len) {
+  int nmetalayer = blosc2_has_metalayer(schunk, name);
   if (nmetalayer < 0) {
     fprintf(stderr, "metalayer \"%s\" not found\n", name);
     return nmetalayer;

--- a/examples/frame_metalayers.c
+++ b/examples/frame_metalayers.c
@@ -62,10 +62,10 @@ int main() {
   blosc2_schunk* schunk = blosc2_new_schunk(cparams, dparams, frame1);
 
   // Add some metalayers (one must add metalayers prior to actual data)
-  blosc2_schunk_add_metalayer(schunk, "my_metalayer1", (uint8_t *) "my_content1",
-                              (uint32_t) strlen("my_content1"));
-  blosc2_schunk_add_metalayer(schunk, "my_metalayer2", (uint8_t *) "my_content1",
-                              (uint32_t) strlen("my_content1"));
+  blosc2_add_metalayer(schunk, "my_metalayer1", (uint8_t *) "my_content1",
+                       (uint32_t) strlen("my_content1"));
+  blosc2_add_metalayer(schunk, "my_metalayer2", (uint8_t *) "my_content1",
+                       (uint32_t) strlen("my_content1"));
   blosc2_metalayer_flush(schunk);
 
   blosc_set_timestamp(&last);
@@ -89,8 +89,8 @@ int main() {
   blosc_set_timestamp(&last);
 
   // Update a metalayer (this is fine as long as the new content does not exceed the size of the previous one)
-  blosc2_schunk_update_metalayer(schunk, "my_metalayer2", (uint8_t *) "my_content2",
-                                 (uint32_t) strlen("my_content2"));
+  blosc2_update_metalayer(schunk, "my_metalayer2", (uint8_t *) "my_content2",
+                          (uint32_t) strlen("my_content2"));
   blosc_set_timestamp(&current);
   ttotal = blosc_elapsed_secs(last, current);
   printf("Time for schunk -> frame: %.3g s, %.1f GB/s\n",
@@ -126,7 +126,7 @@ int main() {
   }
   uint8_t* content;
   uint32_t content_len;
-  if (blosc2_schunk_get_metalayer(schunk2, "my_metalayer1", &content, &content_len) < 0) {
+  if (blosc2_get_metalayer(schunk2, "my_metalayer1", &content, &content_len) < 0) {
       printf("metalayer not found");
       return -1;
   }

--- a/examples/frame_metalayers.c
+++ b/examples/frame_metalayers.c
@@ -3,7 +3,7 @@
   http://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 
-  Example program demonstrating use of the Blosc filter from C code.
+  Example program demonstrating the use of the metalayers.
 
   To compile this program:
 
@@ -39,129 +39,108 @@
 
 
 int main() {
-    static int32_t data[CHUNKSIZE];
-    size_t isize = CHUNKSIZE * sizeof(int32_t);
-    int64_t nbytes, cbytes;
-    int i, nchunk;
-    int nchunks;
-    blosc_timestamp_t last, current;
-    double ttotal;
+  static int32_t data[CHUNKSIZE];
+  size_t isize = CHUNKSIZE * sizeof(int32_t);
+  int64_t nbytes, cbytes;
+  int i, nchunk;
+  int nchunks;
+  blosc_timestamp_t last, current;
+  double ttotal;
 
-    printf("Blosc version info: %s (%s)\n",
-           BLOSC_VERSION_STRING, BLOSC_VERSION_DATE);
+  printf("Blosc version info: %s (%s)\n",
+         BLOSC_VERSION_STRING, BLOSC_VERSION_DATE);
 
-    /* Create a super-chunk container */
-    blosc2_cparams cparams = BLOSC2_CPARAMS_DEFAULTS;
-    cparams.typesize = sizeof(int32_t);
-    cparams.compcode = BLOSC_LZ4;
-    cparams.clevel = 9;
-    cparams.nthreads = NTHREADS;
-    blosc2_dparams dparams = BLOSC2_DPARAMS_DEFAULTS;
-    dparams.nthreads = NTHREADS;
-    blosc2_schunk* schunk = blosc2_new_schunk(cparams, dparams, NULL);
+  /* Create a super-chunk container */
+  blosc2_cparams cparams = BLOSC2_CPARAMS_DEFAULTS;
+  cparams.typesize = sizeof(int32_t);
+  cparams.compcode = BLOSC_LZ4;
+  cparams.clevel = 9;
+  cparams.nthreads = NTHREADS;
+  blosc2_dparams dparams = BLOSC2_DPARAMS_DEFAULTS;
+  dparams.nthreads = NTHREADS;
+  blosc2_frame* frame1 = blosc2_new_frame(NULL);
+  blosc2_schunk* schunk = blosc2_new_schunk(cparams, dparams, frame1);
 
-    blosc_set_timestamp(&last);
-    for (nchunk = 0; nchunk < NCHUNKS; nchunk++) {
-        for (i = 0; i < CHUNKSIZE; i++) {
-            data[i] = i * nchunk;
-        }
-        nchunks = blosc2_schunk_append_buffer(schunk, data, isize);
-        assert(nchunks == nchunk + 1);
-    }
-    /* Gather some info */
-    nbytes = schunk->nbytes;
-    cbytes = schunk->cbytes;
-    blosc_set_timestamp(&current);
-    ttotal = blosc_elapsed_secs(last, current);
-    printf("Compression ratio: %.1f MB -> %.1f MB (%.1fx)\n",
-           nbytes / MB, cbytes / MB, (1. * nbytes) / cbytes);
-    printf("Compression time: %.3g s, %.1f MB/s\n",
-           ttotal, nbytes / (ttotal * MB));
+  // Add some metalayers (one must add metalayers prior to actual data)
+  blosc2_schunk_add_metalayer(schunk, "my_metalayer1", (uint8_t *) "my_content1",
+                              (uint32_t) strlen("my_content1"));
+  blosc2_schunk_add_metalayer(schunk, "my_metalayer2", (uint8_t *) "my_content1",
+                              (uint32_t) strlen("my_content1"));
+  blosc2_metalayer_flush(schunk);
 
-    // super-chunk -> frame1 (in-memory)
-    blosc_set_timestamp(&last);
-    blosc2_frame* frame1 = blosc2_new_frame(NULL);
+  blosc_set_timestamp(&last);
+  for (nchunk = 0; nchunk < NCHUNKS; nchunk++) {
+      for (i = 0; i < CHUNKSIZE; i++) {
+          data[i] = i * nchunk;
+      }
+      nchunks = blosc2_schunk_append_buffer(schunk, data, isize);
+      assert(nchunks == nchunk + 1);
+  }
+  /* Gather some info */
+  nbytes = schunk->nbytes;
+  cbytes = schunk->cbytes;
+  blosc_set_timestamp(&current);
+  ttotal = blosc_elapsed_secs(last, current);
+  printf("Compression ratio: %.1f MB -> %.1f MB (%.1fx)\n",
+         nbytes / MB, cbytes / MB, (1. * nbytes) / cbytes);
+  printf("Compression time: %.3g s, %.1f MB/s\n",
+         ttotal, nbytes / (ttotal * MB));
 
-    // Add some metalayers
-    blosc2_frame_add_metalayer(frame1, "my_metalayer1", (uint8_t *) "my_content1",
-                               (uint32_t) strlen("my_content1"));
-    blosc2_frame_add_metalayer(frame1, "my_metalayer2", (uint8_t *) "my_content1",
-                               (uint32_t) strlen("my_content1"));
-    blosc2_frame_update_metalayer(frame1, "my_metalayer2", (uint8_t *) "my_content2",
-                                  (uint32_t) strlen("my_content2"));
-    int64_t frame_len = blosc2_schunk_to_frame(schunk, frame1);
-    blosc_set_timestamp(&current);
-    ttotal = blosc_elapsed_secs(last, current);
-    printf("Time for schunk -> frame: %.3g s, %.1f GB/s\n",
-           ttotal, nbytes / (ttotal * GB));
-    printf("Frame length in memory: %ld bytes\n", (long)frame_len);
+  blosc_set_timestamp(&last);
 
-    // frame1 (in-memory) -> fileframe (on-disk)
-    blosc_set_timestamp(&last);
-    frame_len = blosc2_frame_to_file(frame1, "frame_metalayers.b2frame");
-    printf("Frame length on disk: %ld bytes\n", (long)frame_len);
-    blosc_set_timestamp(&current);
-    ttotal = blosc_elapsed_secs(last, current);
-    printf("Time for frame -> fileframe (simple_frame.b2frame): %.3g s, %.1f GB/s\n",
-           ttotal, nbytes / (ttotal * GB));
+  // Update a metalayer (this is fine as long as the new content does not exceed the size of the previous one)
+  blosc2_schunk_update_metalayer(schunk, "my_metalayer2", (uint8_t *) "my_content2",
+                                 (uint32_t) strlen("my_content2"));
+  blosc_set_timestamp(&current);
+  ttotal = blosc_elapsed_secs(last, current);
+  printf("Time for schunk -> frame: %.3g s, %.1f GB/s\n",
+         ttotal, nbytes / (ttotal * GB));
+  printf("Frame length in memory: %ld bytes\n", (long)frame1->len);
 
-    // fileframe (file) -> frame2 (on-disk frame)
-    blosc_set_timestamp(&last);
-    blosc2_frame* frame2 = blosc2_frame_from_file("frame_metalayers.b2frame");
-    blosc_set_timestamp(&current);
-    ttotal = blosc_elapsed_secs(last, current);
-    printf("Time for fileframe (%s) -> frame : %.3g s, %.1f GB/s\n",
-           frame2->fname, ttotal, nbytes / (ttotal * GB));
+  // frame1 (in-memory) -> fileframe (on-disk)
+  blosc_set_timestamp(&last);
+  int64_t frame_len = blosc2_frame_to_file(frame1, "frame_metalayers.b2frame");
+  printf("Frame length on disk: %ld bytes\n", (long)frame_len);
+  blosc_set_timestamp(&current);
+  ttotal = blosc_elapsed_secs(last, current);
+  printf("Time for frame -> fileframe (simple_frame.b2frame): %.3g s, %.1f GB/s\n",
+         ttotal, nbytes / (ttotal * GB));
 
-    // Check that the attributes had a good roundtrip
-    if (frame2->nmetalayers != 2) {
-        printf("nclients not retrieved correctly!\n");
-        return -1;
-    }
-    uint8_t* content;
-    uint32_t content_len;
-    if (blosc2_frame_get_metalayer(frame2, "my_metalayer1", &content, &content_len) < 0) {
-        printf("metalayer not found");
-        return -1;
-    }
-    if (memcmp(content, "my_content1", content_len) != 0) {
-        printf("serialized content for metalayer not retrieved correctly!\n");
-        return -1;
-    }
-    free(content);
+  // fileframe (file) -> schunk2 (schunk based on a on-disk frame)
+  blosc_set_timestamp(&last);
+  blosc2_frame* frame2 = blosc2_frame_from_file("frame_metalayers.b2frame");
+  blosc2_schunk* schunk2 = blosc2_schunk_from_frame(frame2, false);
+  if (schunk2 == NULL) {
+    printf("Cannot get the schunk from frame2");
+    return -1;
+  }
+  blosc_set_timestamp(&current);
+  ttotal = blosc_elapsed_secs(last, current);
+  printf("Time for fileframe (%s) -> schunk : %.3g s, %.1f GB/s\n",
+         frame2->fname, ttotal, nbytes / (ttotal * GB));
 
-    // frame2 (on-disk) -> schunk
-    blosc_set_timestamp(&last);
-    blosc2_schunk* schunk2 = blosc2_new_schunk(cparams, dparams, frame2);
-    if (schunk2 == NULL) {
-        printf("Bad conversion frame2 -> schunk2!\n");
-        return -1;
-    }
-    blosc_set_timestamp(&current);
-    ttotal = blosc_elapsed_secs(last, current);
-    printf("Time for fileframe -> schunk: %.3g s, %.1f GB/s\n",
-           ttotal, nbytes / (ttotal * GB));
+  // Check that the metalayers had a good roundtrip
+  if (schunk2->nmetalayers != 2) {
+      printf("nclients not retrieved correctly!\n");
+      return -1;
+  }
+  uint8_t* content;
+  uint32_t content_len;
+  if (blosc2_schunk_get_metalayer(schunk2, "my_metalayer1", &content, &content_len) < 0) {
+      printf("metalayer not found");
+      return -1;
+  }
+  if (memcmp(content, "my_content1", content_len) != 0) {
+      printf("serialized content for metalayer not retrieved correctly!\n");
+      return -1;
+  }
+  free(content);
 
-    // Check that the attributes had a good roundtrip
-    if (schunk2->frame->nmetalayers != 2) {
-        printf("metalayer not retrieved correctly!\n");
-        return -1;
-    }
-    if (blosc2_frame_get_metalayer(schunk2->frame, "my_metalayer2", &content, &content_len) < 0) {
-        printf("metalayer not found");
-        return -1;
-    }
-    if (memcmp(content, "my_content2", content_len) != 0) {
-        printf("serialized content for metalayer not retrieved correctly!\n");
-        return -1;
-    }
-    free(content);
+  /* Free resources */
+  blosc2_free_schunk(schunk);
+  blosc2_free_schunk(schunk2);
+  blosc2_free_frame(frame1);
+  blosc2_free_frame(frame2);
 
-    /* Free resources */
-    blosc2_free_schunk(schunk);
-    blosc2_free_schunk(schunk2);
-    blosc2_free_frame(frame1);
-    blosc2_free_frame(frame2);
-
-    return 0;
+  return 0;
 }

--- a/examples/frame_metalayers.c
+++ b/examples/frame_metalayers.c
@@ -66,7 +66,6 @@ int main() {
                        (uint32_t) strlen("my_content1"));
   blosc2_add_metalayer(schunk, "my_metalayer2", (uint8_t *) "my_content1",
                        (uint32_t) strlen("my_content1"));
-  blosc2_metalayer_flush(schunk);
 
   blosc_set_timestamp(&last);
   for (nchunk = 0; nchunk < NCHUNKS; nchunk++) {

--- a/examples/frame_simple.c
+++ b/examples/frame_simple.c
@@ -74,8 +74,8 @@ int main() {
   }
 
   // Add some usermeta data
-  int umlen = blosc2_schunk_update_usermeta(schunk, (uint8_t*)"This is a usermeta content...",32,
-                                            BLOSC2_CPARAMS_DEFAULTS);
+  int umlen = blosc2_update_usermeta(schunk, (uint8_t *) "This is a usermeta content...", 32,
+                                     BLOSC2_CPARAMS_DEFAULTS);
   if (umlen < 0) {
     printf("Cannot write usermeta chunk");
   }
@@ -90,7 +90,7 @@ int main() {
   printf("Compression time: %.3g s, %.1f MB/s\n",
          ttotal, nbytes / (ttotal * MB));
   uint8_t* usermeta;
-  int content_len = blosc2_schunk_get_usermeta(schunk, &usermeta);
+  int content_len = blosc2_get_usermeta(schunk, &usermeta);
   printf("Usermeta in schunk: '%s' with length: %d\n", usermeta, content_len);
   free(usermeta);
 
@@ -177,10 +177,10 @@ int main() {
   }
   printf("Successful roundtrip schunk <-> frame <-> fileframe !\n");
 
-  content_len = blosc2_schunk_get_usermeta(schunk1, &usermeta);
+  content_len = blosc2_get_usermeta(schunk1, &usermeta);
   printf("Usermeta in schunk1: '%s' with length: %d\n", usermeta, content_len);
   free(usermeta);
-  content_len = blosc2_schunk_get_usermeta(schunk2, &usermeta);
+  content_len = blosc2_get_usermeta(schunk2, &usermeta);
   printf("Usermeta in schunk2: '%s' with length: %d\n", usermeta, content_len);
   free(usermeta);
 

--- a/tests/test_frame.c
+++ b/tests/test_frame.c
@@ -132,6 +132,9 @@ static char* test_frame() {
   nbytes = schunk->nbytes;
   cbytes = schunk->cbytes;
   if (nchunks > 0) {
+    if (nbytes <= 10 * cbytes) {
+      printf("Error!");
+    }
     mu_assert("ERROR: bad compression ratio in frame", nbytes > 10 * cbytes);
   }
 

--- a/tests/test_frame.c
+++ b/tests/test_frame.c
@@ -71,7 +71,7 @@ static char* test_frame() {
   }
 
   if (usermeta) {
-    blosc2_schunk_update_usermeta(schunk, (uint8_t*)content, content_len, BLOSC2_CPARAMS_DEFAULTS);
+    blosc2_update_usermeta(schunk, (uint8_t *) content, content_len, BLOSC2_CPARAMS_DEFAULTS);
   }
 
   if (!sparse_schunk) {
@@ -100,11 +100,11 @@ static char* test_frame() {
   }
 
   if (usermeta) {
-    int content_len_ = blosc2_schunk_get_usermeta(schunk, &content_);
+    int content_len_ = blosc2_get_usermeta(schunk, &content_);
     mu_assert("ERROR: bad usermeta length in frame", content_len_ == content_len);
     mu_assert("ERROR: bad usermeta data in frame", strncmp((char*)content_, content, content_len) == 0);
     free(content_);
-    blosc2_schunk_update_usermeta(schunk, (uint8_t*)content2, content_len2, BLOSC2_CPARAMS_DEFAULTS);
+    blosc2_update_usermeta(schunk, (uint8_t *) content2, content_len2, BLOSC2_CPARAMS_DEFAULTS);
   }
 
   // Feed it with data
@@ -136,11 +136,11 @@ static char* test_frame() {
   }
 
   if (usermeta) {
-    int content_len_ = blosc2_schunk_get_usermeta(schunk, &content_);
+    int content_len_ = blosc2_get_usermeta(schunk, &content_);
     mu_assert("ERROR: bad usermeta length in frame", content_len_ == content_len2);
     mu_assert("ERROR: bad usermeta data in frame", strncmp((char*)content_, content2, content_len2) == 0);
     free(content_);
-    blosc2_schunk_update_usermeta(schunk, (uint8_t*)content3, content_len3, BLOSC2_CPARAMS_DEFAULTS);
+    blosc2_update_usermeta(schunk, (uint8_t *) content3, content_len3, BLOSC2_CPARAMS_DEFAULTS);
   }
 
   if (!sparse_schunk) {
@@ -185,7 +185,7 @@ static char* test_frame() {
   }
 
   if (usermeta) {
-    int content_len_ = blosc2_schunk_get_usermeta(schunk, &content_);
+    int content_len_ = blosc2_get_usermeta(schunk, &content_);
     mu_assert("ERROR: bad usermeta length in frame", content_len_ == content_len3);
     mu_assert("ERROR: bad usermeta data in frame", strncmp((char*)content_, content3, content_len3) == 0);
     free(content_);

--- a/tests/test_frame.c
+++ b/tests/test_frame.c
@@ -132,9 +132,6 @@ static char* test_frame() {
   nbytes = schunk->nbytes;
   cbytes = schunk->cbytes;
   if (nchunks > 0) {
-    if (nbytes <= 10 * cbytes) {
-      printf("Error!");
-    }
     mu_assert("ERROR: bad compression ratio in frame", nbytes > 10 * cbytes);
   }
 

--- a/tests/test_schunk.c
+++ b/tests/test_schunk.c
@@ -41,8 +41,8 @@ static char* test_schunk() {
   schunk = blosc2_new_schunk(cparams, dparams, NULL);
 
 //  // Add a couple of metalayers
-//  blosc2_schunk_add_metalayer(schunk, "metalayer1", "my metalayer1", sizeof("my metalayer1"));
-//  blosc2_schunk_add_metalayer(schunk, "metalayer2", "my metalayer1", sizeof("my metalayer1"));
+//  blosc2_add_metalayer(schunk, "metalayer1", "my metalayer1", sizeof("my metalayer1"));
+//  blosc2_add_metalayer(schunk, "metalayer2", "my metalayer1", sizeof("my metalayer1"));
 
   // Feed it with data
   for (int nchunk = 0; nchunk < nchunks; nchunk++) {
@@ -53,7 +53,7 @@ static char* test_schunk() {
     mu_assert("ERROR: bad append in frame", nchunk >= 0);
   }
 
-//  blosc2_schunk_update_metalayer(schunk, "metalayer2", (uint8_t*)"my metalayer2", sizeof("my metalayer2"));
+//  blosc2_update_metalayer(schunk, "metalayer2", (uint8_t*)"my metalayer2", sizeof("my metalayer2"));
   // Attach some user metadata into it
   blosc2_schunk_update_usermeta(schunk, (uint8_t*)"testing the usermeta", 16, BLOSC2_CPARAMS_DEFAULTS);
 
@@ -95,10 +95,10 @@ static char* test_schunk() {
 //  // metalayers
 //  uint8_t* content;
 //  uint32_t content_len;
-//  blosc2_schunk_get_metalayer(schunk, "metalayer1", &content, &content_len);
+//  blosc2_get_metalayer(schunk, "metalayer1", &content, &content_len);
 //  mu_assert("ERROR: bad metalayer content", strncat((char*)content, "my metalayer1", content_len));
 //  free(content);
-//  blosc2_schunk_get_metalayer(schunk, "metalayer2", &content, &content_len);
+//  blosc2_get_metalayer(schunk, "metalayer2", &content, &content_len);
 //  mu_assert("ERROR: bad metalayer content", strncat((char*)content, "my metalayer1", content_len));
 //  free(content);
 

--- a/tests/test_schunk.c
+++ b/tests/test_schunk.c
@@ -40,6 +40,10 @@ static char* test_schunk() {
   dparams.nthreads = NTHREADS;
   schunk = blosc2_new_schunk(cparams, dparams, NULL);
 
+//  // Add a couple of metalayers
+//  blosc2_schunk_add_metalayer(schunk, "metalayer1", "my metalayer1", sizeof("my metalayer1"));
+//  blosc2_schunk_add_metalayer(schunk, "metalayer2", "my metalayer1", sizeof("my metalayer1"));
+
   // Feed it with data
   for (int nchunk = 0; nchunk < nchunks; nchunk++) {
     for (int i = 0; i < CHUNKSIZE; i++) {
@@ -49,6 +53,7 @@ static char* test_schunk() {
     mu_assert("ERROR: bad append in frame", nchunk >= 0);
   }
 
+//  blosc2_schunk_update_metalayer(schunk, "metalayer2", (uint8_t*)"my metalayer2", sizeof("my metalayer2"));
   // Attach some user metadata into it
   blosc2_schunk_update_usermeta(schunk, (uint8_t*)"testing the usermeta", 16, BLOSC2_CPARAMS_DEFAULTS);
 
@@ -87,11 +92,21 @@ static char* test_schunk() {
     }
   }
 
+//  // metalayers
+//  uint8_t* content;
+//  uint32_t content_len;
+//  blosc2_schunk_get_metalayer(schunk, "metalayer1", &content, &content_len);
+//  mu_assert("ERROR: bad metalayer content", strncat((char*)content, "my metalayer1", content_len));
+//  free(content);
+//  blosc2_schunk_get_metalayer(schunk, "metalayer2", &content, &content_len);
+//  mu_assert("ERROR: bad metalayer content", strncat((char*)content, "my metalayer1", content_len));
+//  free(content);
+
   // Check the user metadata
   uint8_t* content2;
-  int32_t content_len = blosc2_schunk_get_usermeta(schunk, &content2);
+  int32_t content2_len = blosc2_schunk_get_usermeta(schunk, &content2);
   mu_assert("ERROR: bad usermeta", strcmp((char*)content2, "testing the usermeta"));
-  mu_assert("ERROR: bad usermeta_len", content_len == 16);
+  mu_assert("ERROR: bad usermeta_len", content2_len == 16);
   free(content2);
 
   /* Free resources */

--- a/tests/test_schunk.c
+++ b/tests/test_schunk.c
@@ -40,9 +40,9 @@ static char* test_schunk() {
   dparams.nthreads = NTHREADS;
   schunk = blosc2_new_schunk(cparams, dparams, NULL);
 
-//  // Add a couple of metalayers
-//  blosc2_add_metalayer(schunk, "metalayer1", "my metalayer1", sizeof("my metalayer1"));
-//  blosc2_add_metalayer(schunk, "metalayer2", "my metalayer1", sizeof("my metalayer1"));
+  // Add a couple of metalayers
+  blosc2_add_metalayer(schunk, "metalayer1", (uint8_t*)"my metalayer1", sizeof("my metalayer1"));
+  blosc2_add_metalayer(schunk, "metalayer2", (uint8_t*)"my metalayer1", sizeof("my metalayer1"));
 
   // Feed it with data
   for (int nchunk = 0; nchunk < nchunks; nchunk++) {
@@ -53,7 +53,7 @@ static char* test_schunk() {
     mu_assert("ERROR: bad append in frame", nchunk >= 0);
   }
 
-//  blosc2_update_metalayer(schunk, "metalayer2", (uint8_t*)"my metalayer2", sizeof("my metalayer2"));
+  blosc2_update_metalayer(schunk, "metalayer2", (uint8_t*)"my metalayer2", sizeof("my metalayer2"));
   // Attach some user metadata into it
   blosc2_schunk_update_usermeta(schunk, (uint8_t*)"testing the usermeta", 16, BLOSC2_CPARAMS_DEFAULTS);
 
@@ -92,20 +92,20 @@ static char* test_schunk() {
     }
   }
 
-//  // metalayers
-//  uint8_t* content;
-//  uint32_t content_len;
-//  blosc2_get_metalayer(schunk, "metalayer1", &content, &content_len);
-//  mu_assert("ERROR: bad metalayer content", strncat((char*)content, "my metalayer1", content_len));
-//  free(content);
-//  blosc2_get_metalayer(schunk, "metalayer2", &content, &content_len);
-//  mu_assert("ERROR: bad metalayer content", strncat((char*)content, "my metalayer1", content_len));
-//  free(content);
+  // metalayers
+  uint8_t* content;
+  uint32_t content_len;
+  blosc2_get_metalayer(schunk, "metalayer1", &content, &content_len);
+  mu_assert("ERROR: bad metalayer content", strncmp((char*)content, "my metalayer1", content_len) == 0);
+  free(content);
+  blosc2_get_metalayer(schunk, "metalayer2", &content, &content_len);
+  mu_assert("ERROR: bad metalayer content", strncmp((char*)content, "my metalayer2", content_len) == 0);
+  free(content);
 
-  // Check the user metadata
+  // Check the usermeta
   uint8_t* content2;
   int32_t content2_len = blosc2_schunk_get_usermeta(schunk, &content2);
-  mu_assert("ERROR: bad usermeta", strcmp((char*)content2, "testing the usermeta"));
+  mu_assert("ERROR: bad usermeta", strncmp((char*)content2, "testing the usermeta", 16) == 0);
   mu_assert("ERROR: bad usermeta_len", content2_len == 16);
   free(content2);
 

--- a/tests/test_schunk.c
+++ b/tests/test_schunk.c
@@ -55,7 +55,7 @@ static char* test_schunk() {
 
   blosc2_update_metalayer(schunk, "metalayer2", (uint8_t*)"my metalayer2", sizeof("my metalayer2"));
   // Attach some user metadata into it
-  blosc2_schunk_update_usermeta(schunk, (uint8_t*)"testing the usermeta", 16, BLOSC2_CPARAMS_DEFAULTS);
+  blosc2_update_usermeta(schunk, (uint8_t *) "testing the usermeta", 16, BLOSC2_CPARAMS_DEFAULTS);
 
   /* Gather some info */
   nbytes = schunk->nbytes;
@@ -104,7 +104,7 @@ static char* test_schunk() {
 
   // Check the usermeta
   uint8_t* content2;
-  int32_t content2_len = blosc2_schunk_get_usermeta(schunk, &content2);
+  int32_t content2_len = blosc2_get_usermeta(schunk, &content2);
   mu_assert("ERROR: bad usermeta", strncmp((char*)content2, "testing the usermeta", 16) == 0);
   mu_assert("ERROR: bad usermeta_len", content2_len == 16);
   free(content2);


### PR DESCRIPTION
Metalayers should be able to be attached into superchunks, and not only to frames.  This is a attempt in order to move them into the schunk object.  It seems to me that the refactoring leads to a more consistent API too, so even if it is a breaking change, I think the benefits are worth it (we are in beta after all).