### PR TITLE
Entropy sensing

### DIFF
--- a/blosc/blosclz.c
+++ b/blosc/blosclz.c
@@ -333,22 +333,24 @@ int blosclz_compress(const int clevel, const void* input, int length,
   long skip_cycle = 0;
   double cratio;
 
-  // Use _early giveup_ for clevel < 5 and then switch to _entropy probing_
-  double maxlength_[10] = {-1, .1, .15, .2, 1., 1., 1., 1., 1., 1.};
+  // Minimum cratios before issuing and _early giveup_
+  // Remind that blosclz is not meant for cratios <= 2 (too costly to decompress)
+  double maxlength_[10] = {-1, .1, .15, .2, .4, .4, .4, .4, .45, .5};
   int32_t maxlength = (int32_t)(length * maxlength_[clevel]);
   if (maxlength > (int32_t)maxout) {
     maxlength = (int32_t)maxout;
   }
   op_limit = op + maxlength;
 
-  // The maximum amount of cycles to skip match lookups (_entropy probing_)
-  long max_skip_cycles_[10] = {255, 0, 0, 0, 6, 4, 2, 2, 1, 0};
+  // The maximum amount of cycles to skip match lookups
+  // A 0 means just _early giveup_ whereas > 0 use _entropy sensing_ too
+  long max_skip_cycles_[10] = {255, 0, 0, 0, 3, 3, 2, 1, 1, 0};
   long max_skip_cycles = max_skip_cycles_[clevel];
   // The minimum compression ratio before skipping a number of cycles
-  double min_cratio_[10] = {-1, 0., 0., 0., 6., 5., 4., 3., 2., 1.};
+  double min_cratio_[10] = {-1, 0., 0., 0., 5., 5., 4., 3., 2., 1.};
   double min_cratio = min_cratio_[clevel];
 
-  uint8_t hashlog_[10] = {0, HASH_LOG -1, HASH_LOG, HASH_LOG, HASH_LOG,
+  uint8_t hashlog_[10] = {0, HASH_LOG - 1, HASH_LOG - 1, HASH_LOG, HASH_LOG,
                            HASH_LOG, HASH_LOG, HASH_LOG, HASH_LOG, HASH_LOG};
   uint8_t hashlog = hashlog_[clevel];
   // Initialize the hash table to distances of 0
@@ -377,16 +379,6 @@ int blosclz_compress(const int clevel, const void* input, int length,
     if (max_skip_cycles) {
       // Enter the entropy probing mode
       if (skip_cycle) {
-        // Just check for runs larger than 4-byte when in entropy probing mode
-        // Not sure if that would help in general, but it does not hurt either
-        if (BLOSCLZ_READU32(ip - 1) == BLOSCLZ_READU32(ip)) {
-          // Way to trigger this: `b2bench blosclz shuffle single 6 1048576 19 19`
-          //printf("m");
-          distance = 1;
-          ref = anchor - 1 + 4;
-          len = 4;
-          goto match;
-        }
         LITERAL(ip, op, op_limit, anchor, copy);
         // Start a new cycle every 256 bytes
         if ((ip - icycle) >= BYTES_IN_CYCLE) {
@@ -435,7 +427,6 @@ int blosclz_compress(const int clevel, const void* input, int length,
       continue;
     }
 
-    match:
     /* last matched byte */
     ip = anchor + len;
 

--- a/blosc/blosclz.c
+++ b/blosc/blosclz.c
@@ -377,6 +377,16 @@ int blosclz_compress(const int clevel, const void* input, int length,
     if (max_skip_cycles) {
       // Enter the entropy probing mode
       if (skip_cycle) {
+        // Just check for runs larger than 4-byte when in entropy probing mode
+        // Not sure if that would help in general, but it does not hurt either
+        if (BLOSCLZ_READU32(ip - 1) == BLOSCLZ_READU32(ip)) {
+          // Way to trigger this: `b2bench blosclz shuffle single 6 1048576 19 19`
+          //printf("m");
+          distance = 1;
+          ref = anchor - 1 + 4;
+          len = 4;
+          goto match;
+        }
         LITERAL(ip, op, op_limit, anchor, copy);
         // Start a new cycle every 256 bytes
         if ((ip - icycle) >= BYTES_IN_CYCLE) {
@@ -425,6 +435,7 @@ int blosclz_compress(const int clevel, const void* input, int length,
       continue;
     }
 
+    match:
     /* last matched byte */
     ip = anchor + len;
 

--- a/blosc/blosclz.c
+++ b/blosc/blosclz.c
@@ -334,7 +334,7 @@ int blosclz_compress(const int clevel, const void* input, int length,
   double cratio;
 
   // Use _early giveup_ for clevel < 5 and then switch to _entropy probing_
-  double maxlength_[10] = {-1, .1, .15, .2, .3, 1., 1., 1., 1., 1.};
+  double maxlength_[10] = {-1, .1, .15, .2, 1., 1., 1., 1., 1., 1.};
   int32_t maxlength = (int32_t)(length * maxlength_[clevel]);
   if (maxlength > (int32_t)maxout) {
     maxlength = (int32_t)maxout;
@@ -342,10 +342,10 @@ int blosclz_compress(const int clevel, const void* input, int length,
   op_limit = op + maxlength;
 
   // The maximum amount of cycles to skip match lookups (_entropy probing_)
-  long max_skip_cycles_[10] = {255, 0, 0, 0, 0, 4, 3, 2, 1, 0};
+  long max_skip_cycles_[10] = {255, 0, 0, 0, 6, 4, 2, 2, 1, 0};
   long max_skip_cycles = max_skip_cycles_[clevel];
   // The minimum compression ratio before skipping a number of cycles
-  double min_cratio_[10] = {-1, 0., 0., 0., 0., 5., 4., 3., 2., 1.};
+  double min_cratio_[10] = {-1, 0., 0., 0., 6., 5., 4., 3., 2., 1.};
   double min_cratio = min_cratio_[clevel];
 
   uint8_t hashlog_[10] = {0, HASH_LOG -1, HASH_LOG, HASH_LOG, HASH_LOG,

--- a/blosc/btune.c
+++ b/blosc/btune.c
@@ -110,20 +110,18 @@ void btune_next_blocksize(blosc2_context *context) {
     // For performance reasons, do not exceed L2 (256KB) cache
     switch (clevel) {
       case 1:
+      case 2:
         blocksize = 16 * 1024;
         break;
-      case 2:
       case 3:
         blocksize = 32 * 1024;
         break;
       case 4:
       case 5:
-        blocksize = 64 * 1024;
-        break;
       case 6:
-      case 7:
         blocksize = 128 * 1024;
         break;
+      case 7:
       case 8:
       case 9:
       default:


### PR DESCRIPTION
This adds a way to sense the entropy of the data that is being compressed.  If the entropy is being sensed as too high, then just copy literals for some cycles before reactivating entropy sensing again.  Although the implemented algorithm is pretty fast, this still adds some overhead, so it is enabled only for `clevel > 3` (see `max_skip_cycles_` levels, where 0 means skip entropy sensing).