### PR TITLE
Run split

### DIFF
--- a/blosc/schunk.c
+++ b/blosc/schunk.c
@@ -196,7 +196,10 @@ int blosc2_schunk_append_chunk(blosc2_schunk *schunk, uint8_t *chunk, bool copy)
     schunk->data[nchunks] = chunk;
   }
   else {
-    frame_append_chunk(schunk->frame, chunk, schunk);
+    if (frame_append_chunk(schunk->frame, chunk, schunk) == NULL) {
+      fprintf(stderr, "Problems appending a chunk");
+      return -1;
+    }
   }
 
   /* printf("Compression chunk #%lld: %d -> %d (%.1fx)\n", */


### PR DESCRIPTION
This implements full run-length detection in blocks/splits.  With this, if a block/split is found to be of the same value, this value is encoded in its length (low byte of int32_t and negated).  The advantage is that, for data blocks made of the same value, there is no need to call an actual codec.  Also, as the overhead of codec storage is avoided, compression ratios tend to be higher.  For example, before this we had:

```
faltet@Francescs-Mac-mini /t/c/build (master)> ./bench/b2bench lz4 shuffle single 6 6291456 8 4                                                          (base)
Blosc version: 2.0.0.beta.6.dev ($Date:: 2020-04-21 #$)
List of supported compressors in this build: blosclz,lz4,lz4hc,lizard,zlib,zstd
Supported compression libraries:
  BloscLZ: 2.3.0
  LZ4: 1.9.1
  Lizard: 1.0.0
  Snappy: unknown
  Zlib: 10.0.3
  Zstd: 1.4.4
Using compressor: lz4
Using shuffle type: shuffle
Running suite: single
--> 6, 6291456, 8, 4, lz4, shuffle
********************** Run info ******************************
Blosc version: 2.0.0.beta.6.dev ($Date:: 2020-04-21 #$)
Using synthetic data with 4 significant bits (out of 32)
Dataset size: 6291456 bytes	Type size: 8 bytes
Working set: 252.0 MB		Number of threads: 6
********************** Running benchmarks *********************
memcpy(write):		 1123.2 us, 5341.7 MB/s
memcpy(read):		  390.2 us, 15377.3 MB/s
Compression level: 0
comp(write):	  470.0 us, 12764.8 MB/s	  Final bytes: 6291488  Ratio: 1.00
decomp(read):	  394.6 us, 15203.4 MB/s	  OK
Compression level: 1
comp(write):	  209.3 us, 28671.7 MB/s	  Final bytes: 37840  Ratio: 166.26
decomp(read):	  220.5 us, 27214.8 MB/s	  OK
Compression level: 2
comp(write):	  191.3 us, 31366.5 MB/s	  Final bytes: 31216  Ratio: 201.55
decomp(read):	  222.1 us, 27011.1 MB/s	  OK
Compression level: 3
comp(write):	  188.9 us, 31762.8 MB/s	  Final bytes: 31216  Ratio: 201.55
decomp(read):	  226.5 us, 26484.8 MB/s	  OK
Compression level: 4
comp(write):	  274.3 us, 21877.7 MB/s	  Final bytes: 25468  Ratio: 247.03
decomp(read):	  375.1 us, 15993.9 MB/s	  OK
Compression level: 5
comp(write):	  269.3 us, 22282.6 MB/s	  Final bytes: 25468  Ratio: 247.03
decomp(read):	  369.3 us, 16246.2 MB/s	  OK
Compression level: 6
comp(write):	  277.7 us, 21602.5 MB/s	  Final bytes: 25468  Ratio: 247.03
decomp(read):	  370.1 us, 16213.1 MB/s	  OK
Compression level: 7
comp(write):	  328.5 us, 18265.3 MB/s	  Final bytes: 25468  Ratio: 247.03
decomp(read):	  373.0 us, 16084.0 MB/s	  OK
Compression level: 8
comp(write):	  289.4 us, 20731.7 MB/s	  Final bytes: 25468  Ratio: 247.03
decomp(read):	  396.4 us, 15136.2 MB/s	  OK
Compression level: 9
comp(write):	  272.3 us, 22036.7 MB/s	  Final bytes: 25468  Ratio: 247.03
decomp(read):	  381.6 us, 15721.4 MB/s	  OK

Round-trip compr/decompr on 7.4 GB
Elapsed time:	    1.0 s, 16622.3 MB/s
```

