### PR TITLE
New frame format

### DIFF
--- a/README_FRAME_FORMAT.rst
+++ b/README_FRAME_FORMAT.rst
@@ -36,7 +36,7 @@ The header of a frame is encoded via  `msgpack <https://msgpack.org>`_ and it fo
       |   |   |   |   |   +--[msgpack] int64
       |   |   |   |   +-- reserved flags
       |   |   |   +--codec_flags (see below)
-      |   |   +---filter_flags (see below)
+      |   |   +---reserved flags
       |   +------general_flags (see below)
       +---[msgpack] str with 4 elements (flags)
 
@@ -52,9 +52,19 @@ The header of a frame is encoded via  `msgpack <https://msgpack.org>`_ and it fo
       |                   +------[msgpack] int32
       +---[msgpack] int32
 
+The it follows the info about the filter pipeline.  There is place for a pipeline that is 8 slots deep, and there is a reserved byte per every filter code and a possible associated meta-info::
+
+    |-40|-41|-42|-43|-44|-45|-46|-47|-48|-49|-4A|-4B|-4C|-4D|-4E|-4F|-50|-51|
+    | d2| X | filter_codes                  | filter_meta                   |
+    |---|---|-------------------------------|-------------------------------|
+      ^   ^
+      |   |
+      |   +--number of filters
+      +--[msgpack] fixext 16
+
 In addition, a frame can be completed with meta-information about the stored data; these data blocks are called metalayers and it is up to the user to store whatever data they want there, with the only (strong) suggestion that they have to be in the msgpack format.  Here it is the format for the case that there exist some metalayers::
 
-  |-40|-41|-42|-43|-44|-----------------------
+  |-52|-53|-54|-55|-56|-----------------------
   | 93| cd| idx   | de| map_of_metalayers
   |---|---------------|-----------------------
     ^   ^    ^      ^

--- a/README_FRAME_FORMAT.rst
+++ b/README_FRAME_FORMAT.rst
@@ -26,7 +26,7 @@ The header of a frame is encoded via  `msgpack <https://msgpack.org>`_ and it fo
       |   |       |                           +--[msgpack] int32
       |   |       +---magic number, currently "b2frame"
       |   +------[msgpack] str with 8 elements
-      +---[msgpack] fixarray with X=0xB (11, no metalayers) or X=0xC (12) elements
+      +---[msgpack] fixarray with X=0xC (12) elements
 
     |-18|-19|-1A|-1B|-1C|-1D|-1E|-1F|-20|-21|-22|-23|-24|-25|-26|-27|-28|-29|-2A|-2B|-2C|-2D|-2E|
     | a4|_f0|_f1|_f2|_f3| d3| uncompressed_size             | d3| compressed_size               |
@@ -52,7 +52,7 @@ The header of a frame is encoded via  `msgpack <https://msgpack.org>`_ and it fo
       |                   +------[msgpack] int32
       +---[msgpack] int32
 
-The it follows the info about the filter pipeline.  There is place for a pipeline that is 8 slots deep, and there is a reserved byte per every filter code and a possible associated meta-info::
+Then it follows the info about the filter pipeline.  There is place for a pipeline that is 8 slots deep, and there is a reserved byte per every filter code and another byte for a possible associated meta-info::
 
     |-40|-41|-42|-43|-44|-45|-46|-47|-48|-49|-4A|-4B|-4C|-4D|-4E|-4F|-50|-51|
     | d2| X | filter_codes                  | filter_meta                   |

--- a/README_FRAME_FORMAT.rst
+++ b/README_FRAME_FORMAT.rst
@@ -89,17 +89,8 @@ __________________________________________
 :general_flags:
     (``uint8``) General flags.
 
-    :``0`` and ``1``:
+    :``0`` to ``3``:
         Format version
-    :``2`` and ``3``: Enumerated
-        :``0``:
-            Reserved (regular chunk?)
-        :``1``:
-            Reserved (extended chunk?)
-        :``2``:
-            Frame
-        :``3``:
-            Reserved (extended frame?)
     :``4`` and ``5``: Enumerated for chunk offsets.
         :``0``:
             16-bit
@@ -112,7 +103,7 @@ __________________________________________
     :``6``:
         Chunks of fixed length (0) or variable length (1)
     :``7``:
