### PR TITLE
Added srcsize parameter to blosc2_decompress_ctx and blosc2_getitem_ctx.

### DIFF
--- a/bench/sum_openmp.c
+++ b/bench/sum_openmp.c
@@ -151,14 +151,14 @@ int main(void) {
       return 1;
     }
   }
-  cparams.compcode = codec;
+  cparams.compcode = (uint8_t)codec;
 
   long clevel = CLEVEL;
   envvar = getenv("SUM_CLEVEL");
   if (envvar != NULL) {
     clevel = strtol(envvar, NULL, 10);
   }
-  cparams.clevel = clevel;
+  cparams.clevel = (uint8_t)clevel;
 
   cparams.typesize = sizeof(DTYPE);
   cparams.nthreads = 1;
@@ -208,7 +208,7 @@ int main(void) {
     for (j = 0; j < nthreads; j++) {
       dctx[j] = blosc2_create_dctx(dparams);
       for (nchunk = 0; nchunk < nchunks_thread; nchunk++) {
-        blosc2_decompress_ctx(dctx[j], schunk->data[j * nchunks_thread + nchunk],
+        blosc2_decompress_ctx(dctx[j], schunk->data[j * nchunks_thread + nchunk], INT32_MAX, 
                               (void*)(chunk[j]), isize);
         for (i = 0; i < CHUNKSIZE; i++) {
           compressed_sum += chunk[j][i];
@@ -217,7 +217,7 @@ int main(void) {
       }
     }
     for (nchunk = NCHUNKS - remaining_chunks; nchunk < NCHUNKS; nchunk++) {
-      blosc2_decompress_ctx(dctx[0], schunk->data[nchunk], (void*)(chunk[0]), isize);
+      blosc2_decompress_ctx(dctx[0], schunk->data[nchunk], INT32_MAX, (void*)(chunk[0]), isize);
       for (i = 0; i < CHUNKSIZE; i++) {
         compressed_sum += chunk[0][i];
         //compressed_sum += i + nchunk * CHUNKSIZE;

--- a/blosc/blosc2.h
+++ b/blosc/blosc2.h
@@ -779,6 +779,7 @@ BLOSC_EXPORT int blosc2_compress_ctx(
  *
  * @param context The blosc2_context struct with the different compression params.
  * @param src The buffer of compressed data.
+ * @param srcsize The length of buffer of compressed data.
  * @param dest The buffer where the decompressed data will be put.
  * @param destsize The size in bytes of the @p dest buffer.
  *
@@ -803,19 +804,19 @@ BLOSC_EXPORT int blosc2_compress_ctx(
  * then 0 (zero) or a negative value will be returned instead.
  */
 BLOSC_EXPORT int blosc2_decompress_ctx(blosc2_context* context, const void* src,
-                                       void* dest, size_t destsize);
+                                       size_t srcsize, void* dest, size_t destsize);
 
 /**
  * @brief Context interface counterpart for #blosc_getitem.
  *
  * It uses similar parameters than the blosc_getitem() function plus a
- * @p context parameter.
+ * @p context parameter and @srcsize compressed buffer length parameter.
  *
  * @return The number of bytes copied to @p dest or a negative value if
  * some error happens.
  */
 BLOSC_EXPORT int blosc2_getitem_ctx(blosc2_context* context, const void* src,
-                                    int start, int nitems, void* dest);
+                                    size_t srcsize, int start, int nitems, void* dest);
 
 
 /*********************************************************************

--- a/blosc/context.h
+++ b/blosc/context.h
@@ -48,6 +48,8 @@ struct blosc2_context_s {
   int32_t blocksize;
   /* Length of the block in bytes */
   int32_t output_bytes;
+  /* Counter for the number of input bytes */
+  int32_t srcsize;
   /* Counter for the number of output bytes */
   int32_t destsize;
   /* Maximum size for destination buffer */

--- a/blosc/schunk.c
+++ b/blosc/schunk.c
@@ -245,8 +245,8 @@ int blosc2_schunk_decompress_chunk(blosc2_schunk *schunk, int nchunk,
                       "('%zd' bytes, but '%d' are needed)\n", nbytes, nbytes_);
       return -11;
     }
-
-    chunksize = blosc2_decompress_ctx(schunk->dctx, src, dest, nbytes);
+    int cbytes = sw32_(src + 12);
+    chunksize = blosc2_decompress_ctx(schunk->dctx, src, cbytes, dest, nbytes);
     if (chunksize < 0 || chunksize != nbytes_) {
       fprintf(stderr, "Error in decompressing chunk");
       return -11;
@@ -466,7 +466,7 @@ int32_t blosc2_get_usermeta(blosc2_schunk* schunk, uint8_t** content) {
   blosc_cbuffer_sizes(schunk->usermeta, &nbytes, &cbytes, &blocksize);
   *content = malloc(nbytes);
   blosc2_context *dctx = blosc2_create_dctx(BLOSC2_DPARAMS_DEFAULTS);
-  int usermeta_nbytes = blosc2_decompress_ctx(dctx, schunk->usermeta, *content, nbytes);
+  int usermeta_nbytes = blosc2_decompress_ctx(dctx, schunk->usermeta, schunk->usermeta_len, *content, nbytes);
   blosc2_free_ctx(dctx);
   if (usermeta_nbytes < 0) {
     return -1;

--- a/examples/contexts.c
+++ b/examples/contexts.c
@@ -73,7 +73,7 @@ int main(void) {
   dparams.nthreads = NTHREADS;
   dctx = blosc2_create_dctx(dparams);
 
-  ret = blosc2_getitem_ctx(dctx, data_out, 5, 5, data_subset);
+  ret = blosc2_getitem_ctx(dctx, data_out, csize, 5, 5, data_subset);
   if (ret < 0) {
     printf("Error in blosc2_getitem_ctx().  Giving up.\n");
     return 1;
@@ -88,7 +88,7 @@ int main(void) {
   printf("Correctly extracted 5 elements from compressed chunk!\n");
 
   /* Decompress  */
-  dsize = blosc2_decompress_ctx(dctx, data_out, data_dest, dsize);
+  dsize = blosc2_decompress_ctx(dctx, data_out, csize, data_dest, dsize);
   if (dsize < 0) {
     printf("Decompression error.  Error code: %d\n", dsize);
     return dsize;

--- a/tests/test_contexts.c
+++ b/tests/test_contexts.c
@@ -58,7 +58,7 @@ int main(void) {
   dparams.nthreads = NTHREADS;
   dctx = blosc2_create_dctx(dparams);
 
-  ret = blosc2_getitem_ctx(dctx, data_out, 5, 5, data_subset);
+  ret = blosc2_getitem_ctx(dctx, data_out, csize, 5, 5, data_subset);
   if (ret < 0) {
     printf("Error in blosc2_getitem_ctx().  Giving up.\n");
     return EXIT_FAILURE;
@@ -72,7 +72,7 @@ int main(void) {
   }
 
   /* Decompress  */
-  dsize = blosc2_decompress_ctx(dctx, data_out, data_dest, (size_t)dsize);
+  dsize = blosc2_decompress_ctx(dctx, data_out, csize, data_dest, (size_t)dsize);
   if (dsize < 0) {
     printf("Decompression error.  Error code: %d\n", dsize);
     return EXIT_FAILURE;

--- a/tests/test_maskout.c
+++ b/tests/test_maskout.c
@@ -31,7 +31,7 @@ int nblocks;
 // Check decompression without mask
 static char *test_nomask(void) {
   blosc2_context *dctx = blosc2_create_dctx(BLOSC2_DPARAMS_DEFAULTS);
-  nbytes = blosc2_decompress_ctx(dctx, dest, dest2, bytesize);
+  nbytes = blosc2_decompress_ctx(dctx, dest, cbytes, dest2, bytesize);
   mu_assert("ERROR: nbytes is not correct", nbytes == bytesize);
 
   int64_t* _src = src;
@@ -50,7 +50,7 @@ static char *test_mask(void) {
 
   memset(dest2, 0, bytesize);
   mu_assert("ERROR: setting maskout", blosc2_set_maskout(dctx, maskout, nblocks) == 0);
-  nbytes = blosc2_decompress_ctx(dctx, dest, dest2, bytesize);
+  nbytes = blosc2_decompress_ctx(dctx, dest, cbytes, dest2, bytesize);
   mu_assert("ERROR: nbytes is not correct", nbytes == bytesize);
 
   int64_t* _src = srcmasked;
@@ -71,7 +71,7 @@ static char *test_mask_nomask(void) {
 
   memset(dest2, 0, bytesize);
   mu_assert("ERROR: setting maskout", blosc2_set_maskout(dctx, maskout, nblocks) == 0);
-  nbytes = blosc2_decompress_ctx(dctx, dest, dest2, bytesize);
+  nbytes = blosc2_decompress_ctx(dctx, dest, cbytes, dest2, bytesize);
   mu_assert("ERROR: nbytes is not correct w/ mask", nbytes == bytesize);
 
   int64_t* _src = srcmasked;  // masked source
@@ -81,7 +81,7 @@ static char *test_mask_nomask(void) {
   }
 
   memset(dest2, 0, bytesize);
-  nbytes = blosc2_decompress_ctx(dctx, dest, dest2, bytesize);
+  nbytes = blosc2_decompress_ctx(dctx, dest, cbytes, dest2, bytesize);
   mu_assert("ERROR: nbytes is not correct w/out mask", nbytes == bytesize);
 
   _src = src;   // original source
@@ -102,7 +102,7 @@ static char *test_mask_nomask_mask(void) {
 
   memset(dest2, 0, bytesize);
   mu_assert("ERROR: setting maskout", blosc2_set_maskout(dctx, maskout, nblocks) == 0);
-  nbytes = blosc2_decompress_ctx(dctx, dest, dest2, bytesize);
+  nbytes = blosc2_decompress_ctx(dctx, dest, cbytes, dest2, bytesize);
   mu_assert("ERROR: nbytes is not correct w/ mask", nbytes == bytesize);
 
   int64_t* _src = srcmasked;  // masked source
@@ -112,7 +112,7 @@ static char *test_mask_nomask_mask(void) {
   }
 
   memset(dest2, 0, bytesize);
-  nbytes = blosc2_decompress_ctx(dctx, dest, dest2, bytesize);
+  nbytes = blosc2_decompress_ctx(dctx, dest, cbytes, dest2, bytesize);
   mu_assert("ERROR: nbytes is not correct w/out mask", nbytes == bytesize);
 
   _src = src;   // original source
@@ -123,7 +123,7 @@ static char *test_mask_nomask_mask(void) {
 
   memset(dest2, 0, bytesize);
   mu_assert("ERROR: setting maskout", blosc2_set_maskout(dctx, maskout2, nblocks) == 0);
-  nbytes = blosc2_decompress_ctx(dctx, dest, dest2, bytesize);
+  nbytes = blosc2_decompress_ctx(dctx, dest, cbytes, dest2, bytesize);
   mu_assert("ERROR: nbytes is not correct w/out mask", nbytes == bytesize);
 
   _src = srcmasked2;  // masked source

--- a/tests/test_prefilter.c
+++ b/tests/test_prefilter.c
@@ -75,7 +75,7 @@ static char *test_prefilter1(void) {
   dctx = blosc2_create_dctx(dparams);
 
   /* Decompress  */
-  dsize = blosc2_decompress_ctx(dctx, data_out, data_dest, (size_t)dsize);
+  dsize = blosc2_decompress_ctx(dctx, data_out, csize, data_dest, (size_t)dsize);
   mu_assert("Decompression error", dsize > 0);
 
   for (int i = 0; i < SIZE; i++) {
@@ -113,7 +113,7 @@ static char *test_prefilter2(void) {
   dctx = blosc2_create_dctx(dparams);
 
   /* Decompress  */
-  dsize = blosc2_decompress_ctx(dctx, data_out, data_dest, (size_t)dsize);
+  dsize = blosc2_decompress_ctx(dctx, data_out, csize, data_dest, (size_t)dsize);
   mu_assert("Decompression error", dsize > 0);
 
   for (int i = 0; i < SIZE; i++) {


### PR DESCRIPTION
This PR adds additional checks to `src` buffers when passing into `blosc2_decompres_ctx` and `blosc2_getitem_ctx` to ensure that blosc2 library does not read past the end of the provided buffer. When reading it checks to see that there is sufficient space in `src` to be able to read the required bytes.

This should fix issues where the Blosc2 header might contain an corrupt/malicious size or offset value and try to read past the end of the `src` buffer.