### PR TITLE
Fixed asan heap-buffer-overflow due to destsize not being checked.

### DIFF
--- a/blosc/blosc2.c
+++ b/blosc/blosc2.c
@@ -1347,6 +1347,11 @@ static int initialize_context_compression(
             BLOSC_MAX_BUFFERSIZE);
     return -1;
   }
+  if (destsize < BLOSC_MAX_OVERHEAD) {
+    fprintf(stderr, "Output buffer size should be larger than %d bytes\n",
+            BLOSC_MAX_OVERHEAD);
+    return -1;
+  }
 
   /* Compression level */
   if (clevel < 0 || clevel > 9) {


### PR DESCRIPTION
`blosc_compress` would proceed to write the header if `destsize == 0`.

```
INFO: Seed: 2318159360
INFO: Loaded 1 modules   (46136 inline 8-bit counters): 46136 [0xddb6a0, 0xde6ad8), 
INFO: Loaded 1 PC tables (46136 PCs): 46136 [0xad4048,0xb883c8), 
INFO:        0 files found in /tmp/compress_fuzzer_corpus
INFO: -max_len is not provided; libFuzzer will not generate inputs larger than 4096 bytes
=================================================================
==11==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x6020000000b1 at pc 0x00000052975c bp 0x7fffc10c7140 sp 0x7fffc10c6908
WRITE of size 16 at 0x6020000000b1 thread T0
SCARINESS: 45 (multi-byte-write-heap-buffer-overflow)
    #0 0x52975b in __asan_memset /src/llvm-project/compiler-rt/lib/asan/asan_interceptors_memintrinsics.cpp:26:3
    #1 0x5ad90a in write_compression_header /src/c-blosc2/blosc/blosc2.c
    #2 0x5af507 in blosc_compress /src/c-blosc2/blosc/blosc2.c:1922:11
    #3 0x55c7b0 in LLVMFuzzerTestOneInput /src/c-blosc2/tests/fuzz/fuzz_compress.c:41:7
    #4 0x4651d1 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:558:15
    #5 0x466646 in fuzzer::Fuzzer::ReadAndExecuteSeedCorpora(std::__Fuzzer::vector<fuzzer::SizedFile, fuzzer::fuzzer_allocator<fuzzer::SizedFile> >&) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:748:3
    #6 0x466ab9 in fuzzer::Fuzzer::Loop(std::__Fuzzer::vector<fuzzer::SizedFile, fuzzer::fuzzer_allocator<fuzzer::SizedFile> >&) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:799:3
rt/lib/fuzzer/FuzzerDriver.cpp:846:6
    #8 0x47e282 in main /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerMain.cpp:19:10
    #9 0x7f4e2a68d82f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2082f)
    #10 0x42af48 in _start (/out/compress_fuzzer+0x42af48)

DEDUP_TOKEN: __asan_memset--write_compression_header--blosc_compress
0x6020000000b1 is located 0 bytes to the right of 1-byte region [0x6020000000b0,0x6020000000b1)
allocated by thread T0 here:
    #0 0x529fed in malloc /src/llvm-project/compiler-rt/lib/asan/asan_malloc_linux.cpp:145:3
    #1 0x55c785 in LLVMFuzzerTestOneInput /src/c-blosc2/tests/fuzz/fuzz_compress.c:37:12
    #2 0x4651d1 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:558:15
    #3 0x466646 in fuzzer::Fuzzer::ReadAndExecuteSeedCorpora(std::__Fuzzer::vector<fuzzer::SizedFile, fuzzer::fuzzer_allocator<fuzzer::SizedFile> >&) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:748:3
    #4 0x466ab9 in fuzzer::Fuzzer::Loop(std::__Fuzzer::vector<fuzzer::SizedFile, fuzzer::fuzzer_allocator<fuzzer::SizedFile> >&) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:799:3
    #5 0x4567e5 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerDriver.cpp:846:6
    #6 0x47e282 in main /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerMain.cpp:19:10
    #7 0x7f4e2a68d82f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2082f)

DEDUP_TOKEN: malloc--LLVMFuzzerTestOneInput--fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long)
SUMMARY: AddressSanitizer: heap-buffer-overflow /src/llvm-project/compiler-rt/lib/asan/asan_interceptors_memintrinsics.cpp:26:3 in __asan_memset
Shadow bytes around the buggy address:
  0x0c047fff7fc0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c047fff7fd0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c047fff7fe0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c047fff7ff0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c047fff8000: fa fa 00 00 fa fa 00 fa fa fa 00 fa fa fa 00 fa
=>0x0c047fff8010: fa fa 01 fa fa fa[01]fa fa fa fd fa fa fa fd fa
  0x0c047fff8020: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c047fff8030: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c047fff8040: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c047fff8050: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c047fff8060: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==11==ABORTING
MS: 0 ; base unit: 0000000000000000000000000000000000000000

```

[crash-da39a3ee5e6b4b0d3255bfef95601890afd80709.zip](https://github.com/Blosc/c-blosc2/files/4828914/crash-da39a3ee5e6b4b0d3255bfef95601890afd80709.zip)