### PR TITLE
Fixed large malloc asan error when dictionary size is not checked.

### DIFF
--- a/blosc/blosc2.c
+++ b/blosc/blosc2.c
@@ -1475,8 +1475,11 @@ static int initialize_context_decompression(
           ZSTD_freeDDict(context->dict_ddict);
       }
       // The trained dictionary is after the bstarts block
-      context->dict_size = (size_t)sw32_(context->bstarts + context->nblocks);
       context->dict_buffer = (void*)(context->bstarts + context->nblocks + 1);
+      context->dict_size = (size_t)sw32_(context->bstarts + context->nblocks);
+      if (context->dict_size > BLOSC2_MAXDICTSIZE) {
+        return -1;
+      }
       context->dict_ddict = ZSTD_createDDict(context->dict_buffer, context->dict_size);
 #endif   // HAVE_ZSTD
     }


### PR DESCRIPTION
```
Running 1 inputs
Running: /home/nathan/Source/c-blosc2/build/tests/fuzz/decompress_fuzzer /home/nathan/Desktop/clusterfuzz-testcase-decompress_fuzzer-5557894660751360
=================================================================
==32272==ERROR: AddressSanitizer: requested allocation size 0xffffffffbebebebe (0xffffffffbebecec0 after adjustments for alignment, red zones etc.) exceeds maximum supported size of 0x10000000000 (thread T0)
    #0 0x49cb1d in malloc /tmp/final/llvm.src/projects/compiler-rt/lib/asan/asan_malloc_linux.cc:145:3
    #1 0x9ce9be in ZSTD_malloc /home/nathan/Source/c-blosc2/internal-complibs/zstd-1.4.5/common/zstd_common.c:60:12
    #2 0xd96ea0 in ZSTD_initDDict_internal /home/nathan/Source/c-blosc2/internal-complibs/zstd-1.4.5/decompress/zstd_ddict.c:130:38
    #3 0xd96b90 in ZSTD_createDDict_advanced /home/nathan/Source/c-blosc2/internal-complibs/zstd-1.4.5/decompress/zstd_ddict.c:155:39
    #4 0xd97806 in ZSTD_createDDict /home/nathan/Source/c-blosc2/internal-complibs/zstd-1.4.5/decompress/zstd_ddict.c:173:12
    #5 0x5b549f in initialize_context_decompression /home/nathan/Source/c-blosc2/blosc/blosc2.c:1482:29
    #6 0x5b1368 in blosc_run_decompression_with_context /home/nathan/Source/c-blosc2/blosc/blosc2.c:1987:11
    #7 0x5b73ea in blosc_decompress /home/nathan/Source/c-blosc2/blosc/blosc2.c:2077:12
    #8 0x4cc476 in LLVMFuzzerTestOneInput /home/nathan/Source/c-blosc2/tests/fuzz/fuzz_decompress.c:33:5
    #9 0x4ccabd in main /home/nathan/Source/c-blosc2/tests/fuzz/standalone.c:32:7
    #10 0x7ffff6ee582f in __libc_start_main /build/glibc-LK5gWL/glibc-2.23/csu/../csu/libc-start.c:291

==32272==HINT: if you don't care about these errors you may set allocator_may_return_null=1
SUMMARY: AddressSanitizer: allocation-size-too-big /tmp/final/llvm.src/projects/compiler-rt/lib/asan/asan_malloc_linux.cc:145:3 in malloc
==32272==ABORTING
```

[clusterfuzz-testcase-decompress_fuzzer-5557894660751360.zip](https://github.com/Blosc/c-blosc2/files/4839932/clusterfuzz-testcase-decompress_fuzzer-5557894660751360.zip)