-        Reserved.
+        Reserved
 
 :filter_flags:
     (``uint8``) Filter flags that are the defaults for all the chunks in storage.

--- a/README_FRAME_FORMAT.rst
+++ b/README_FRAME_FORMAT.rst
@@ -26,7 +26,7 @@ The header of a frame is encoded via  `msgpack <https://msgpack.org>`_ and it fo
       |   |       |                           +--[msgpack] int32
       |   |       +---magic number, currently "b2frame"
       |   +------[msgpack] str with 8 elements
-      +---[msgpack] fixarray with X=0xC (12) elements
+      +---[msgpack] fixarray with X=0xD (13) elements
 
     |-18|-19|-1A|-1B|-1C|-1D|-1E|-1F|-20|-21|-22|-23|-24|-25|-26|-27|-28|-29|-2A|-2B|-2C|-2D|-2E|
     | a4|_f0|_f1|_f2|_f3| d3| uncompressed_size             | d3| compressed_size               |

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -12,14 +12,19 @@ Changes from 2.0.0-beta.1 to 2.0.0-beta.2
   new `blosc2_update_usermeta()` and `blosc2_get_usermeta()` functions.
 
 * Metalayers must now be attached to super-chunks, not frames.  The reason is
-  that frames are increasingly treated as a storage specifier (in-memory or disk
-  now, but can be other means in the future), whereas the actual API for I/O
-  (including metainfo) goes into super-chunks.  See PR #75.
+  that frames are increasingly treated as a storage specifier (in-memory or
+  disk now, but can be other means in the future), whereas the actual API for
+  I/O (including metainfo) goes into super-chunks.  See PR #75.
 
 * New frame format documented in
   [README_FRAME_FORMAT.rst](README_FRAME_FORMAT.rst). Remember that the frame
   format is not written in stone yet, so some changes may be introduced before
   getting out of beta.
+
+* BREAKING CHANGE: the format for frames has changed and
+  BLOSC2_VERSION_FRAME_FORMAT is now set to 1.  There is no attempt to support
+  previous formats, but there will probably be backward compatibility support
+  starting from version 1 on.
 
 * BREAKING CHANGE: the next APIs have been renamed:
   + blosc2_frame_has_metalayer -> blosc2_has_metalayer

--- a/blosc/blosc-private.h
+++ b/blosc/blosc-private.h
@@ -70,41 +70,6 @@ static inline void _sw32(void* dest, int32_t a) {
   }
 }
 
-/* Convert filter pipeline to filter flags */
-static uint8_t filters_to_flags(const uint8_t* filters) {
-  uint8_t flags = 0;
-
-  for (int i = 0; i < BLOSC2_MAX_FILTERS; i++) {
-    switch (filters[i]) {
-      case BLOSC_SHUFFLE:
-        flags |= BLOSC_DOSHUFFLE;
-        break;
-      case BLOSC_BITSHUFFLE:
-        flags |= BLOSC_DOBITSHUFFLE;
-        break;
-      case BLOSC_DELTA:
-        flags |= BLOSC_DODELTA;
-        break;
-      default :
-        break;
-    }
-  }
-  return flags;
-}
-
-
-/* Convert filter flags to filter pipeline */
-static void flags_to_filters(const uint8_t flags, uint8_t* filters) {
-  /* Initialize the filter pipeline */
-  memset(filters, 0, BLOSC2_MAX_FILTERS);
-  /* Fill the filter pipeline */
-  if (flags & BLOSC_DOSHUFFLE)
-    filters[BLOSC2_MAX_FILTERS - 1] = BLOSC_SHUFFLE;
-  if (flags & BLOSC_DOBITSHUFFLE)
-    filters[BLOSC2_MAX_FILTERS - 1] = BLOSC_BITSHUFFLE;
-  if (flags & BLOSC_DODELTA)
-    filters[BLOSC2_MAX_FILTERS - 2] = BLOSC_DELTA;
-}
 
 #ifdef __cplusplus
 }

--- a/blosc/blosc2.c
+++ b/blosc/blosc2.c
@@ -1229,6 +1229,43 @@ static int do_job(blosc2_context* context) {
 }
 
 
