### PR TITLE
Enable ALTIVEC extension regardless to the version of gcc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: bionic
 sudo: required
 
 language: c

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-dist: bionic
 sudo: required
 
 language: c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -287,11 +287,11 @@ elseif (CMAKE_SYSTEM_PROCESSOR STREQUAL armv7l OR
         message(WARNING "Unable to determine which ${CMAKE_SYSTEM_PROCESSOR} hardware features are supported by the C compiler (${CMAKE_C_COMPILER_ID} ${CMAKE_C_COMPILER_VERSION}).")
     endif ()
 elseif (CMAKE_SYSTEM_PROCESSOR STREQUAL ppc64le)
-	if (CMAKE_C_COMPILER_ID STREQUAL GNU)
-		set(COMPILER_SUPPORT_ALTIVEC TRUE)
-	else ()
-		set(COMPILER_SUPPORT_ALTIVEC FALSE)
-	endif ()
+    if (CMAKE_C_COMPILER_ID STREQUAL GNU AND CMAKE_C_COMPILER_VERSION VERSION_GREATER 6)
+        set(COMPILER_SUPPORT_ALTIVEC TRUE)
+    else ()
+        set(COMPILER_SUPPORT_ALTIVEC FALSE)
+    endif ()
 else ()
     # If the target system processor isn't recognized, emit a warning message to alert the user
     # that hardware-acceleration support won't be available but allow configuration to proceed.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -287,11 +287,11 @@ elseif (CMAKE_SYSTEM_PROCESSOR STREQUAL armv7l OR
         message(WARNING "Unable to determine which ${CMAKE_SYSTEM_PROCESSOR} hardware features are supported by the C compiler (${CMAKE_C_COMPILER_ID} ${CMAKE_C_COMPILER_VERSION}).")
     endif ()
 elseif (CMAKE_SYSTEM_PROCESSOR STREQUAL ppc64le)
-    if (CMAKE_C_COMPILER_ID STREQUAL GNU AND CMAKE_C_COMPILER_VERSION VERSION_GREATER 8)
+	if (CMAKE_C_COMPILER_ID STREQUAL GNU)
 		set(COMPILER_SUPPORT_ALTIVEC TRUE)
-    else ()
-        set(COMPILER_SUPPORT_ALTIVEC FALSE)
-    endif ()
+	else ()
+		set(COMPILER_SUPPORT_ALTIVEC FALSE)
+	endif ()
 else ()
     # If the target system processor isn't recognized, emit a warning message to alert the user
     # that hardware-acceleration support won't be available but allow configuration to proceed.

--- a/blosc/CMakeLists.txt
+++ b/blosc/CMakeLists.txt
@@ -213,7 +213,7 @@ if (COMPILER_SUPPORT_NEON)
             APPEND PROPERTY COMPILE_DEFINITIONS SHUFFLE_NEON_ENABLED)
 endif (COMPILER_SUPPORT_NEON)
 if (COMPILER_SUPPORT_ALTIVEC)
-    set_source_files_properties(shuffle-altivec.c bitshuffle-altivec.c PROPERTIES COMPILE_FLAGS -DNO_WARN_X86_INTRINSICS)
+    set_source_files_properties(shuffle-altivec.c bitshuffle-altivec.c PROPERTIES COMPILE_FLAGS "-maltivec")
 
     # Define a symbol for the shuffle-dispatch implementation
     # so it knows ALTIVEC is supported even though that file is


### PR DESCRIPTION
Tested on gcc7 where the option NO_WARN_X86_INTRINSICS was not (yet) present (appeared in gcc8). Did not manage to have *clang* compiling the same way :(