### PR TITLE
Move check for valid blocksize before calculations

### DIFF
--- a/blosc/blosc2.c
+++ b/blosc/blosc2.c
@@ -1432,17 +1432,18 @@ static int initialize_context_decompression(
   context->typesize = (uint8_t)context->src[3];
   context->sourcesize = sw32_(context->src + 4);
   context->blocksize = sw32_(context->src + 8);
-  /* Total blocks */
-  context->nblocks = context->sourcesize / context->blocksize;
-  context->leftover = context->sourcesize % context->blocksize;
-  context->nblocks = (context->leftover > 0) ?
-                      context->nblocks + 1 : context->nblocks;
 
   // Some checks for malformed headers
   if (context->blocksize <= 0 || context->blocksize > destsize ||
       context->typesize <= 0 || context->typesize > BLOSC_MAX_TYPESIZE) {
     return -1;
   }
+
+  /* Total blocks */
+  context->nblocks = context->sourcesize / context->blocksize;
+  context->leftover = context->sourcesize % context->blocksize;
+  context->nblocks = (context->leftover > 0) ?
+                      context->nblocks + 1 : context->nblocks;
 
   if (context->block_maskout != NULL && context->block_maskout_nitems != context->nblocks) {
     fprintf(stderr, "The number of items in block_maskout (%d) must match the number"


### PR DESCRIPTION
Divide-by-zero exception if blocksize is zero from ASAN.

```
AddressSanitizer:DEADLYSIGNAL
=================================================================
==12==ERROR: AddressSanitizer: FPE on unknown address 0x0000005b132f (pc 0x0000005b132f bp 0x7ffeb63f12d0 sp 0x7ffeb63f1250 T0)
SCARINESS: 10 (signal)
    #0 0x5b132f in initialize_context_decompression /src/c-blosc2/blosc/blosc2.c:1411:42
    #1 0x5b132f in blosc_run_decompression_with_context /src/c-blosc2/blosc/blosc2.c:1949:11
    #2 0x5b2537 in blosc_decompress /src/c-blosc2/blosc/blosc2.c:2030:12
    #3 0x55c439 in LLVMFuzzerTestOneInput /src/c-blosc2/tests/fuzz/fuzz_decompress.c:28:5
    #4 0x4651d1 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:558:15
    #5 0x464915 in fuzzer::Fuzzer::RunOne(unsigned char const*, unsigned long, bool, fuzzer::InputInfo*, bool*) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:470:3
    #6 0x466340 in fuzzer::Fuzzer::MutateAndTestOne() /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:701:19
    #7 0x466db5 in fuzzer::Fuzzer::Loop(std::__Fuzzer::vector<fuzzer::SizedFile, fuzzer::fuzzer_allocator<fuzzer::SizedFile> >&) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:837:5
    #8 0x4567e5 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerDriver.cpp:846:6
    #9 0x47e282 in main /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerMain.cpp:19:10
    #10 0x7f509e25982f in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2082f)
    #11 0x42af48 in _start (/out/decompress_fuzzer+0x42af48)

DEDUP_TOKEN: initialize_context_decompression--blosc_run_decompression_with_context--blosc_decompress
AddressSanitizer can not provide additional info.
SUMMARY: AddressSanitizer: FPE /src/c-blosc2/blosc/blosc2.c:1411:42 in initialize_context_decompression
==12==ABORTING
```
[crash-fa4a981c0dffd15b0ac7bdc191bb6a73a36fa763.zip](https://github.com/Blosc/c-blosc2/files/4833483/crash-fa4a981c0dffd15b0ac7bdc191bb6a73a36fa763.zip)