+/* Convert filter pipeline to filter flags */
+static uint8_t filters_to_flags(const uint8_t* filters) {
+  uint8_t flags = 0;
+
+  for (int i = 0; i < BLOSC2_MAX_FILTERS; i++) {
+    switch (filters[i]) {
+      case BLOSC_SHUFFLE:
+        flags |= BLOSC_DOSHUFFLE;
+        break;
+      case BLOSC_BITSHUFFLE:
+        flags |= BLOSC_DOBITSHUFFLE;
+        break;
+      case BLOSC_DELTA:
+        flags |= BLOSC_DODELTA;
+        break;
+      default :
+        break;
+    }
+  }
+  return flags;
+}
+
+
+/* Convert filter flags to filter pipeline */
+static void flags_to_filters(const uint8_t flags, uint8_t* filters) {
+  /* Initialize the filter pipeline */
+  memset(filters, 0, BLOSC2_MAX_FILTERS);
+  /* Fill the filter pipeline */
+  if (flags & BLOSC_DOSHUFFLE)
+    filters[BLOSC2_MAX_FILTERS - 1] = BLOSC_SHUFFLE;
+  if (flags & BLOSC_DOBITSHUFFLE)
+    filters[BLOSC2_MAX_FILTERS - 1] = BLOSC_BITSHUFFLE;
+  if (flags & BLOSC_DODELTA)
+    filters[BLOSC2_MAX_FILTERS - 2] = BLOSC_DELTA;
+}
+
+
 static int initialize_context_compression(
   blosc2_context* context, int32_t sourcesize, const void* src, void* dest,
   int32_t destsize, int clevel, uint8_t const *filters,

--- a/blosc/blosc2.h
+++ b/blosc/blosc2.h
@@ -769,6 +769,7 @@ typedef struct {
   uint8_t* sdata;  //!< The in-memory serialized data
   int64_t len;     //!< The current length of the frame in (compressed) bytes
   int64_t maxlen;  //!< The maximum length of the frame; if 0, there is no maximum
+  uint32_t trailer_len;  //!< The current length of the trailer in (compressed) bytes
 } blosc2_frame;
 
 /**

--- a/blosc/blosc2.h
+++ b/blosc/blosc2.h
@@ -54,13 +54,18 @@ enum {
 };
 
 
-/* The FRAME_FORMAT_VERSION symbols below should be just 2-bit long */
+/* The FRAME_FORMAT_VERSION symbols below should be just 4-bit long */
 enum {
-  /* Blosc format version, starting at 0
-     0 -> First version (introduced in beta.1)
-     */
-  BLOSC2_VERSION_FRAME_FORMAT_BETA1 = 0,  // for beta.1 and before
-  BLOSC2_VERSION_FRAME_FORMAT = BLOSC2_VERSION_FRAME_FORMAT_BETA1,
+  /* Blosc format version
+   *  4 -> First version (introduced in beta.1)
+   *  1 -> Second version (introduced in beta.2)
+   *
+   *  *Important note*: version 4 should be avoided because it was used
+   *  for beta.1 and before, and it won't be supported anymore.
+   */
+  BLOSC2_VERSION_FRAME_FORMAT_BETA1 = 4,  // for beta.1 and before
+  BLOSC2_VERSION_FRAME_FORMAT_BETA2 = 1,  // for beta.2 and after
+  BLOSC2_VERSION_FRAME_FORMAT = BLOSC2_VERSION_FRAME_FORMAT_BETA2,
 };
 
 enum {

--- a/blosc/frame.c
+++ b/blosc/frame.c
@@ -79,43 +79,6 @@ void swap_store(void *dest, const void *pa, int size) {
     free(pa2_);
 }
 
-// Get the number of filters in pipeline
-int get_nfilters(const uint8_t* filters) {
-  int nfilters = 0;
-  for (int i = 0; i < BLOSC2_MAX_FILTERS; i++) {
-    if (filters[i] != BLOSC_NOFILTER) {
-      nfilters++;
-    }
-  }
-  return nfilters;
-}
-
-// Get a metalayer for the filter pipeline
-int filters_to_metalayer(const uint8_t* filters, const uint8_t* filters_meta, void** metalayer) {
-  // int nfilters = get_nfilters(filters);
-  // Store the whole pipeline (can be useful for btune)
-  int nfilters = BLOSC2_MAX_FILTERS;
-  int metalayer_len = 1 + 1 + 1 + nfilters * 2;
-  *metalayer = calloc(metalayer_len, 1);
-  uint8_t* mp = *metalayer;
-  *mp = 0x90 + 2;  // array with 2 elements
-  mp += 1;
-  // Create and fill up the filters and associated metainfo in the pipeline
-  uint8_t* mp_filters = mp;
-  uint8_t* mp_meta = mp + nfilters;
-  *mp_filters = 0x90 + nfilters;  // array with nfilter elements
-  mp_filters += 1;
-  *mp_meta = 0x90 + nfilters;  // array with nfilter elements
-  mp_meta += 1;
-  int nfilter = 0;
-  for (int i = 0; i < BLOSC2_MAX_FILTERS; i++) {
-    mp_filters[nfilter] = filters[i];
-    mp_meta[nfilter] = filters_meta[i];
-    nfilter++;
-  }
-  return metalayer_len;
-}
-
 
 /* Create a new (empty) frame */
 blosc2_frame* blosc2_new_frame(char* fname) {
@@ -146,7 +109,7 @@ int blosc2_free_frame(blosc2_frame *frame) {
 }
 
 
-void* new_header_frame(blosc2_schunk *schunk, blosc2_frame *frame, bool update) {
+void *new_header_frame(blosc2_schunk *schunk, blosc2_frame *frame) {
   assert(frame != NULL);
   uint8_t* h2 = calloc(FRAME_HEADER_MINLEN, 1);
   uint8_t* h2p = h2;
@@ -185,28 +148,7 @@ void* new_header_frame(blosc2_schunk *schunk, blosc2_frame *frame, bool update) 
   h2p += 1;
   assert(h2p - h2 < FRAME_HEADER_MINLEN);
 
-  // Filter flags
-  int nfilters = get_nfilters(schunk->filters);
-  // Remove the false below when a proper pipeline could be serialized properly inside the header
-  // Rational: creating a new metalayer in the middle of the header creation is not a good idea.
-  if (false && (nfilters > 1)) {
-    if (!update) {
-      // Build a new metalayer for filters just if we are not updating the frame; otherwise it is already there
-      void *metafilters = NULL;
-      int metafilters_len = filters_to_metalayer(schunk->filters, schunk->filters_meta, &metafilters);
-      int res = blosc2_add_metalayer(schunk, FRAME_FILTER_PIPELINE_NAME, metafilters,
-                                     metafilters_len);
-      if (res < 0) {
-        fprintf(stderr, "Error: problems adding the filter pipeline as a metalayer\n");
-        return NULL;
-      }
-    }
-  }
-  else {
-    // Filter pipeline described here
-    uint8_t filter_flags = filters_to_flags(schunk->filters);
-    *h2p = FRAME_FILTERS_PIPE_DESCRIBED_HERE | (uint8_t)(filter_flags << FRAME_FILTERS_PIPE_START_BIT);
-  }
+  // Reserved flags
   h2p += 1;
   assert(h2p - h2 < FRAME_HEADER_MINLEN);
 
@@ -269,17 +211,39 @@ void* new_header_frame(blosc2_schunk *schunk, blosc2_frame *frame, bool update) 
   h2p += 2;
   assert(h2p - h2 < FRAME_HEADER_MINLEN);
 
+  // The boolean for FRAME_HAS_USERMETA
+  *h2p = (schunk->usermeta_len > 0) ? (uint8_t)0xc3 : (uint8_t)0xc2;
+  h2p += 1;
+  assert(h2p - h2 < FRAME_HEADER_MINLEN);
+
+  // The space for FRAME_FILTER_PIPELINE
+  *h2p = 0xd8;  //  fixext 16
+  h2p += 1;
+  assert(BLOSC2_MAX_FILTERS <= FRAME_FILTER_PIPELINE_MAX);
+  // Store the filter pipeline in header
+  uint8_t* mp_filters = h2 + FRAME_FILTER_PIPELINE + 1;
+  uint8_t* mp_meta = h2 + FRAME_FILTER_PIPELINE + 1 + FRAME_FILTER_PIPELINE_MAX;
+  int nfilters = 0;
+  for (int i = 0; i < BLOSC2_MAX_FILTERS; i++) {
+    if (schunk->filters[i] != BLOSC_NOFILTER) {
+      mp_filters[nfilters] = schunk->filters[i];
+      mp_meta[nfilters] = schunk->filters_meta[i];
+      nfilters++;
+    }
+  }
+  *h2p = (uint8_t)nfilters;
+  h2p += 1;
+  h2p += 16;
+  assert(h2p - h2 == FRAME_HEADER_MINLEN);
+
+  int32_t hsize = FRAME_HEADER_MINLEN;
+
   // Now, deal with metalayers
   int16_t nmetalayers = schunk->nmetalayers;
   // The msgpack header will start as a fix array of 11 or 12 elements (if it has metalayers)
   *h2 = 0x90;
   *h2 += (nmetalayers > 0) ? FRAME_HEADER_NFIELDS_METALAYER : FRAME_HEADER_NFIELDS_NOMETALAYER;
-  // The boolean for FRAME_HAS_USERMETA
-  *h2p = (schunk->usermeta_len > 0) ? (uint8_t)0xc3 : (uint8_t)0xc2;
-  h2p += 1;
-  assert(h2p - h2 == FRAME_HEADER_MINLEN);
 
-  int32_t hsize = FRAME_HEADER_MINLEN;
   if (nmetalayers == 0) {
     goto out;
   }
@@ -371,7 +335,7 @@ void* new_header_frame(blosc2_schunk *schunk, blosc2_frame *frame, bool update) 
 
 int get_header_info(blosc2_frame *frame, int32_t *header_len, int64_t *frame_len, int64_t *nbytes,
                     int64_t *cbytes, int32_t *chunksize, int32_t *nchunks, int32_t *typesize,
-                    uint8_t *compcode, uint8_t *clevel, uint8_t *filters) {
+                    uint8_t *compcode, uint8_t *clevel, uint8_t *filters, uint8_t *filters_meta) {
   uint8_t* framep = frame->sdata;
   uint8_t* header = NULL;
 
@@ -396,7 +360,7 @@ int get_header_info(blosc2_frame *frame, int32_t *header_len, int64_t *frame_len
     swap_store(typesize, framep + FRAME_TYPESIZE, sizeof(*typesize));
   }
 
-  // Codecs and filters
+  // Codecs
   uint8_t frame_codecs = framep[FRAME_CODECS];
   if (clevel != NULL) {
     *clevel = frame_codecs >> 4u;
@@ -405,11 +369,18 @@ int get_header_info(blosc2_frame *frame, int32_t *header_len, int64_t *frame_len
     *compcode = frame_codecs & 0xFu;
   }
 
-  uint8_t filter_flags = framep[FRAME_FILTERS];
-  if (filters != NULL) {
-    if (filter_flags & FRAME_FILTERS_PIPE_DESCRIBED_HERE) {
-      filter_flags = (filter_flags & FRAME_FILTER_PIPE_DESCRIPTION) >> FRAME_FILTERS_PIPE_START_BIT;
-      flags_to_filters(filter_flags, filters);
+  // Filters
+  if (filters != NULL && filters_meta != NULL) {
+    uint8_t nfilters = framep[FRAME_FILTER_PIPELINE];
+    if (nfilters > BLOSC2_MAX_FILTERS) {
+      fprintf(stderr, "Error: the number of filters in frame header are too large for Blosc2");
+      return -1;
+    }
+    uint8_t *filters_ = framep + FRAME_FILTER_PIPELINE + 1;
+    uint8_t *filters_meta_ = framep + FRAME_FILTER_PIPELINE + 1 + FRAME_FILTER_PIPELINE_MAX;
+    for (int i = 0; i < nfilters; i++) {
+      filters[i] = filters_[i];
+      filters_meta[i] = filters_meta_[i];
     }
   }
 
@@ -533,7 +504,7 @@ int frame_update_trailer(blosc2_frame* frame, blosc2_schunk* schunk) {
   int32_t chunksize;
   int32_t nchunks;
   int ret = get_header_info(frame, &header_len, &frame_len, &nbytes, &cbytes, &chunksize, &nchunks,
-                            NULL, NULL, NULL, NULL);
+                            NULL, NULL, NULL, NULL, NULL);
   if (ret < 0) {
     fprintf(stderr, "unable to get meta info from frame");
     return -1;
@@ -580,7 +551,7 @@ int64_t blosc2_schunk_to_frame(blosc2_schunk *schunk, blosc2_frame *frame) {
   int64_t cbytes = schunk->cbytes;
   FILE* fp = NULL;
 
-  uint8_t* h2 = new_header_frame(schunk, frame, false);
+  uint8_t* h2 = new_header_frame(schunk, frame);
   uint32_t h2len;
   swap_store(&h2len, h2 + FRAME_HEADER_LEN, sizeof(h2len));
 
@@ -752,30 +723,6 @@ int get_offsets(blosc2_frame *frame, int32_t header_len, int64_t cbytes, int32_t
 }
 
 
-// Get the filter pipeline from the associated metalayer
-int filters_from_metalayer(blosc2_schunk* schunk, char* mlname,
-                           uint8_t* filters, uint8_t* filters_meta) {
-  uint8_t* metalayer;
-  uint32_t metalayer_len;
-  int nmetalayer = blosc2_has_metalayer(schunk, mlname);
-  if (nmetalayer < 0) {
-    return 0;
-  }
-  int rc = blosc2_get_metalayer(schunk, mlname, &metalayer, &metalayer_len);
-  if (rc < 0) {
-    return rc;
-  }
-  uint8_t nfilters = metalayer[1] & 0xFu;  // a fix array has the length in the first 4 bits
-  if (nfilters > BLOSC2_MAX_FILTERS) {
-    fprintf(stderr, "Error: number of filters in metalayer is too large\n");
-    return -1;
-  }
-  memcpy(filters, metalayer + 2, nfilters);
-  memcpy(filters_meta, metalayer + 2 + nfilters, nfilters);
-  return nfilters;
-}
-
-
 int frame_update_header(blosc2_frame* frame, blosc2_schunk* schunk, bool new) {
   uint8_t* header = frame->sdata;
 
@@ -797,7 +744,7 @@ int frame_update_header(blosc2_frame* frame, blosc2_schunk* schunk, bool new) {
   swap_store(&prev_h2len, header + FRAME_HEADER_LEN, sizeof(prev_h2len));
 
   // Build a new header
-  uint8_t* h2 = new_header_frame(schunk, frame, true);
+  uint8_t* h2 = new_header_frame(schunk, frame);
   uint32_t h2len;
   swap_store(&h2len, h2 + FRAME_HEADER_LEN, sizeof(h2len));
 
@@ -841,7 +788,7 @@ int32_t frame_get_usermeta(blosc2_frame* frame, uint8_t** usermeta) {
   int32_t chunksize;
   int32_t nchunks;
   int ret = get_header_info(frame, &header_len, &frame_len, &nbytes, &cbytes, &chunksize, &nchunks,
-                            NULL, NULL, NULL, NULL);
+                            NULL, NULL, NULL, NULL, NULL);
   if (ret < 0) {
     fprintf(stderr, "Unable to get the header info from frame");
     return -1;
@@ -903,7 +850,7 @@ int frame_get_metalayers(blosc2_frame* frame, blosc2_schunk* schunk) {
   int32_t chunksize;
   int32_t nchunks;
   int ret = get_header_info(frame, &header_len, &frame_len, &nbytes, &cbytes, &chunksize, &nchunks,
-                            NULL, NULL, NULL, NULL);
+                            NULL, NULL, NULL, NULL, NULL);
   if (ret < 0) {
     fprintf(stderr, "Unable to get the header info from frame");
     return -1;
@@ -998,7 +945,7 @@ blosc2_schunk* blosc2_schunk_from_frame(blosc2_frame* frame, bool copy) {
   schunk->frame = frame;
   int ret = get_header_info(frame, &header_len, &frame_len, &schunk->nbytes, &schunk->cbytes,
                             &schunk->chunksize, &schunk->nchunks, &schunk->typesize,
-                            &schunk->compcode, &schunk->clevel, schunk->filters);
+                            &schunk->compcode, &schunk->clevel, schunk->filters, schunk->filters_meta);
   if (ret < 0) {
     fprintf(stderr, "unable to get meta info from frame");
     return NULL;
@@ -1097,12 +1044,6 @@ blosc2_schunk* blosc2_schunk_from_frame(blosc2_frame* frame, bool copy) {
     fprintf(stderr, "Error: cannot access the metalayers");
     return NULL;
   }
-  // Now that we have access to metalayers, go and try with a possible filter pipeline metalayer
-  rc = filters_from_metalayer(schunk, FRAME_FILTER_PIPELINE_NAME, schunk->filters, schunk->filters_meta);
-  if (rc < 0) {
-    fprintf(stderr, "Error: cannot access the metalayers");
-    return NULL;
-  }
 
   usermeta_len = frame_get_usermeta(frame, &usermeta);
   if (usermeta_len < 0) {
@@ -1137,7 +1078,7 @@ int frame_get_chunk(blosc2_frame *frame, int nchunk, uint8_t **chunk, bool *need
   *chunk = NULL;
   *needs_free = false;
   int ret = get_header_info(frame, &header_len, &frame_len, &nbytes, &cbytes, &chunksize, &nchunks,
-                            NULL, NULL, NULL, NULL);
+                            NULL, NULL, NULL, NULL, NULL);
   if (ret < 0) {
     fprintf(stderr, "unable to get meta info from frame");
     return -1;
@@ -1197,7 +1138,7 @@ void* frame_append_chunk(blosc2_frame* frame, void* chunk, blosc2_schunk* schunk
   int32_t chunksize;
   int32_t nchunks;
   int rc = get_header_info(frame, &header_len, &frame_len, &nbytes, &cbytes, &chunksize, &nchunks,
-                            NULL, NULL, NULL, NULL);
+                           NULL, NULL, NULL, NULL, NULL);
   if (rc < 0) {
     fprintf(stderr, "unable to get meta info from frame");
     return NULL;
@@ -1243,7 +1184,7 @@ void* frame_append_chunk(blosc2_frame* frame, void* chunk, blosc2_schunk* schunk
   int32_t off_nbytes = (nchunks + 1) * 8;
   int64_t* offsets = malloc((size_t)off_nbytes);
   if (nchunks > 0) {
-    int rc = get_offsets(frame, header_len, cbytes, nchunks, offsets);
+    rc = get_offsets(frame, header_len, cbytes, nchunks, offsets);
     if (rc < 0) {
       fprintf(stderr, "Error: cannot get the offset for chunk %d for the frame\n", nchunks);
       return NULL;

--- a/blosc/frame.c
+++ b/blosc/frame.c
@@ -116,7 +116,7 @@ void *new_header_frame(blosc2_schunk *schunk, blosc2_frame *frame) {
 
   // The msgpack header starts here
   *h2p = 0x90;  // fixarray...
-  *h2p += 12;   // ...with 12 elements
+  *h2p += 13;   // ...with 13 elements
   h2p += 1;
 
   // Magic number

--- a/blosc/frame.c
+++ b/blosc/frame.c
@@ -143,7 +143,7 @@ void *new_header_frame(blosc2_schunk *schunk, blosc2_frame *frame) {
   assert(h2p - h2 < FRAME_HEADER_MINLEN);
 
   // General flags
-  *h2p = 0x4 + BLOSC2_VERSION_FRAME_FORMAT;  // frame + version
+  *h2p = BLOSC2_VERSION_FRAME_FORMAT;  // version
   *h2p += 0x20;  // 64-bit offsets
   h2p += 1;
   assert(h2p - h2 < FRAME_HEADER_MINLEN);

--- a/blosc/frame.h
+++ b/blosc/frame.h
@@ -37,7 +37,8 @@
 #define FRAME_TRAILER_VERSION (0U)  // can be up to 127
 #define FRAME_TRAILER_USERMETA_LEN_OFFSET (3)  // offset to usermeta length
 #define FRAME_TRAILER_USERMETA_OFFSET (7)  // offset to usermeta chunk
-#define FRAME_TRAILER_MIN_LENGTH (30)  // minimum length for the trailer (msgpack overhead)
+#define FRAME_TRAILER_MINLEN (30)  // minimum length for the trailer (msgpack overhead)
+#define FRAME_TRAILER_LEN_OFFSET (22)  // offset to trailer length (counting from the end)
 
 void* frame_append_chunk(blosc2_frame* frame, void* chunk, blosc2_schunk* schunk);
 int frame_get_chunk(blosc2_frame *frame, int nchunk, uint8_t **chunk, bool *needs_free);

--- a/blosc/frame.h
+++ b/blosc/frame.h
@@ -32,8 +32,6 @@
 
 // Other constants
 #define FRAME_FILTER_PIPELINE_MAX (8)  // the maximum number of filters that can be stored in header
-#define FRAME_HEADER_NFIELDS_NOMETALAYER (11)
-#define FRAME_HEADER_NFIELDS_METALAYER (12)
 #define FRAME_TRAILER_VERSION (0U)  // can be up to 127
 #define FRAME_TRAILER_USERMETA_LEN_OFFSET (3)  // offset to usermeta length
 #define FRAME_TRAILER_USERMETA_OFFSET (7)  // offset to usermeta chunk

--- a/blosc/frame.h
+++ b/blosc/frame.h
@@ -17,7 +17,6 @@
 #define FRAME_HEADER_LEN (FRAME_HEADER_MAGIC + 8 + 1)  // 11
 #define FRAME_LEN (FRAME_HEADER_LEN + 4 + 1)  // 16
 #define FRAME_FLAGS (FRAME_LEN + 8 + 1)  // 25
-#define FRAME_FILTERS (FRAME_FLAGS + 1)  // 26
 #define FRAME_CODECS (FRAME_FLAGS + 2)  // 27
 #define FRAME_NBYTES (FRAME_FLAGS + 4 + 1)  // 30
 #define FRAME_CBYTES (FRAME_NBYTES + 8 + 1)  // 39
@@ -26,22 +25,19 @@
 #define FRAME_NTHREADS_C (FRAME_CHUNKSIZE + 4 + 1)  // 58
 #define FRAME_NTHREADS_D (FRAME_NTHREADS_C + 2 + 1)  // 61
 #define FRAME_HAS_USERMETA (FRAME_NTHREADS_D + 2)  // 63
-#define FRAME_HEADER_MINLEN (FRAME_HAS_USERMETA + 1)  // 64 <- minimum length
-#define FRAME_METALAYERS (FRAME_HAS_USERMETA + 1)  // 64
-#define FRAME_IDX_SIZE (FRAME_METALAYERS + 1 + 1)  // 66
+#define FRAME_FILTER_PIPELINE (FRAME_HAS_USERMETA + 1 + 1) // 65
+#define FRAME_HEADER_MINLEN (FRAME_FILTER_PIPELINE + 1 + 16)  // 82 <- minimum length
+#define FRAME_METALAYERS (FRAME_HEADER_MINLEN)  // 82
+#define FRAME_IDX_SIZE (FRAME_METALAYERS + 1 + 1)  // 84
 
 // Other constants
-#define FRAME_FILTERS_PIPE_START_BIT (3U)
-#define FRAME_FILTERS_PIPE_DESCRIBED_HERE (2U)  // 0b10
-#define FRAME_FILTER_PIPE_DESCRIPTION (120U)  // 0b1111000
+#define FRAME_FILTER_PIPELINE_MAX (8)  // the maximum number of filters that can be stored in header
 #define FRAME_HEADER_NFIELDS_NOMETALAYER (11)
 #define FRAME_HEADER_NFIELDS_METALAYER (12)
 #define FRAME_TRAILER_VERSION (0U)  // can be up to 127
 #define FRAME_TRAILER_USERMETA_LEN_OFFSET (3)  // offset to usermeta length
 #define FRAME_TRAILER_USERMETA_OFFSET (7)  // offset to usermeta chunk
 #define FRAME_TRAILER_MIN_LENGTH (30)  // minimum length for the trailer (msgpack overhead)
-
-#define FRAME_FILTER_PIPELINE_NAME "_filter_pipeline"
 
 void* frame_append_chunk(blosc2_frame* frame, void* chunk, blosc2_schunk* schunk);
 int frame_get_chunk(blosc2_frame *frame, int nchunk, uint8_t **chunk, bool *needs_free);


### PR DESCRIPTION
This implements a new version of the header of the frame that supports serialization of the filter pipeline with full generality.  This supposes a breaking change with frames generated with beta.1 or before, but there will be no attempt to support the previous one.

This should be ready to go as it is now.