With the support for run-length detection, we have:

```
faltet@Francescs-Mac-mini ~/b/c/build (run-split)> ./bench/b2bench lz4 shuffle single 6 6291456 8 4                                                      (base)
Blosc version: 2.0.0.beta.6.dev ($Date:: 2020-04-21 #$)
List of supported compressors in this build: blosclz,lz4,lz4hc,lizard,zlib,zstd
Supported compression libraries:
  BloscLZ: 2.3.0
  LZ4: 1.9.1
  Lizard: 1.0.0
  Snappy: unknown
  Zlib: 10.0.3
  Zstd: 1.4.4
Using compressor: lz4
Using shuffle type: shuffle
Running suite: single
--> 6, 6291456, 8, 4, lz4, shuffle
********************** Run info ******************************
Blosc version: 2.0.0.beta.6.dev ($Date:: 2020-04-21 #$)
Using synthetic data with 4 significant bits (out of 32)
Dataset size: 6291456 bytes	Type size: 8 bytes
Working set: 252.0 MB		Number of threads: 6
********************** Running benchmarks *********************
memcpy(write):		 1094.5 us, 5482.0 MB/s
memcpy(read):		  391.1 us, 15342.5 MB/s
Compression level: 0
comp(write):	  470.9 us, 12741.4 MB/s	  Final bytes: 6291488  Ratio: 1.00
decomp(read):	  400.9 us, 14964.8 MB/s	  OK
Compression level: 1
comp(write):	  172.3 us, 34813.9 MB/s	  Final bytes: 13072  Ratio: 481.29
decomp(read):	  110.0 us, 54566.6 MB/s	  OK
Compression level: 2
comp(write):	  160.1 us, 37466.0 MB/s	  Final bytes: 9616  Ratio: 654.27
decomp(read):	  111.2 us, 53950.4 MB/s	  OK
Compression level: 3
comp(write):	  156.1 us, 38433.3 MB/s	  Final bytes: 9616  Ratio: 654.27
decomp(read):	  113.0 us, 53100.7 MB/s	  OK
Compression level: 4
comp(write):	  283.7 us, 21146.1 MB/s	  Final bytes: 6604  Ratio: 952.67
decomp(read):	  281.4 us, 21325.0 MB/s	  OK
Compression level: 5
comp(write):	  248.4 us, 24154.9 MB/s	  Final bytes: 6604  Ratio: 952.67
decomp(read):	  271.0 us, 22143.6 MB/s	  OK
Compression level: 6
comp(write):	  245.2 us, 24470.3 MB/s	  Final bytes: 6604  Ratio: 952.67
decomp(read):	  283.6 us, 21158.6 MB/s	  OK
Compression level: 7
comp(write):	  240.0 us, 24994.8 MB/s	  Final bytes: 6604  Ratio: 952.67
decomp(read):	  267.5 us, 22427.7 MB/s	  OK
Compression level: 8
comp(write):	  218.2 us, 27501.1 MB/s	  Final bytes: 6604  Ratio: 952.67
decomp(read):	  316.4 us, 18961.5 MB/s	  OK
Compression level: 9
comp(write):	  284.0 us, 21124.1 MB/s	  Final bytes: 6604  Ratio: 952.67
decomp(read):	  266.9 us, 22484.5 MB/s	  OK

Round-trip compr/decompr on 7.4 GB
Elapsed time:	    0.8 s, 19659.3 MB/s
```

So, compression is both faster and more efficient.  Moreover, the run-length detection is very cheap, and it should not harm the vast majority of data distributions.  A worst case would be datasets where the values on  a split would be the same, except for the last few elements; but as the run-length detection function is fast, this is not too bad, even for such special cases.

This is done prior to any codec, so it benefits to all of them.