### PR TITLE
Added fuzzers for blosc compression/decompression.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,8 @@
 #       build the shared library version of the Blosc library
 #   BUILD_TESTS: default ON
 #       build test programs and generates the "test" target
+#   BUILD_FUZZERS: default ON
+#       build fuzz programs and generates "fuzz" targets
 #   BUILD_BENCHMARKS: default ON
 #       build the benchmark programs
 #   BUILD_EXAMPLES: default ON
@@ -97,6 +99,8 @@ option(BUILD_SHARED
     "Build a shared library version of the blosc library." ON)
 option(BUILD_TESTS
     "Build test programs form the blosc compression library" ON)
+option(BUILD_FUZZERS
+    "Build fuzzer programs from the blosc compression library" ON)
 option(BUILD_BENCHMARKS
     "Build benchmark programs form the blosc compression library" ON)
 option(BUILD_EXAMPLES
@@ -361,6 +365,11 @@ if(BUILD_TESTS)
     enable_testing()
     add_subdirectory(tests)
     add_subdirectory(compat)
+endif()
+
+if(BUILD_FUZZERS)
+    enable_testing()
+    add_subdirectory(tests/fuzz)
 endif()
 
 if(BUILD_BENCHMARKS)

--- a/tests/fuzz/CMakeLists.txt
+++ b/tests/fuzz/CMakeLists.txt
@@ -1,0 +1,77 @@
+# flags
+link_directories(${PROJECT_BINARY_DIR}/blosc)
+
+# look for fuzzing lib and link with it if found
+if(CMAKE_C_COMPILER_ID STREQUAL "Clang")
+    enable_language(CXX)
+
+    if(DEFINED ENV{LIB_FUZZING_ENGINE})
+        set(FUZZING_ENGINE $ENV{LIB_FUZZING_ENGINE})
+        set(FUZZING_ENGINE_FOUND TRUE)
+    else()
+        find_library(FUZZING_ENGINE "FuzzingEngine")
+    endif()
+endif()
+
+# If fuzzing lib not found then create standalone fuzz runner
+if(NOT FUZZING_ENGINE_FOUND)
+    set(FUZZER_SRC standalone.c)
+else()
+    set(FUZZER_SRC)
+endif()
+
+# sources
+file(GLOB SOURCES fuzz_*.c)
+
+# targets and tests
+foreach(source ${SOURCES})
+    get_filename_component(target ${source} NAME_WE)
+
+    # Enable support for testing accelerated shuffles
+    if(COMPILER_SUPPORT_SSE2 AND SSE2_FOUND)
+        # Define a symbol so tests for SSE2 shuffle/unshuffle will be compiled in.
+        set_property(
+                SOURCE ${source}
+                APPEND PROPERTY COMPILE_DEFINITIONS SHUFFLE_SSE2_ENABLED)
+    endif()
+
+    if(COMPILER_SUPPORT_AVX2 AND AVX2_FOUND)
+        # Define a symbol so tests for AVX2 shuffle/unshuffle will be compiled in.
+        set_property(
+                SOURCE ${source}
+                APPEND PROPERTY COMPILE_DEFINITIONS SHUFFLE_AVX2_ENABLED)
+    endif()
+
+    if(COMPILER_SUPPORT_NEON)
+        # Define a symbol so tests for NEON shuffle/unshuffle will be compiled in.
+        set_property(
+                SOURCE ${source}
+                APPEND PROPERTY COMPILE_DEFINITIONS SHUFFLE_NEON_ENABLED)
+    endif()
+
+    if(COMPILER_SUPPORT_ALTIVEC)
+        # Define a symbol so tests for NEON shuffle/unshuffle will be compiled in.
+        set_property(
+                SOURCE ${source}
+                APPEND PROPERTY COMPILE_DEFINITIONS SHUFFLE_ALTIVEC_ENABLED)
+    endif()
+
+    add_executable(${target} ${source} ${FUZZER_SRC})
+
+    # OSS-Fuzz expect fuzzers to end with _fuzzer
+    string(REPLACE "fuzz_" "" output_name ${target})
+    set_target_properties(${target} PROPERTIES OUTPUT_NAME ${output_name}_fuzzer)
+
+    if(FUZZING_ENGINE_FOUND)
+        set_target_properties(${target} PROPERTIES LINKER_LANGUAGE CXX)
+        target_link_libraries(${target} ${FUZZING_ENGINE})
+    endif()
+
+    target_link_libraries(${target} blosc2_static)
+    add_dependencies(${target} blosc2_static)
+
+    # run standalone fuzzer against each file
+    file(GLOB COMPAT_FILES ${PROJECT_SOURCE_DIR}/compat/*.cdata)
+    add_test(NAME ${target} COMMAND ${target} ${COMPAT_FILES})
+
+endforeach()

--- a/tests/fuzz/fuzz_compress.c
+++ b/tests/fuzz/fuzz_compress.c
@@ -1,0 +1,62 @@
+#include <stdint.h>
+#include <stdlib.h>
+
+#include "blosc2.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  const char *compressors[] = { "blosclz", "lz4", "lz4hc", "snappy", "zlib", "zstd" };
+  int level = 9, filter = BLOSC_BITSHUFFLE, cindex = 0, i = 0;
+  size_t nbytes, cbytes, blocksize;
+  void *output, *input;
+
+  blosc_set_nthreads(1);
+
+  if (size > 0)
+    level = data[0] % (9 + 1);
+  if (size > 1)
+    filter = data[1] % (BLOSC_BITSHUFFLE + 1);
+  if (size > 2)
+    cindex = data[2];
+
+  /* Find next available compressor */
+  while (blosc_set_compressor(compressors[cindex % 6]) == -1 && i < 6) {
+    cindex++, i++;
+  }
+  if (i == 6) {
+    /* No compressors available */
+    return 0;
+  }
+
+  if (size > 3 && data[3] % 7 == 0)
+    blosc_set_blocksize(4096);
+
+  output = malloc(size + 1);
+  if (output == NULL)
+    return 0;
+
+  if (blosc_compress(level, filter, 1, size, data, output, size) == 0) {
+    /* Cannot compress src buffer into dest */
+    free(output);
+    return 0;
+  }
+
+  blosc_cbuffer_sizes(output, &nbytes, &cbytes, &blocksize);
+
+  input = malloc(cbytes);
+  if (input != NULL) {
+    blosc_decompress(output, input, cbytes);
+    free(input);
+  }
+
+  free(output);
+
+  return 0;
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/tests/fuzz/fuzz_decompress.c
+++ b/tests/fuzz/fuzz_decompress.c
@@ -1,0 +1,36 @@
+#include <stdint.h>
+#include <stdlib.h>
+
+#include "blosc2.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  size_t nbytes, cbytes, blocksize;
+  void *output;
+
+  if (size < BLOSC_MIN_HEADER_LENGTH) {
+    return 0;
+  }
+
+  blosc_cbuffer_sizes(data, &nbytes, &cbytes, &blocksize);
+  if (cbytes != size) {
+    return 0;
+  }
+  if (nbytes == 0) {
+    return 0;
+  }
+  
+  output = malloc(cbytes);
+  if (output != NULL) {
+    blosc_decompress(data, output, cbytes);
+    free(output);
+  }
+  return 0;
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/tests/fuzz/standalone.c
+++ b/tests/fuzz/standalone.c
@@ -1,0 +1,44 @@
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+extern int LLVMFuzzerTestOneInput(const unsigned char *data, size_t size);
+
+int main(int argc, char **argv) {
+  int i;
+  fprintf(stderr, "Running %d inputs\n", argc - 1);
+
+  for (i = 1; i < argc; i++) {
+    size_t len, err, n_read = 0;
+    unsigned char *buf;
+    FILE *f = NULL;
+
+    f = fopen(argv[i], "rb+");
+    if (f == NULL) {
+      /* Failed to open this file: it may be a directory. */
+      fprintf(stderr, "Skipping: %s\n", argv[i]);
+      continue;
+    }
+    fprintf(stderr, "Running: %s %s\n", argv[0], argv[i]);
+
+    fseek(f, 0, SEEK_END);
+    len = ftell(f);
+    fseek(f, 0, SEEK_SET);
+
+    buf = (unsigned char *)malloc(len);
+    if (buf != NULL) {
+      n_read = fread(buf, 1, len, f);
+      assert(n_read == len);
+      LLVMFuzzerTestOneInput(buf, len);
+      free(buf);
+    }
+
+    err = fclose(f);
+    assert(err == 0);
+    (void)err;
+
+    fprintf(stderr, "Done:    %s: (%d bytes)\n", argv[i], (int)n_read);
+  }
+
+  return 0;
+}


### PR DESCRIPTION
* Adds simple fuzzers for testing `blosc_compress` and `blosc_decompress`.
  * Fuzzers are linked against fuzzing library for use with OSS-Fuzz
* Adds cmake tests using the fuzzers and tests against all the files in `compat` folder, all those files are a good seed corpus.
* Adds `BUILD_FUZZERS` cmake option for enabling the fuzzers and their tests.
