### PR TITLE
New version of BloscLZ codec that implements entropy probing

### DIFF
--- a/blosc/blosc2.c
+++ b/blosc/blosc2.c
@@ -1628,7 +1628,7 @@ static int write_compression_header(blosc2_context* context,
     *(context->header_flags) |= BLOSC_DODELTA;
   }
 
-  dont_split = !split_block(context->compcode, context->typesize,
+  dont_split = !split_block(context, context->typesize,
                             context->blocksize, extended_header);
   *(context->header_flags) |= dont_split << 4;  /* dont_split is in bit 4 */
   *(context->header_flags) |= compformat << 5;  /* codec starts at bit 5 */

--- a/blosc/blosc2.c
+++ b/blosc/blosc2.c
@@ -1414,8 +1414,8 @@ static uint8_t get_filter_flags(const uint8_t header_flags,
 }
 
 
-static int initialize_context_decompression(
-        blosc2_context* context, const void* src, void* dest, size_t destsize) {
+static int initialize_context_decompression(blosc2_context* context, const void* src,
+                                            void* dest, int32_t destsize) {
   context->do_compress = 0;
   context->src = (const uint8_t*)src;
   context->dest = (uint8_t*)dest;
@@ -1976,7 +1976,7 @@ int blosc_run_decompression_with_context(blosc2_context* context, const void* sr
     return -1;
   }
 
-  error = initialize_context_decompression(context, src, dest, destsize);
+  error = initialize_context_decompression(context, src, dest, (int32_t)destsize);
   if (error < 0) {
     return error;
   }

--- a/blosc/blosclz.c
+++ b/blosc/blosclz.c
@@ -526,7 +526,7 @@ int blosclz_compress(const int clevel, const void* input, int length,
       csize_3b = get_csize(ibase, maxlen, true);
       csize_4b = get_csize(ibase, maxlen, false);
       ipshift = (csize_3b < csize_4b) ? 3 : 4;
-      cratio = (csize_3b < csize_4b) ? (maxlen / csize_3b) : (maxlen / csize_4b);
+      cratio = (csize_3b < csize_4b) ? ((double)maxlen / csize_3b) : ((double)maxlen / csize_4b);
       break;
     default:
       break;

--- a/blosc/blosclz.c
+++ b/blosc/blosclz.c
@@ -532,7 +532,7 @@ int blosclz_compress(const int clevel, const void* input, int length,
       break;
   }
   // compression ratios less than 2x are too expensive for a fast codec like this one
-  if (cratio < 2) {
+  if ((clevel < 9 && cratio < 2) || (clevel == 9 && cratio < 1.2)) {
     goto out;
   }
 

--- a/blosc/blosclz.c
+++ b/blosc/blosclz.c
@@ -507,7 +507,7 @@ int blosclz_compress(const int clevel, const void* input, int length,
     case 1:
     case 2:
     case 3:
-      maxlen = 2 * 1024;
+      maxlen = length / 8;
       csize_4b = get_csize(ibase, maxlen, false);
       cratio = (double)maxlen / csize_4b;
       break;
@@ -516,13 +516,13 @@ int blosclz_compress(const int clevel, const void* input, int length,
     case 6:
     case 7:
     case 8:
-      maxlen = 16 * 1024;
+      maxlen = length / 8;
       csize_4b = get_csize(ibase, maxlen, false);
       cratio = (double)maxlen / csize_4b;
       break;
     case 9:
       // case 9 is special.  we need to asses the optimal shift
-      maxlen = 16 * 1024;
+      maxlen = length / 8;
       csize_3b = get_csize(ibase, maxlen, true);
       csize_4b = get_csize(ibase, maxlen, false);
       ipshift = (csize_3b < csize_4b) ? 3 : 4;
@@ -594,9 +594,7 @@ int blosclz_compress(const int clevel, const void* input, int length,
 
     // Encoding short lengths is expensive during decompression
     // Encode only for reasonable lengths (extensive experiments done)
-    if ((len < minlen) ||
-        (len <= 8 && distance > MAX_DISTANCE) ||
-        (len <= 5 && distance <= MAX_DISTANCE)) {
+    if (len < minlen || (len <= 5 && distance >= MAX_DISTANCE)) {
       LITERAL(ip, op, op_limit, anchor, copy)
       continue;
     }

--- a/blosc/blosclz.c
+++ b/blosc/blosclz.c
@@ -572,7 +572,8 @@ int blosclz_compress(const int clevel, const void* input, int length,
 
     unsigned len = (int)(ip - anchor);
     // If match is close, let's reduce the minimum length to encode it
-    unsigned minlen = (distance < MAX_DISTANCE) ? minlen_[clevel] - 1 : minlen_[clevel];
+    //unsigned minlen = (distance < MAX_DISTANCE) ? minlen_[clevel] - 1 : minlen_[clevel];
+    unsigned minlen = minlen_[clevel];
     // Encoding short lengths is expensive during decompression
     if (len < minlen) {
       LITERAL(ip, op, op_limit, anchor, copy)

--- a/blosc/blosclz.c
+++ b/blosc/blosclz.c
@@ -573,7 +573,11 @@ int blosclz_compress(const int clevel, const void* input, int length,
     unsigned len = (int)(ip - anchor);
     // If match is close, let's reduce the minimum length to encode it
     //unsigned minlen = (distance < MAX_DISTANCE) ? minlen_[clevel] - 1 : minlen_[clevel];
-    unsigned minlen = minlen_[clevel];
+    unsigned minlen = (distance < MAX_DISTANCE) ? minlen_[clevel] - 1 : minlen_[clevel];
+    if (clevel == 9) {
+      minlen = ipshift;
+    }
+    //unsigned minlen = minlen_[clevel];
     // Encoding short lengths is expensive during decompression
     if (len < minlen) {
       LITERAL(ip, op, op_limit, anchor, copy)

--- a/blosc/blosclz.c
+++ b/blosc/blosclz.c
@@ -476,6 +476,9 @@ int blosclz_compress(const int clevel, const void* input, int length,
   // Minimum lengths for encoding
   unsigned minlen_[10] = {0, 12, 12, 11, 10, 9, 8, 7, 6, 5};
 
+  // Minimum compression ratios for initiate encoding
+  double cratio_[10] = {0, 2, 2, 2, 2, 1.8, 1.6, 1.4, 1.2, 1.1};
+
   uint8_t hashlog_[10] = {0, HASH_LOG - 2, HASH_LOG - 1, HASH_LOG, HASH_LOG,
                           HASH_LOG, HASH_LOG, HASH_LOG, HASH_LOG, HASH_LOG};
   uint8_t hashlog = hashlog_[clevel];
@@ -531,8 +534,8 @@ int blosclz_compress(const int clevel, const void* input, int length,
     default:
       break;
   }
-  // compression ratios less than 2x are too expensive for a fast codec like this one
-  if ((clevel < 9 && cratio < 2) || (clevel == 9 && cratio < 1.2)) {
+  // discard probes with small compression ratios (too expensive)
+  if (cratio < cratio_ [clevel]) {
     goto out;
   }
 

--- a/blosc/blosclz.c
+++ b/blosc/blosclz.c
@@ -347,7 +347,7 @@ static uint8_t* get_run_or_match(uint8_t* ip, uint8_t* ip_bound, const uint8_t* 
 
 
 // Get the compressed size of a buffer.  Useful for testing compression ratios for high clevels.
-int get_csize(uint8_t* ibase, int length, int maxout, bool force_3b_match) {
+static int get_csize(uint8_t* ibase, int length, int maxout, bool force_3b_match) {
   uint8_t* ip = ibase;
   int32_t oc = 0;
   int32_t oc_limit = maxout;

--- a/blosc/blosclz.c
+++ b/blosc/blosclz.c
@@ -347,7 +347,7 @@ static uint8_t* get_run_or_match(uint8_t* ip, uint8_t* ip_bound, const uint8_t* 
 
 
 // Get the compressed size of a buffer.  Useful for testing compression ratios for high clevels.
-static int get_csize(uint8_t* ibase, int length, int maxout, bool force_3b_match) {
+static int get_csize(uint8_t* ibase, int length, int maxout, bool force_3b_shift) {
   uint8_t* ip = ibase;
   int32_t oc = 0;
   int32_t oc_limit = maxout;
@@ -408,7 +408,7 @@ static int get_csize(uint8_t* ibase, int length, int maxout, bool force_3b_match
     /* get runs or matches; zero distance means a run */
     ip = get_run_or_match(ip, ip_bound, ref, !distance);
 
-    ip -= force_3b_match ? 3 : 4;
+    ip -= force_3b_shift ? 3 : 4;
     unsigned len = (int)(ip - anchor);
     // If match is close, let's reduce the minimum length to encode it
     unsigned minlen = (distance < MAX_DISTANCE) ? 3 : 4;

--- a/blosc/blosclz.h
+++ b/blosc/blosclz.h
@@ -20,7 +20,7 @@
 extern "C" {
 #endif
 
-#define BLOSCLZ_VERSION_STRING "2.2.0"
+#define BLOSCLZ_VERSION_STRING "2.3.0"
 
 
 /**

--- a/blosc/btune.c
+++ b/blosc/btune.c
@@ -102,7 +102,7 @@ void btune_next_blocksize(blosc2_context *context) {
   }
 
   /* Now the blocksize for splittable codecs */
-  if (clevel > 0 && split_block(context->compcode, typesize, blocksize, true)) {
+  if (clevel > 0 && split_block(context, typesize, blocksize, true)) {
     // For performance reasons, do not exceed 256 KB (in must fit in L2 cache)
     switch (clevel) {
       case 1:

--- a/tests/test_maxout.c
+++ b/tests/test_maxout.c
@@ -38,8 +38,7 @@ static char* test_input_too_large(void) {
 static char* test_maxout_less(void) {
 
   /* Get a compressed buffer */
-  cbytes = blosc_compress(clevel, doshuffle, typesize, size, src, dest,
-                          size + BLOSC_MAX_OVERHEAD - 1);
+  cbytes = blosc_compress(clevel, doshuffle, typesize, size, src, dest, size);
   mu_assert("ERROR: cbytes is not 0", cbytes == 0);
 
   return 0;
@@ -64,7 +63,7 @@ static char* test_maxout_equal(void) {
   /* Get a compressed buffer */
   cbytes = blosc_compress(clevel, doshuffle, typesize, size, src, dest,
                           size + BLOSC_MAX_OVERHEAD);
-  mu_assert("ERROR: cbytes is not correct", cbytes == (int)size + BLOSC_MAX_OVERHEAD);
+  mu_assert("ERROR: cbytes is not correct", cbytes <= (int)size + BLOSC_MAX_OVERHEAD);
 
   /* Decompress the buffer */
   nbytes = blosc_decompress(dest, dest2, size);
@@ -95,7 +94,7 @@ static char* test_maxout_great(void) {
   /* Get a compressed buffer */
   cbytes = blosc_compress(clevel, doshuffle, typesize, size, src, dest,
                           size + BLOSC_MAX_OVERHEAD + 1);
-  mu_assert("ERROR: cbytes is not correct", cbytes == (int)size + BLOSC_MAX_OVERHEAD);
+  mu_assert("ERROR: cbytes is not correct", cbytes <= (int)size + BLOSC_MAX_OVERHEAD);
 
   /* Decompress the buffer */
   nbytes = blosc_decompress(dest, dest2, size);


### PR DESCRIPTION
Sometimes is difficult to asses which parameters are better for compressing some dataset.  Here it is an implementation that probes the beginning of the buffers (just 1/8 of it, for speed) and determines which parameters are best.  The implementation for clevel == 9 is a bit more sophisticated and works pretty well against b2bench.  Testing this in other scenarios (RAINFALL dataset) also shows that BloscLZ is better suited for more real data, and not just synthetic.