### PR TITLE
const-qualify static strings

### DIFF
--- a/blosc/blosc2.c
+++ b/blosc/blosc2.c
@@ -206,7 +206,7 @@ static int compname_to_clibcode(const char* compname) {
 }
 
 /* Return the library name associated with the compressor code */
-static char* clibcode_to_clibname(int clibcode) {
+static const char* clibcode_to_clibname(int clibcode) {
   if (clibcode == BLOSC_BLOSCLZ_LIB) return BLOSC_BLOSCLZ_LIBNAME;
   if (clibcode == BLOSC_LZ4_LIB) return BLOSC_LZ4_LIBNAME;
   if (clibcode == BLOSC_LIZARD_LIB) return BLOSC_LIZARD_LIBNAME;
@@ -222,9 +222,9 @@ static char* clibcode_to_clibname(int clibcode) {
  */
 
 /* Get the compressor name associated with the compressor code */
-int blosc_compcode_to_compname(int compcode, char** compname) {
+int blosc_compcode_to_compname(int compcode, const char** compname) {
   int code = -1;    /* -1 means non-existent compressor code */
-  char* name = NULL;
+  const char* name = NULL;
 
   /* Map the compressor code */
   if (compcode == BLOSC_BLOSCLZ)
@@ -678,7 +678,7 @@ static int blosc_c(struct thread_context* thread_context, int32_t bsize,
   int32_t ctbytes = 0;              /* number of compressed bytes in block */
   int64_t maxout;
   int32_t typesize = context->typesize;
-  char* compname;
+  const char* compname;
   int accel;
   const uint8_t* _src;
   uint8_t *_tmp = tmp, *_tmp2 = tmp2, *_tmp3 = thread_context->tmp4;
@@ -924,7 +924,7 @@ static int blosc_d(
   int32_t ntbytes = 0;           /* number of uncompressed bytes in block */
   uint8_t* _dest;
   int32_t typesize = context->typesize;
-  char* compname;
+  const char* compname;
   int last_filter_index = last_filter(filters, 'd');
 
   if ((last_filter_index >= 0) &&
@@ -1478,7 +1478,7 @@ static int write_compression_header(blosc2_context* context,
 #endif /*  HAVE_ZSTD */
 
     default: {
-      char* compname;
+      const char* compname;
       compname = clibcode_to_clibname(compformat);
       fprintf(stderr, "Blosc has not been compiled with '%s' ", compname);
       fprintf(stderr, "compression support.  Please use one having it.");
@@ -1656,7 +1656,7 @@ int blosc2_compress_ctx(blosc2_context* context, size_t nbytes,
   if (context->use_dict && context->dict_cdict == NULL) {
 
     if (context->compcode != BLOSC_ZSTD) {
-      char* compname;
+      const char* compname;
       compname = clibcode_to_clibname(context->compcode);
       fprintf(stderr, "Codec %s does not support dicts.  Giving up.\n",
               compname);
@@ -1835,7 +1835,7 @@ int blosc_compress(int clevel, int doshuffle, size_t typesize, size_t nbytes,
   if (envvar != NULL) {
     // TODO: here is the only place that returns an extended header from
     //   a blosc_compress() call.  This should probably be fixed.
-    char *compname;
+    const char *compname;
     blosc2_context *cctx;
     blosc2_cparams cparams = BLOSC2_CPARAMS_DEFAULTS;
 
@@ -2418,9 +2418,9 @@ int blosc_set_nthreads(int nthreads_new) {
 }
 
 
-char* blosc_get_compressor(void)
+const char* blosc_get_compressor(void)
 {
-  char* compname;
+  const char* compname;
   blosc_compcode_to_compname(g_compressor, &compname);
 
   return compname;
@@ -2446,7 +2446,7 @@ void blosc_set_delta(int dodelta) {
 
 }
 
-char* blosc_list_compressors(void) {
+const char* blosc_list_compressors(void) {
   static int compressors_list_done = 0;
   static char ret[256];
 
@@ -2480,17 +2480,15 @@ char* blosc_list_compressors(void) {
 }
 
 
-char* blosc_get_version_string(void) {
-  static char ret[256];
-  strcpy(ret, BLOSC_VERSION_STRING);
-  return ret;
+const char* blosc_get_version_string(void) {
+  return BLOSC_VERSION_STRING;
 }
 
 
-int blosc_get_complib_info(char* compname, char** complib, char** version) {
+int blosc_get_complib_info(const char* compname, char** complib, char** version) {
   int clibcode;
-  char* clibname;
-  char* clibversion = "unknown";
+  const char* clibname;
+  const char* clibversion = "unknown";
 
 #if (defined(HAVE_LZ4) && defined(LZ4_VERSION_MAJOR)) || \
   (defined(HAVE_LIZARD) && defined(LIZARD_VERSION_MAJOR)) || \
@@ -2588,10 +2586,10 @@ void blosc_cbuffer_versions(const void* cbuffer, int* version,
 
 
 /* Return the compressor library/format used in a compressed buffer. */
-char* blosc_cbuffer_complib(const void* cbuffer) {
+const char* blosc_cbuffer_complib(const void* cbuffer) {
   uint8_t* _src = (uint8_t*)(cbuffer);  /* current pos for source buffer */
   int clibcode;
-  char* complib;
+  const char* complib;
 
   /* Read the compressor format/library info */
   clibcode = (_src[2] & 0xe0) >> 5;

--- a/blosc/blosc2.h
+++ b/blosc/blosc2.h
@@ -403,7 +403,7 @@ BLOSC_EXPORT int blosc_set_nthreads(int nthreads);
  *
  * @return The string identifying the compressor being used.
  */
-BLOSC_EXPORT char* blosc_get_compressor(void);
+BLOSC_EXPORT const char* blosc_get_compressor(void);
 
 
 /**
@@ -440,7 +440,7 @@ BLOSC_EXPORT void blosc_set_delta(int dodelta);
  * @return The compressor code. If the compressor code is not recognized,
  * or there is not support for it in this build, -1 is returned.
  */
-BLOSC_EXPORT int blosc_compcode_to_compname(int compcode, char** compname);
+BLOSC_EXPORT int blosc_compcode_to_compname(int compcode, const char** compname);
 
 
 /**
@@ -465,7 +465,7 @@ BLOSC_EXPORT int blosc_compname_to_compcode(const char* compname);
  *
  * This function should always succeed.
  */
-BLOSC_EXPORT char* blosc_list_compressors(void);
+BLOSC_EXPORT const char* blosc_list_compressors(void);
 
 
 /**
@@ -474,7 +474,7 @@ BLOSC_EXPORT char* blosc_list_compressors(void);
  * @return The string with the current Blosc version.
  * Useful for dynamic libraries.
  */
-BLOSC_EXPORT char* blosc_get_version_string(void);
+BLOSC_EXPORT const char* blosc_get_version_string(void);
 
 
 /**
@@ -492,7 +492,7 @@ BLOSC_EXPORT char* blosc_get_version_string(void);
  * @return The code for the compression library (>=0). If it is not supported,
  * this function returns -1.
  */
-BLOSC_EXPORT int blosc_get_complib_info(char* compname, char** complib,
+BLOSC_EXPORT int blosc_get_complib_info(const char* compname, char** complib,
                                         char** version);
 
 
@@ -574,7 +574,7 @@ BLOSC_EXPORT void blosc_cbuffer_versions(const void* cbuffer, int* version,
  *
  * This function should always succeed.
  */
-BLOSC_EXPORT char* blosc_cbuffer_complib(const void* cbuffer);
+BLOSC_EXPORT const char* blosc_cbuffer_complib(const void* cbuffer);
 
 
 /*********************************************************************
@@ -962,7 +962,7 @@ BLOSC_EXPORT int blosc2_schunk_get_dparams(blosc2_schunk *schunk, blosc2_dparams
  *
  * @return If successful, return the index of the metalayer. Else, return a negative value.
  */
-BLOSC_EXPORT int blosc2_has_metalayer(blosc2_schunk *schunk, char *name);
+BLOSC_EXPORT int blosc2_has_metalayer(blosc2_schunk *schunk, const char *name);
 
 /**
  * @brief Add content into a new metalayer.
@@ -974,7 +974,7 @@ BLOSC_EXPORT int blosc2_has_metalayer(blosc2_schunk *schunk, char *name);
  *
  * @return If successful, the index of the new metalayer. Else, return a negative value.
  */
-BLOSC_EXPORT int blosc2_add_metalayer(blosc2_schunk *schunk, char *name, uint8_t *content,
+BLOSC_EXPORT int blosc2_add_metalayer(blosc2_schunk *schunk, const char *name, uint8_t *content,
                                       uint32_t content_len);
 
 /**
@@ -990,7 +990,7 @@ BLOSC_EXPORT int blosc2_add_metalayer(blosc2_schunk *schunk, char *name, uint8_t
  *
  * @return If successful, the index of the metalayer. Else, return a negative value.
  */
-BLOSC_EXPORT int blosc2_update_metalayer(blosc2_schunk *schunk, char *name, uint8_t *content,
+BLOSC_EXPORT int blosc2_update_metalayer(blosc2_schunk *schunk, const char *name, uint8_t *content,
                                          uint32_t content_len);
 
 /**
@@ -1006,7 +1006,7 @@ BLOSC_EXPORT int blosc2_update_metalayer(blosc2_schunk *schunk, char *name, uint
  *
  * @return If successful, the index of the new metalayer. Else, return a negative value.
  */
-BLOSC_EXPORT int blosc2_get_metalayer(blosc2_schunk *schunk, char *name, uint8_t **content,
+BLOSC_EXPORT int blosc2_get_metalayer(blosc2_schunk *schunk, const char *name, uint8_t **content,
                                       uint32_t *content_len);
 
 
@@ -1057,7 +1057,7 @@ BLOSC_EXPORT int blosc2_get_usermeta(blosc2_schunk* schunk, uint8_t** content);
  *
  * @return The new frame.
  */
-BLOSC_EXPORT blosc2_frame* blosc2_new_frame(char* fname);
+BLOSC_EXPORT blosc2_frame* blosc2_new_frame(const char* fname);
 
 /**
  * @brief Create a frame from a super-chunk.
@@ -1092,7 +1092,7 @@ BLOSC_EXPORT int blosc2_free_frame(blosc2_frame *frame);
  * @return The size of the frame.  If negative, an error happened (including
  * that the original frame is not in-memory).
  */
-BLOSC_EXPORT int64_t blosc2_frame_to_file(blosc2_frame *frame, char *fname);
+BLOSC_EXPORT int64_t blosc2_frame_to_file(blosc2_frame *frame, const char *fname);
 
 /**
  * @brief Initialize a frame out of a file.

--- a/blosc/frame.c
+++ b/blosc/frame.c
@@ -81,7 +81,7 @@ void swap_store(void *dest, const void *pa, int size) {
 
 
 /* Create a new (empty) frame */
-blosc2_frame* blosc2_new_frame(char* fname) {
+blosc2_frame* blosc2_new_frame(const char* fname) {
   blosc2_frame* new_frame = malloc(sizeof(blosc2_frame));
   memset(new_frame, 0, sizeof(blosc2_frame));
   if (fname != NULL) {
@@ -618,7 +618,7 @@ int64_t blosc2_schunk_to_frame(blosc2_schunk *schunk, blosc2_frame *frame) {
 
 
 /* Write an in-memory frame out to a file. */
-int64_t blosc2_frame_to_file(blosc2_frame *frame, char *fname) {
+int64_t blosc2_frame_to_file(blosc2_frame *frame, const char *fname) {
     // make sure that we are using an in-memory frame
     if (frame->fname != NULL) {
       fprintf(stderr, "Error: the original frame must be in-memory");

--- a/blosc/schunk.c
+++ b/blosc/schunk.c
@@ -290,7 +290,7 @@ int blosc2_schunk_get_chunk(blosc2_schunk *schunk, int nchunk, uint8_t **chunk, 
  *
  * If successful, return the index of the metalayer.  Else, return a negative value.
  */
-int blosc2_has_metalayer(blosc2_schunk *schunk, char *name) {
+int blosc2_has_metalayer(blosc2_schunk *schunk, const char *name) {
   if (strlen(name) > BLOSC2_METALAYER_NAME_MAXLEN) {
     fprintf(stderr, "metalayers cannot be larger than %d chars\n", BLOSC2_METALAYER_NAME_MAXLEN);
     return -1;
@@ -340,7 +340,7 @@ int metalayer_flush(blosc2_schunk* schunk) {
  *
  * If successful, return the index of the new metalayer.  Else, return a negative value.
  */
-int blosc2_add_metalayer(blosc2_schunk *schunk, char *name, uint8_t *content, uint32_t content_len) {
+int blosc2_add_metalayer(blosc2_schunk *schunk, const char *name, uint8_t *content, uint32_t content_len) {
   int nmetalayer = blosc2_has_metalayer(schunk, name);
   if (nmetalayer >= 0) {
     fprintf(stderr, "metalayer \"%s\" already exists", name);
@@ -372,7 +372,7 @@ int blosc2_add_metalayer(blosc2_schunk *schunk, char *name, uint8_t *content, ui
  *
  * If successful, return the index of the new metalayer.  Else, return a negative value.
  */
-int blosc2_update_metalayer(blosc2_schunk *schunk, char *name, uint8_t *content, uint32_t content_len) {
+int blosc2_update_metalayer(blosc2_schunk *schunk, const char *name, uint8_t *content, uint32_t content_len) {
   int nmetalayer = blosc2_has_metalayer(schunk, name);
   if (nmetalayer < 0) {
     fprintf(stderr, "metalayer \"%s\" not found\n", name);
@@ -407,7 +407,7 @@ int blosc2_update_metalayer(blosc2_schunk *schunk, char *name, uint8_t *content,
  *
  * If successful, return the index of the new metalayer.  Else, return a negative value.
  */
-int blosc2_get_metalayer(blosc2_schunk *schunk, char *name, uint8_t **content,
+int blosc2_get_metalayer(blosc2_schunk *schunk, const char *name, uint8_t **content,
                          uint32_t *content_len) {
   int nmetalayer = blosc2_has_metalayer(schunk, name);
   if (nmetalayer < 0) {

--- a/tests/test_api.c
+++ b/tests/test_api.c
@@ -56,7 +56,7 @@ static char* test_cbuffer_versions() {
 
 
 static char* test_cbuffer_complib() {
-  char* complib;
+  const char* complib;
 
   complib = blosc_cbuffer_complib(dest);
   mu_assert("ERROR: complib incorrect", strcmp(complib, "BloscLZ") == 0);

--- a/tests/test_compressor.c
+++ b/tests/test_compressor.c
@@ -24,7 +24,7 @@ size_t size = 8 * 1000 * 1000;  /* must be divisible by typesize */
 
 /* Check compressor */
 static char *test_compressor() {
-  char* compressor;
+  const char* compressor;
 
   /* Before any blosc_compress() the compressor must be blosclz */
   compressor = blosc_get_compressor();
@@ -51,7 +51,7 @@ static char *test_compressor() {
 
 /* Check compressing + decompressing */
 static char *test_compress_decompress() {
-  char* compressor;
+  const char* compressor;
 
   /* Activate the BLOSC_COMPRESSOR variable */
   setenv("BLOSC_COMPRESSOR", "lz4", 0);


### PR DESCRIPTION
This is a minor PR that changes `char*` declarations to `const char*` wherever they refer to static strings or string literals.  This is useful for two cases especially:

* In a function like `blosc2_frame_from_file(const char *fname)` that takes a string as an argument, it makes it explicit that Blosc does not take "ownership" of the pointer (it internally allocates its own copy if needed in all such functions that I changed).  Also, it eliminates [deprecation warnings in C++](https://stackoverflow.com/questions/13690306/conversion-from-string-literal-to-char-is-deprecated) if one passes a string literal for such arguments.

* In a function like `const char* blosc_get_version_string(void)`, it makes it clear that the caller should not call `free` on the returned pointer.