### PR TITLE
fix neon implementation of bitshuffle

### DIFF
--- a/blosc/bitshuffle-neon.c
+++ b/blosc/bitshuffle-neon.c
@@ -951,6 +951,8 @@ bitshuffle_neon(void* _src, void* _dest, const size_t size,
          so we're done processing here. */
       return count;
   }
+
+  return (int64_t)size * (int64_t)elem_size;
 }
 
 /* Bitunshuffle a block.  This can never fail. */
@@ -996,4 +998,6 @@ bitunshuffle_neon(void* _src, void* _dest, const size_t size,
          so we're done processing here. */
       return count;
   }
+  
+  return (int64_t)size * (int64_t)elem_size;
 }


### PR DESCRIPTION
Bitshuffling is broken in the neon implementation.
This PR fixes the missing return path. The shuffling function now always returns the shuffled size.