### PR TITLE
Added check to ensure compressed byte fields are valid.

### DIFF
--- a/blosc/blosc2.c
+++ b/blosc/blosc2.c
@@ -974,6 +974,12 @@ static int blosc_d(
     cbytes = sw32_(src);      /* amount of compressed bytes */
     src += sizeof(int32_t);
     ctbytes += (int32_t)sizeof(int32_t);
+
+    if (cbytes < 0 || ctbytes < 0) {
+      /* cbytes and ctbytes should never be negative */
+      return -2;
+    }
+
     /* Uncompress */
     if (cbytes == neblock) {
       memcpy(_dest, src, (unsigned int)neblock);


### PR DESCRIPTION
There is a similar check of `cbytes` that happens during compression. I copied that error code which was -2. Let me know if you want a different error code. 

```
Running 1 inputs
Running: /home/nathan/Source/c-blosc2/build/tests/fuzz/decompress_fuzzer /home/nathan/Desktop/clusterfuzz-testcase-decompress_fuzzer-5132024578048000
AddressSanitizer:DEADLYSIGNAL
=================================================================
==109003==ERROR: AddressSanitizer: SEGV on unknown address 0x6200010003fa (pc 0x000000db7ea4 bp 0x7fffffffc9f0 sp 0x7fffffffc9d0 T0)
==109003==The signal is caused by a READ memory access.
    #0 0xdb7ea3 in MEM_read32 /home/nathan/Source/c-blosc2/internal-complibs/zstd-1.4.5/decompress/../common/mem.h
    #1 0xd9d0e2 in MEM_readLE32 /home/nathan/Source/c-blosc2/internal-complibs/zstd-1.4.5/decompress/../common/mem.h:353:16
    #2 0xda0d28 in ZSTD_decompressMultiFrame /home/nathan/Source/c-blosc2/internal-complibs/zstd-1.4.5/decompress/zstd_decompress.c:735:37
    #3 0xda13a9 in ZSTD_decompress_usingDDict /home/nathan/Source/c-blosc2/internal-complibs/zstd-1.4.5/decompress/zstd_decompress.c:1255:12
    #4 0xda133b in ZSTD_decompressDCtx /home/nathan/Source/c-blosc2/internal-complibs/zstd-1.4.5/decompress/zstd_decompress.c:815:12
    #5 0x5f5848 in zstd_wrap_decompress /home/nathan/Source/c-blosc2/blosc/blosc2.c:518:12
    #6 0x5bc371 in blosc_d /home/nathan/Source/c-blosc2/blosc/blosc2.c:1012:18
    #7 0x5eaf0b in serial_blosc /home/nathan/Source/c-blosc2/blosc/blosc2.c:1105:18
    #8 0x5a3af6 in do_job /home/nathan/Source/c-blosc2/blosc/blosc2.c:1264:15
    #9 0x5b1685 in blosc_run_decompression_with_context /home/nathan/Source/c-blosc2/blosc/blosc2.c:2009:15
    #10 0x5b741a in blosc_decompress /home/nathan/Source/c-blosc2/blosc/blosc2.c:2078:12
    #11 0x4cc476 in LLVMFuzzerTestOneInput /home/nathan/Source/c-blosc2/tests/fuzz/fuzz_decompress.c:33:5
    #12 0x4ccabd in main /home/nathan/Source/c-blosc2/tests/fuzz/standalone.c:32:7
    #13 0x7ffff6ee582f in __libc_start_main /build/glibc-LK5gWL/glibc-2.23/csu/../csu/libc-start.c:291
    #14 0x424c08 in _start (/home/nathan/Source/c-blosc2/build/tests/fuzz/decompress_fuzzer+0x424c08)

AddressSanitizer can not provide additional info.
SUMMARY: AddressSanitizer: SEGV /home/nathan/Source/c-blosc2/internal-complibs/zstd-1.4.5/decompress/../common/mem.h in MEM_read32
```
