### PR TITLE
allow threading backend to be replaced by caller

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,12 @@ compiler:
   - gcc
   - clang
 
+# whether to test threads using callback backend
+env:
+  matrix:
+    - BLOSC_TEST_CALLBACK=yes
+    - BLOSC_TEST_CALLBACK=no
+
 before_install: ./scripts/travis-before-install.sh
 
 before_script:

--- a/blosc/blosc2.c
+++ b/blosc/blosc2.c
@@ -2137,9 +2137,9 @@ int blosc2_getitem_ctx(blosc2_context* context, const void* src, int start,
   return result;
 }
 
-
-/* Decompress & unshuffle several blocks in a single thread */
-static void* t_blosc(void* ctxt) {
+/* execute single compression/decompression job for a single thread_context */
+static void t_blosc_do_job(void *ctxt)
+{
   struct thread_context* thcontext = (struct thread_context*)ctxt;
   blosc2_context* context = thcontext->parent_context;
   int32_t cbytes;
@@ -2165,6 +2165,162 @@ static void* t_blosc(void* ctxt) {
   uint8_t* tmp;
   uint8_t* tmp2;
   uint8_t* tmp3;
+
+  /* Get parameters for this thread before entering the main loop */
+  blocksize = context->blocksize;
+  ebsize = blocksize + context->typesize * sizeof(int32_t);
+  compress = context->do_compress;
+  flags = *(context->header_flags);
+  maxbytes = context->destsize;
+  nblocks = context->nblocks;
+  leftover = context->leftover;
+  bstarts = context->bstarts;
+  src = context->src;
+  dest = context->dest;
+
+  /* Resize the temporaries if needed */
+  if (blocksize != thcontext->tmpblocksize) {
+    my_free(thcontext->tmp);
+    thcontext->tmp = my_malloc((size_t)3 * blocksize + ebsize);
+    thcontext->tmp2 = thcontext->tmp + blocksize;
+    thcontext->tmp3 = thcontext->tmp + blocksize + ebsize;
+    thcontext->tmp4 = thcontext->tmp + 2 * blocksize + ebsize;
+    thcontext->tmpblocksize = blocksize;
+  }
+
+  tmp = thcontext->tmp;
+  tmp2 = thcontext->tmp2;
+  tmp3 = thcontext->tmp3;
+
+  ntbytes = 0;                /* only useful for decompression */
+
+  if (compress && !(flags & BLOSC_MEMCPYED)) {
+    /* Compression always has to follow the block order */
+    pthread_mutex_lock(&context->count_mutex);
+    context->thread_nblock++;
+    nblock_ = context->thread_nblock;
+    pthread_mutex_unlock(&context->count_mutex);
+    tblock = nblocks;
+  }
+  else {
+    /* Decompression can happen using any order.  We choose
+      sequential block order on each thread */
+
+    /* Blocks per thread */
+    tblocks = nblocks / context->nthreads;
+    leftover2 = nblocks % context->nthreads;
+    tblocks = (leftover2 > 0) ? tblocks + 1 : tblocks;
+
+    nblock_ = thcontext->tid * tblocks;
+    tblock = nblock_ + tblocks;
+    if (tblock > nblocks) {
+      tblock = nblocks;
+    }
+  }
+
+  /* Loop over blocks */
+  leftoverblock = 0;
+  while ((nblock_ < tblock) &&
+          (context->thread_giveup_code > 0)) {
+    bsize = blocksize;
+    if (nblock_ == (nblocks - 1) && (leftover > 0)) {
+      bsize = leftover;
+      leftoverblock = 1;
+    }
+    if (compress) {
+      if (flags & BLOSC_MEMCPYED) {
+        /* We want to memcpy only */
+        fastcopy(dest + BLOSC_MAX_OVERHEAD + nblock_ * blocksize,
+                  src + nblock_ * blocksize, (unsigned int)bsize);
+        cbytes = (int32_t)bsize;
+      }
+      else {
+        /* Regular compression */
+        if (context->clevel == 0) {
+          // We can copy straight to destination, as we know where we can write
+          tmp2 = dest + BLOSC_MAX_OVERHEAD + nblock_ * blocksize;
+        }
+        cbytes = blosc_c(thcontext, bsize, leftoverblock, 0,
+                          ebsize, src, nblock_ * blocksize, tmp2, tmp, tmp3);
+      }
+    }
+    else {
+      if (flags & BLOSC_MEMCPYED) {
+        /* We want to memcpy only */
+        fastcopy(dest + nblock_ * blocksize,
+                  src + BLOSC_MAX_OVERHEAD + nblock_ * blocksize, (unsigned int)bsize);
+        cbytes = (int32_t)bsize;
+      }
+      else {
+        cbytes = blosc_d(thcontext, bsize, leftoverblock,
+                          src + sw32_(bstarts + nblock_),
+                          dest, nblock_ * blocksize, tmp, tmp2);
+      }
+    }
+
+    /* Check whether current thread has to giveup */
+    if (context->thread_giveup_code <= 0) {
+      break;
+    }
+
+    /* Check results for the compressed/decompressed block */
+    if (cbytes < 0) {            /* compr/decompr failure */
+      /* Set giveup_code error */
+      pthread_mutex_lock(&context->count_mutex);
+      context->thread_giveup_code = cbytes;
+      pthread_mutex_unlock(&context->count_mutex);
+      break;
+    }
+
+    if (compress && !(flags & BLOSC_MEMCPYED)) {
+      /* Start critical section */
+      pthread_mutex_lock(&context->count_mutex);
+      ntdest = context->output_bytes;
+      // Note: do not use a typical local dict_training variable here
+      // because it is probably cached from previous calls if the number of
+      // threads does not change (the usual thing).
+      if (!(context->use_dict && context->dict_cdict == NULL) && context->clevel != 0) {
+        _sw32(bstarts + nblock_, (int32_t) ntdest);
+      }
+
+      if ((cbytes == 0) || (ntdest + cbytes > maxbytes)) {
+        context->thread_giveup_code = 0;  /* uncompressible buf */
+        pthread_mutex_unlock(&context->count_mutex);
+        break;
+      }
+      context->thread_nblock++;
+      nblock_ = context->thread_nblock;
+      context->output_bytes += cbytes;
+      pthread_mutex_unlock(&context->count_mutex);
+      /* End of critical section */
+
+      /* Copy the compressed buffer to destination */
+      if (context->clevel != 0) {
+        // We can avoid the copy when clevel == 0 (already copied)
+        fastcopy(dest + ntdest, tmp2, (unsigned int) cbytes);
+      }
+    }
+    else {
+      nblock_++;
+      /* Update counter for this thread */
+      ntbytes += cbytes;
+    }
+
+  } /* closes while (nblock_) */
+
+  /* Sum up all the bytes decompressed */
+  if ((!compress || (flags & BLOSC_MEMCPYED)) && (context->thread_giveup_code > 0)) {
+    /* Update global counter for all threads (decompression only) */
+    pthread_mutex_lock(&context->count_mutex);
+    context->output_bytes += ntbytes;
+    pthread_mutex_unlock(&context->count_mutex);
+  }
+}
+
+/* Decompress & unshuffle several blocks in a single thread */
+static void* t_blosc(void* ctxt) {
+  struct thread_context* thcontext = (struct thread_context*)ctxt;
+  blosc2_context* context = thcontext->parent_context;
 #ifdef BLOSC_POSIX_BARRIERS
   int rc;
 #endif
@@ -2177,155 +2333,7 @@ static void* t_blosc(void* ctxt) {
       break;
     }
 
-    /* Get parameters for this thread before entering the main loop */
-    blocksize = context->blocksize;
-    ebsize = blocksize + context->typesize * sizeof(int32_t);
-    compress = context->do_compress;
-    flags = *(context->header_flags);
-    maxbytes = context->destsize;
-    nblocks = context->nblocks;
-    leftover = context->leftover;
-    bstarts = context->bstarts;
-    src = context->src;
-    dest = context->dest;
-
-    /* Resize the temporaries if needed */
-    if (blocksize != thcontext->tmpblocksize) {
-      my_free(thcontext->tmp);
-      thcontext->tmp = my_malloc((size_t)3 * blocksize + ebsize);
-      thcontext->tmp2 = thcontext->tmp + blocksize;
-      thcontext->tmp3 = thcontext->tmp + blocksize + ebsize;
-      thcontext->tmp4 = thcontext->tmp + 2 * blocksize + ebsize;
-      thcontext->tmpblocksize = blocksize;
-    }
-
-    tmp = thcontext->tmp;
-    tmp2 = thcontext->tmp2;
-    tmp3 = thcontext->tmp3;
-
-    ntbytes = 0;                /* only useful for decompression */
-
-    if (compress && !(flags & BLOSC_MEMCPYED)) {
-      /* Compression always has to follow the block order */
-      pthread_mutex_lock(&context->count_mutex);
-      context->thread_nblock++;
-      nblock_ = context->thread_nblock;
-      pthread_mutex_unlock(&context->count_mutex);
-      tblock = nblocks;
-    }
-    else {
-      /* Decompression can happen using any order.  We choose
-       sequential block order on each thread */
-
-      /* Blocks per thread */
-      tblocks = nblocks / context->nthreads;
-      leftover2 = nblocks % context->nthreads;
-      tblocks = (leftover2 > 0) ? tblocks + 1 : tblocks;
-
-      nblock_ = thcontext->tid * tblocks;
-      tblock = nblock_ + tblocks;
-      if (tblock > nblocks) {
-        tblock = nblocks;
-      }
-    }
-
-    /* Loop over blocks */
-    leftoverblock = 0;
-    while ((nblock_ < tblock) &&
-            (context->thread_giveup_code > 0)) {
-      bsize = blocksize;
-      if (nblock_ == (nblocks - 1) && (leftover > 0)) {
-        bsize = leftover;
-        leftoverblock = 1;
-      }
-      if (compress) {
-        if (flags & BLOSC_MEMCPYED) {
-          /* We want to memcpy only */
-          fastcopy(dest + BLOSC_MAX_OVERHEAD + nblock_ * blocksize,
-                   src + nblock_ * blocksize, (unsigned int)bsize);
-          cbytes = (int32_t)bsize;
-        }
-        else {
-          /* Regular compression */
-          if (context->clevel == 0) {
-            // We can copy straight to destination, as we know where we can write
-            tmp2 = dest + BLOSC_MAX_OVERHEAD + nblock_ * blocksize;
-          }
-          cbytes = blosc_c(thcontext, bsize, leftoverblock, 0,
-                           ebsize, src, nblock_ * blocksize, tmp2, tmp, tmp3);
-        }
-      }
-      else {
-        if (flags & BLOSC_MEMCPYED) {
-          /* We want to memcpy only */
-          fastcopy(dest + nblock_ * blocksize,
-                   src + BLOSC_MAX_OVERHEAD + nblock_ * blocksize, (unsigned int)bsize);
-          cbytes = (int32_t)bsize;
-        }
-        else {
-          cbytes = blosc_d(thcontext, bsize, leftoverblock,
-                           src + sw32_(bstarts + nblock_),
-                           dest, nblock_ * blocksize, tmp, tmp2);
-        }
-      }
-
-      /* Check whether current thread has to giveup */
-      if (context->thread_giveup_code <= 0) {
-        break;
-      }
-
-      /* Check results for the compressed/decompressed block */
-      if (cbytes < 0) {            /* compr/decompr failure */
-        /* Set giveup_code error */
-        pthread_mutex_lock(&context->count_mutex);
-        context->thread_giveup_code = cbytes;
-        pthread_mutex_unlock(&context->count_mutex);
-        break;
-      }
-
-      if (compress && !(flags & BLOSC_MEMCPYED)) {
-        /* Start critical section */
-        pthread_mutex_lock(&context->count_mutex);
-        ntdest = context->output_bytes;
-        // Note: do not use a typical local dict_training variable here
-        // because it is probably cached from previous calls if the number of
-        // threads does not change (the usual thing).
-        if (!(context->use_dict && context->dict_cdict == NULL) && context->clevel != 0) {
-          _sw32(bstarts + nblock_, (int32_t) ntdest);
-        }
-
-        if ((cbytes == 0) || (ntdest + cbytes > maxbytes)) {
-          context->thread_giveup_code = 0;  /* uncompressible buf */
-          pthread_mutex_unlock(&context->count_mutex);
-          break;
-        }
-        context->thread_nblock++;
-        nblock_ = context->thread_nblock;
-        context->output_bytes += cbytes;
-        pthread_mutex_unlock(&context->count_mutex);
-        /* End of critical section */
-
-        /* Copy the compressed buffer to destination */
-        if (context->clevel != 0) {
-          // We can avoid the copy when clevel == 0 (already copied)
-          fastcopy(dest + ntdest, tmp2, (unsigned int) cbytes);
-        }
-      }
-      else {
-        nblock_++;
-        /* Update counter for this thread */
-        ntbytes += cbytes;
-      }
-
-    } /* closes while (nblock_) */
-
-    /* Sum up all the bytes decompressed */
-    if ((!compress || (flags & BLOSC_MEMCPYED)) && (context->thread_giveup_code > 0)) {
-      /* Update global counter for all threads (decompression only) */
-      pthread_mutex_lock(&context->count_mutex);
-      context->output_bytes += ntbytes;
-      pthread_mutex_unlock(&context->count_mutex);
-    }
+    t_blosc_do_job(ctxt);
 
     /* Meeting point for all threads (wait for finalization) */
     WAIT_FINISH(NULL, context);

--- a/blosc/blosc2.c
+++ b/blosc/blosc2.c
@@ -1183,7 +1183,7 @@ create_thread_context(blosc2_context* context, int32_t tid) {
 }
 
 /* free members of thread_context, but not thread_context itself */
-static void _free_thread_context(struct thread_context* thread_context) {
+static void destroy_thread_context(struct thread_context* thread_context) {
   my_free(thread_context->tmp);
 #if defined(HAVE_ZSTD)
   if (thread_context->zstd_cctx != NULL) {
@@ -1201,7 +1201,7 @@ static void _free_thread_context(struct thread_context* thread_context) {
 }
 
 void free_thread_context(struct thread_context* thread_context) {
-  _free_thread_context(thread_context);
+  destroy_thread_context(thread_context);
   my_free(thread_context);
 }
 
@@ -2705,7 +2705,7 @@ int release_threadpool(blosc2_context *context) {
     if (threads_callback) {
       /* free context data for user-managed threads */
       for (t=0; t<context->threads_started; t++)
-        _free_thread_context(context->thread_contexts + t);
+        destroy_thread_context(context->thread_contexts + t);
       my_free(context->thread_contexts);
     }
     else {

--- a/blosc/blosc2.h
+++ b/blosc/blosc2.h
@@ -380,8 +380,9 @@ BLOSC_EXPORT int blosc_getitem(const void* src, int start, int nitems, void* des
 
 /**
   Pointer to a callback function that executes `dojob(jobdata + i*jobdata_elsize)` for `i = 0 to numjobs-1`,
-  possibly in parallel threads (but not returning until all `dojob` calls have returned.   This allows the
+  possibly in parallel threads (but not returning until all `dojob` calls have returned).   This allows the
   caller to provide a custom threading backend as an alternative to the default Blosc-managed threads.
+  `callback_data` is passed through from `blosc_set_threads_callback`.
  */
 typedef void (*blosc_threads_callback)(void *callback_data, void (*dojob)(void *), int numjobs, size_t jobdata_elsize, void *jobdata);
 

--- a/blosc/blosc2.h
+++ b/blosc/blosc2.h
@@ -379,6 +379,22 @@ BLOSC_EXPORT int blosc_getitem(const void* src, int start, int nitems, void* des
 
 
 /**
+  Pointer to a callback function that executes `dojob(jobdata + i*jobdata_elsize)` for `i = 0 to numjobs-1`,
+  possibly in parallel threads (but not returning until all `dojob` calls have returned.   This allows the
+  caller to provide a custom threading backend as an alternative to the default Blosc-managed threads.
+ */
+typedef void (*blosc_threads_callback)(void *callback_data, void (*dojob)(void *), int numjobs, size_t jobdata_elsize, void *jobdata);
+
+/**
+  Set the threading backend for parallel compression/decompression to use `callback` to execute work
+  instead of using the Blosc-managed threads.   This function is *not* thread-safe and should be called
+  before any other Blosc function: it affects all Blosc contexts.  Passing `NULL` uses the default
+  Blosc threading backend.  The `callback_data` argument is passed through to the callback.
+ */
+BLOSC_EXPORT void blosc_set_threads_callback(blosc_threads_callback callback, void *callback_data);
+
+
+/**
  * @brief Returns the current number of threads that are used for
  * compression/decompression.
  */

--- a/blosc/context.h
+++ b/blosc/context.h
@@ -96,6 +96,7 @@ struct blosc2_context_s {
   int threads_started;
   int end_threads;
   pthread_t *threads;
+  struct thread_context **thread_contexts; /* only for user-managed threads */
   pthread_mutex_t count_mutex;
 #ifdef BLOSC_POSIX_BARRIERS
   pthread_barrier_t barr_init;

--- a/blosc/context.h
+++ b/blosc/context.h
@@ -96,7 +96,7 @@ struct blosc2_context_s {
   int threads_started;
   int end_threads;
   pthread_t *threads;
-  struct thread_context **thread_contexts; /* only for user-managed threads */
+  struct thread_context *thread_contexts; /* only for user-managed threads */
   pthread_mutex_t count_mutex;
 #ifdef BLOSC_POSIX_BARRIERS
   pthread_barrier_t barr_init;

--- a/tests/test_api.c
+++ b/tests/test_api.c
@@ -101,6 +101,7 @@ static char* all_tests() {
 int main() {
   char* result;
 
+  install_blosc_callback_test(); /* optionally install callback test */
   blosc_init();
   blosc_set_nthreads(1);
 

--- a/tests/test_change_nthreads_append.c
+++ b/tests/test_change_nthreads_append.c
@@ -103,6 +103,7 @@ int main(int argc, char **argv) {
     printf("STARTING TESTS for %s", argv[0]);
   }
 
+  install_blosc_callback_test(); /* optionally install callback test */
   blosc_init();
 
   /* Run all the suite */

--- a/tests/test_common.h
+++ b/tests/test_common.h
@@ -154,4 +154,22 @@ inline static void blosc_test_print_bad_arg_msg(const int32_t arg_index) {
   fprintf(stderr, "Invalid value specified for argument at index %d.\n", arg_index);
 }
 
+/* dummy callback backend for testing purposes */
+/* serial "threads" backend */
+static void dummy_threads_callback(void *callback_data, void (*dojob)(void *), int numjobs, size_t jobdata_elsize, void *jobdata)
+{
+  int i;
+  (void) callback_data; /* unused */
+  for (i = 0; i < numjobs; ++i)
+    dojob(((char *) jobdata) + ((unsigned) i)*jobdata_elsize);
+}
+/* install the callback if environment variable BLOSC_TEST_CALLBACK="yes" */
+static void install_blosc_callback_test(void)
+{
+  char *callback_env;
+  callback_env = getenv("BLOSC_TEST_CALLBACK");
+  if (callback_env && !strcmp(callback_env, "yes"))
+    blosc_set_threads_callback(dummy_threads_callback, NULL);
+}
+
 #endif  /* !defined(BLOSC_TEST_COMMON_H) */

--- a/tests/test_compress_roundtrip.c
+++ b/tests/test_compress_roundtrip.c
@@ -108,6 +108,7 @@ int main(int argc, char** argv) {
   }
 
   /* Initialize blosc before running tests. */
+  install_blosc_callback_test(); /* optionally install callback test */
   blosc_init();
   blosc_set_nthreads(blosc_thread_count);
 

--- a/tests/test_contexts.c
+++ b/tests/test_contexts.c
@@ -33,6 +33,8 @@ int main() {
   printf("Blosc version info: %s (%s)\n",
          BLOSC_VERSION_STRING, BLOSC_VERSION_DATE);
 
+  install_blosc_callback_test(); /* optionally install callback test */
+
   /* Create a context for compression */
   cparams.typesize = sizeof(int32_t);
   cparams.compcode = BLOSC_BLOSCLZ;

--- a/tests/test_delta_schunk.c
+++ b/tests/test_delta_schunk.c
@@ -28,6 +28,7 @@ int main() {
          BLOSC_VERSION_STRING, BLOSC_VERSION_DATE);
 
   /* Initialize the Blosc compressor */
+  install_blosc_callback_test(); /* optionally install callback test */
   blosc_init();
 
   /* Create a super-chunk container */

--- a/tests/test_nthreads.c
+++ b/tests/test_nthreads.c
@@ -86,6 +86,7 @@ int main() {
   /* Activate the BLOSC_NTHREADS variable */
   setenv("BLOSC_NTHREADS", "3", 1);
 
+  install_blosc_callback_test(); /* optionally install callback test */
   blosc_init();
   blosc_set_nthreads(1);
 

--- a/tests/test_prefilter.c
+++ b/tests/test_prefilter.c
@@ -135,6 +135,8 @@ int main() {
     data2[i] = i * 2;
   }
 
+  install_blosc_callback_test(); /* optionally install callback test */
+
   /* Create a context for compression */
   cparams = BLOSC2_CPARAMS_DEFAULTS;
   cparams.typesize = sizeof(int32_t);

--- a/tests/test_schunk.c
+++ b/tests/test_schunk.c
@@ -134,6 +134,7 @@ static char *all_tests() {
 int main() {
   char *result;
 
+  install_blosc_callback_test(); /* optionally install callback test */
   blosc_init();
 
   /* Run all the suite */


### PR DESCRIPTION
This PR adds a new function `blosc_set_threads_callback` that allows the caller to register a callback in order to change the threading backend at runtime — instead of spawning its own threads and passing work to them with a mutex, Blosc will pass an array of work (an array of `thread_context*`)  to the callback, which can execute the work in serial or in parallel using whatever mechanism it wants.

Motivation: this allows Blosc threading to be *composable* with caller multithreading, instead of having Blosc and the caller fight over the same CPUs.    In particular, this enables Blosc threading to be composable with:

* Julia's [new partr threading scheduler](https://julialang.org/blog/2019/07/multithreading).
* Callers using [Intels's Threading Building Blocks (TBB)](https://en.wikipedia.org/wiki/Threading_Building_Blocks).
* Callers using Cilk, OpenMP, etcetera.

The design and implementation is very similar to the new pluggable threading backend for FFTW (FFTW/fftw3#175), which worked out very well for us.   Aside from a trivial refactoring of the `t_blosc` function, the actual new code seems pretty minimal — only a couple of dozen lines, with a practical overhead of a single `if` statement in the `parallel_blosc` function for people not using this feature.

Marking it as a WIP since I haven't tested it yet other than checking that it compiles, but I wanted to get some early feedback.   (Moved from Blosc/c-blosc#276)