### PR TITLE
Fixed missing blosc_cbuffer_validate function

### DIFF
--- a/blosc/blosc2.c
+++ b/blosc/blosc2.c
@@ -2708,6 +2708,25 @@ void blosc_cbuffer_sizes(const void* cbuffer, size_t* nbytes,
   *cbytes = (size_t)sw32_(_src + 12);      /* compressed buffer size */
 }
 
+int blosc_cbuffer_validate(const void* cbuffer, size_t cbytes, size_t* nbytes) {
+  size_t header_cbytes, header_blocksize;
+  if (cbytes < BLOSC_MIN_HEADER_LENGTH) {
+    /* Compressed data should contain enough space for header */
+    *nbytes = 0;
+    return -1;
+  }
+  blosc_cbuffer_sizes(cbuffer, nbytes, &header_cbytes, &header_blocksize);
+  if (header_cbytes != cbytes) {
+    /* Compressed size from header does not match `cbytes` */
+    *nbytes = 0;
+    return -1;
+  }
+  if (*nbytes > BLOSC_MAX_BUFFERSIZE) {
+    /* Uncompressed size is larger than allowed */
+    return -1;
+  }
+  return 0;
+}
 
 /* Return `typesize` and `flags` from a compressed buffer. */
 void blosc_cbuffer_metainfo(const void* cbuffer, size_t* typesize, int* flags) {

--- a/blosc/blosc2.h
+++ b/blosc/blosc2.h
@@ -543,6 +543,22 @@ BLOSC_EXPORT int blosc_free_resources(void);
 BLOSC_EXPORT void blosc_cbuffer_sizes(const void* cbuffer, size_t* nbytes,
                                       size_t* cbytes, size_t* blocksize);
 
+/**
+ * @brief Checks that the compressed buffer starting at @cbuffer of length @cbytes may
+ * contain valid blosc compressed data, and that it is safe to call
+ * blosc_decompress/blosc_decompress_ctx/blosc_getitem.
+ * On success, returns 0 and sets @nbytes to the size of the uncompressed data.
+ * This does not guarantee that the decompression function won't return an error,
+ * but does guarantee that it is safe to attempt decompression.
+ *
+ * @param cbuffer The buffer of compressed data.
+ * @param cbytes The number of compressed bytes.
+ * @param nbytes The pointer where the number of uncompressed bytes will be put.
+ *
+ * @return On failure, returns -1.
+ */
+BLOSC_EXPORT int blosc_cbuffer_validate(const void* cbuffer, size_t cbytes,
+                                         size_t* nbytes);
 
 /**
  * @brief Get information about a compressed buffer, namely the type size

--- a/tests/fuzz/fuzz_decompress.c
+++ b/tests/fuzz/fuzz_decompress.c
@@ -22,7 +22,12 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
   if (nbytes == 0) {
     return 0;
   }
-  
+
+  if (blosc_cbuffer_validate(data, size, &nbytes) != 0) {
+    /* Unexpected `nbytes` specified in blosc header */
+    return 0;
+  }
+
   output = malloc(cbytes);
   if (output != NULL) {
     blosc_decompress(data, output, cbytes);


### PR DESCRIPTION
This also fixes the following ASAN error: https://oss-fuzz.com/testcase-detail/5114316075565056.