### PR TITLE
Add secure versions of blosc_compress and blosc_decompress

### DIFF
--- a/blosc/blosc2.c
+++ b/blosc/blosc2.c
@@ -964,7 +964,7 @@ int pipeline_d(blosc2_context* context, const int32_t bsize, uint8_t* dest,
 /* Decompress & unshuffle a single block */
 static int blosc_d(
     struct thread_context* thread_context, int32_t bsize,
-    int32_t leftoverblock, const uint8_t* src, size_t srcsize, uint8_t* dest,
+    int32_t leftoverblock, const uint8_t* src, int32_t srcsize, uint8_t* dest,
     int32_t offset, uint8_t* tmp, uint8_t* tmp2) {
   blosc2_context* context = thread_context->parent_context;
   uint8_t* filters = context->filters;
@@ -1373,7 +1373,7 @@ static void flags_to_filters(const uint8_t flags, uint8_t* filters) {
 
 
 static int initialize_context_compression(
-  blosc2_context* context, const void* src, size_t srcsize, void* dest,
+  blosc2_context* context, const void* src, int32_t srcsize, void* dest,
   int32_t destsize, int clevel, uint8_t const *filters,
   uint8_t const *filters_meta, int32_t typesize, int compressor,
   int32_t blocksize, int new_nthreads, int nthreads, blosc2_schunk* schunk) {
@@ -1814,8 +1814,8 @@ int blosc_compress_context(blosc2_context* context) {
 
 
 /* The public secure routine for compression with context. */
-int blosc2_compress_ctx(blosc2_context* context, const void* src, size_t srcsize,
-                        void* dest, size_t destsize) {
+int blosc2_compress_ctx(blosc2_context* context, const void* src, int32_t srcsize,
+                        void* dest, int32_t destsize) {
   int error, cbytes;
 
   if (context->do_compress != 1) {
@@ -1934,8 +1934,8 @@ void build_filters(const int doshuffle, const int delta,
 }
 
 /* The public secure routine for compression. */
-int blosc2_compress(int clevel, int doshuffle, size_t typesize,
-                    const void* src, size_t srcsize, void* dest, size_t destsize) {
+int blosc2_compress(int clevel, int doshuffle, int32_t typesize,
+                    const void* src, int32_t srcsize, void* dest, int32_t destsize) {
   int error;
   int result;
   char* envvar;
@@ -2077,12 +2077,12 @@ int blosc2_compress(int clevel, int doshuffle, size_t typesize,
 /* The public routine for compression. */
 int blosc_compress(int clevel, int doshuffle, size_t typesize, size_t nbytes,
                    const void* src, void* dest, size_t destsize) {
-  return blosc2_compress(clevel, doshuffle, typesize, src, nbytes, dest, destsize);
+  return blosc2_compress(clevel, doshuffle, (int32_t)typesize, src, (int32_t)nbytes, dest, (int32_t)destsize);
 }
 
 
-int blosc_run_decompression_with_context(blosc2_context* context, const void* src, size_t srcsize,
-                                         void* dest, size_t destsize) {
+int blosc_run_decompression_with_context(blosc2_context* context, const void* src, int32_t srcsize,
+                                         void* dest, int32_t destsize) {
   int32_t ntbytes;
   uint8_t* _src = (uint8_t*)src;
   uint8_t version;
@@ -2132,8 +2132,8 @@ int blosc_run_decompression_with_context(blosc2_context* context, const void* sr
 
 
 /* The public secure routine for decompression with context. */
-int blosc2_decompress_ctx(blosc2_context* context, const void* src, size_t srcsize,
-                          void* dest, size_t destsize) {
+int blosc2_decompress_ctx(blosc2_context* context, const void* src, int32_t srcsize,
+                          void* dest, int32_t destsize) {
   int result;
 
   if (context->do_compress != 0) {
@@ -2155,7 +2155,7 @@ int blosc2_decompress_ctx(blosc2_context* context, const void* src, size_t srcsi
 
 
 /* The public secure routine for decompression. */
-int blosc2_decompress(const void* src, size_t srcsize, void* dest, size_t destsize) {
+int blosc2_decompress(const void* src, int32_t srcsize, void* dest, int32_t destsize) {
   int result;
   char* envvar;
   long nthreads;
@@ -2200,14 +2200,14 @@ int blosc2_decompress(const void* src, size_t srcsize, void* dest, size_t destsi
 
 /* The public routine for decompression. */
 int blosc_decompress(const void* src, void* dest, size_t destsize) {
-  return blosc2_decompress(src, INT32_MAX, dest, destsize);
+  return blosc2_decompress(src, INT32_MAX, dest, (int32_t)destsize);
 }
 
 
 /* Specific routine optimized for decompression a small number of
    items out of a compressed chunk.  This does not use threads because
    it would affect negatively to performance. */
-int _blosc_getitem(blosc2_context* context, const void* src, size_t srcsize,
+int _blosc_getitem(blosc2_context* context, const void* src, int32_t srcsize,
                    int start, int nitems, void* dest) {
   uint8_t* _src = NULL;             /* current pos for source buffer */
   uint8_t flags;                    /* flags for header */
@@ -2393,7 +2393,7 @@ int blosc_getitem(const void* src, int start, int nitems, void* dest) {
   return result;
 }
 
-int blosc2_getitem_ctx(blosc2_context* context, const void* src, size_t srcsize,
+int blosc2_getitem_ctx(blosc2_context* context, const void* src, int32_t srcsize,
     int start, int nitems, void* dest) {
   uint8_t* _src = (uint8_t*)(src);
   int result;

--- a/blosc/blosc2.c
+++ b/blosc/blosc2.c
@@ -1583,12 +1583,12 @@ static int initialize_context_decompression(blosc2_context* context, const void*
       return -1;
     }
     context->dict_size = (size_t)sw32_(bstarts_end);
-    if (src_end < (uint8_t *)(bstarts_end + 1) + context->dict_size) {
-      /* Not enough input to read entire dictionary */
+    if (context->dict_size <= 0 || context->dict_size > BLOSC2_MAXDICTSIZE) {
+      /* Dictionary size is smaller than minimum or larger than maximum allowed */
       return -1;
     }
-    if (context->dict_size > BLOSC2_MAXDICTSIZE) {
-      /* Dictionary is larger than maximum size allowed */
+    if (src_end < (uint8_t *)(bstarts_end + 1) + context->dict_size) {
+      /* Not enough input to read entire dictionary */
       return -1;
     }
     context->dict_buffer = (void*)(bstarts_end + 1);

--- a/blosc/blosc2.c
+++ b/blosc/blosc2.c
@@ -1813,8 +1813,8 @@ int blosc_compress_context(blosc2_context* context) {
 
 
 /* The public routine for compression with context. */
-int blosc2_compress_ctx(blosc2_context* context, size_t nbytes,
-                        const void* src, void* dest, size_t destsize) {
+int blosc2_compress_ctx(blosc2_context* context, const void* src, size_t srcsize,
+                        void* dest, size_t destsize) {
   int error, cbytes;
 
   if (context->do_compress != 1) {
@@ -1823,7 +1823,7 @@ int blosc2_compress_ctx(blosc2_context* context, size_t nbytes,
   }
 
   error = initialize_context_compression(
-    context, (int32_t)nbytes, src, dest, (int32_t)destsize,
+    context, (int32_t)srcsize, src, dest, (int32_t)destsize,
     context->clevel, context->filters, context->filters_meta,
     context->typesize, context->compcode, context->blocksize,
     context->new_nthreads, context->nthreads, context->schunk);
@@ -1856,8 +1856,8 @@ int blosc2_compress_ctx(blosc2_context* context, size_t nbytes,
     // Build the dictionary out of the filters outcome and compress with it
     size_t dict_maxsize = BLOSC2_MAXDICTSIZE;
     // Do not make the dict more than 5% larger than uncompressed buffer
-    if (dict_maxsize > nbytes / 20) {
-      dict_maxsize = nbytes / 20;
+    if (dict_maxsize > srcsize / 20) {
+      dict_maxsize = srcsize / 20;
     }
     void* samples_buffer = context->dest + BLOSC_EXTENDED_HEADER_LENGTH;
     unsigned nblocks = 8;  // the minimum that accepts zstd as of 1.4.0
@@ -2036,7 +2036,7 @@ int blosc_compress(int clevel, int doshuffle, size_t typesize, size_t nbytes,
     cparams.nthreads = (uint8_t)g_nthreads;
     cctx = blosc2_create_cctx(cparams);
     /* Do the actual compression */
-    result = blosc2_compress_ctx(cctx, nbytes, src, dest, destsize);
+    result = blosc2_compress_ctx(cctx, src, nbytes, dest, destsize);
     /* Release context resources */
     blosc2_free_ctx(cctx);
     return result;

--- a/blosc/blosc2.h
+++ b/blosc/blosc2.h
@@ -271,48 +271,9 @@ BLOSC_EXPORT void blosc_destroy(void);
  * buffer. A negative return value means that an internal error happened. This
  * should never happen. If you see this, please report it back
  * together with the buffer data causing this and compression settings.
-*/
-/*
- * Environment variables
- * _____________________
  *
- * *blosc_compress()* honors different environment variables to control
- * internal parameters without the need of doing that programatically.
- * Here are the ones supported:
- *
- * **BLOSC_CLEVEL=(INTEGER)**: This will overwrite the @p clevel parameter
- * before the compression process starts.
- *
- * **BLOSC_SHUFFLE=[NOSHUFFLE | SHUFFLE | BITSHUFFLE]**: This will
- * overwrite the *doshuffle* parameter before the compression process
- * starts.
- *
- * **BLOSC_DELTA=(1|0)**: This will call *blosc_set_delta()^* before the
- * compression process starts.
- *
- * **BLOSC_TYPESIZE=(INTEGER)**: This will overwrite the *typesize*
- * parameter before the compression process starts.
- *
- * **BLOSC_COMPRESSOR=[BLOSCLZ | LZ4 | LZ4HC | LIZARD | SNAPPY | ZLIB]**:
- * This will call *blosc_set_compressor(BLOSC_COMPRESSOR)* before the
- * compression process starts.
- *
- * **BLOSC_NTHREADS=(INTEGER)**: This will call
- * *blosc_set_nthreads(BLOSC_NTHREADS)* before the compression process
- * starts.
- *
- * **BLOSC_BLOCKSIZE=(INTEGER)**: This will call
- * *blosc_set_blocksize(BLOSC_BLOCKSIZE)* before the compression process
- * starts.  *NOTE:* The blocksize is a critical parameter with
- * important restrictions in the allowed values, so use this with care.
- *
- * **BLOSC_NOLOCK=(ANY VALUE)**: This will call *blosc2_compress_ctx()* under
- * the hood, with the *compressor*, *blocksize* and
- * *numinternalthreads* parameters set to the same as the last calls to
- * *blosc_set_compressor*, *blosc_set_blocksize* and
- * *blosc_set_nthreads*. *BLOSC_CLEVEL*, *BLOSC_SHUFFLE*, *BLOSC_DELTA* and
- * *BLOSC_TYPESIZE* environment vars will also be honored.
- *
+ * This function supports all the configuration based environment variables
+ * available in blosc2_compress.
  */
 BLOSC_EXPORT int blosc_compress(int clevel, int doshuffle, size_t typesize,
                                 size_t nbytes, const void* src, void* dest,
@@ -341,23 +302,9 @@ BLOSC_EXPORT int blosc_compress(int clevel, int doshuffle, size_t typesize,
  * If an error occurs, e.g. the compressed data is corrupted or the
  * output buffer is not large enough, then 0 (zero) or a negative value
  * will be returned instead.
-*/
-/*
- * Environment variables
- * _____________________
  *
- * *blosc_decompress* honors different environment variables to control
- * internal parameters without the need of doing that programatically.
- * Here are the ones supported:
- *
- * **BLOSC_NTHREADS=(INTEGER)**: This will call
- * *blosc_set_nthreads(BLOSC_NTHREADS)* before the proper decompression
- * process starts.
- *
- * **BLOSC_NOLOCK=(ANY VALUE)**: This will call *blosc2_decompress_ctx*
- * under the hood, with the *numinternalthreads* parameter set to the
- * same value as the last call to *blosc_set_nthreads*.
- *
+ * This function supports all the configuration based environment variables
+ * available in blosc2_decompress.
  */
 BLOSC_EXPORT int blosc_decompress(const void* src, void* dest, size_t destsize);
 
@@ -745,6 +692,133 @@ BLOSC_EXPORT void blosc2_free_ctx(blosc2_context* context);
  *
  */
 BLOSC_EXPORT int blosc2_set_maskout(blosc2_context *ctx, bool *maskout, int nblocks);
+/**
+ * @brief Compress a block of data in the @p src buffer and returns the size of
+ * compressed block.
+ *
+ * @remark Compression is memory safe and guaranteed not to write @p dest
+ * more than what is specified in @p destsize.
+ * There is not a minimum for @p src buffer size @p nbytes.
+ *
+ * @warning The @p src buffer and the @p dest buffer can not overlap.
+ *
+ * @param clevel The desired compression level and must be a number
+ * between 0 (no compression) and 9 (maximum compression).
+ * @param doshuffle Specifies whether the shuffle compression preconditioner
+ * should be applied or not. @a BLOSC_NOFILTER means not applying filters,
+ * @a BLOSC_SHUFFLE means applying shuffle at a byte level and
+ * @a BLOSC_BITSHUFFLE at a bit level (slower but *may* achieve better
+ * compression).
+ * @param typesize Is the number of bytes for the atomic type in binary
+ * @p src buffer.  This is mainly useful for the shuffle preconditioner.
+ * For implementation reasons, only a 1 < typesize < 256 will allow the
+ * shuffle filter to work.  When typesize is not in this range, shuffle
+ * will be silently disabled.
+ * @param src The buffer containing the data to compress.
+ * @param srcsize The number of bytes to compress in the @p src buffer.
+ * @param dest The buffer where the compressed data will be put,
+ * must have at least the size of @p destsize.
+ * @param destsize The size of the dest buffer. Blosc
+ * guarantees that if you set @p destsize to, at least,
+ * (@p nbytes + @a BLOSC_MAX_OVERHEAD), the compression will always succeed.
+ *
+ * @return The number of bytes compressed.
+ * If @p src buffer cannot be compressed into @p destsize, the return
+ * value is zero and you should discard the contents of the @p dest
+ * buffer. A negative return value means that an internal error happened. This
+ * should never happen. If you see this, please report it back
+ * together with the buffer data causing this and compression settings.
+*/
+/*
+ * Environment variables
+ * _____________________
+ *
+ * *blosc_compress()* honors different environment variables to control
+ * internal parameters without the need of doing that programatically.
+ * Here are the ones supported:
+ *
+ * **BLOSC_CLEVEL=(INTEGER)**: This will overwrite the @p clevel parameter
+ * before the compression process starts.
+ *
+ * **BLOSC_SHUFFLE=[NOSHUFFLE | SHUFFLE | BITSHUFFLE]**: This will
+ * overwrite the *doshuffle* parameter before the compression process
+ * starts.
+ *
+ * **BLOSC_DELTA=(1|0)**: This will call *blosc_set_delta()^* before the
+ * compression process starts.
+ *
+ * **BLOSC_TYPESIZE=(INTEGER)**: This will overwrite the *typesize*
+ * parameter before the compression process starts.
+ *
+ * **BLOSC_COMPRESSOR=[BLOSCLZ | LZ4 | LZ4HC | LIZARD | SNAPPY | ZLIB]**:
+ * This will call *blosc_set_compressor(BLOSC_COMPRESSOR)* before the
+ * compression process starts.
+ *
+ * **BLOSC_NTHREADS=(INTEGER)**: This will call
+ * *blosc_set_nthreads(BLOSC_NTHREADS)* before the compression process
+ * starts.
+ *
+ * **BLOSC_BLOCKSIZE=(INTEGER)**: This will call
+ * *blosc_set_blocksize(BLOSC_BLOCKSIZE)* before the compression process
+ * starts.  *NOTE:* The blocksize is a critical parameter with
+ * important restrictions in the allowed values, so use this with care.
+ *
+ * **BLOSC_NOLOCK=(ANY VALUE)**: This will call *blosc2_compress_ctx()* under
+ * the hood, with the *compressor*, *blocksize* and
+ * *numinternalthreads* parameters set to the same as the last calls to
+ * *blosc_set_compressor*, *blosc_set_blocksize* and
+ * *blosc_set_nthreads*. *BLOSC_CLEVEL*, *BLOSC_SHUFFLE*, *BLOSC_DELTA* and
+ * *BLOSC_TYPESIZE* environment vars will also be honored.
+ *
+ */
+BLOSC_EXPORT int blosc2_compress(int clevel, int doshuffle, size_t typesize,
+                                 const void* src, size_t srcsize, void* dest,
+                                 size_t destsize);
+
+
+/**
+ * @brief Decompress a block of compressed data in @p src, put the result in
+ * @p dest and returns the size of the decompressed block.
+ *
+ * @warning The @p src buffer and the @p dest buffer can not overlap.
+ *
+ * @remark Decompression is memory safe and guaranteed not to write the @p dest
+ * buffer more than what is specified in @p destsize.
+ *
+ * @remark In case you want to keep under control the number of bytes read from
+ * source, you can call #blosc_cbuffer_sizes first to check whether the
+ * @p nbytes (i.e. the number of bytes to be read from @p src buffer by this
+ * function) in the compressed buffer is ok with you.
+ *
+ * @param src The buffer to be decompressed.
+ * @param srcsize The size of the buffer to be decompressed.
+ * @param dest The buffer where the decompressed data will be put.
+ * @param destsize The size of the @p dest buffer.
+ *
+ * @return The number of bytes decompressed.
+ * If an error occurs, e.g. the compressed data is corrupted or the
+ * output buffer is not large enough, then 0 (zero) or a negative value
+ * will be returned instead.
+*/
+/*
+ * Environment variables
+ * _____________________
+ *
+ * *blosc_decompress* honors different environment variables to control
+ * internal parameters without the need of doing that programatically.
+ * Here are the ones supported:
+ *
+ * **BLOSC_NTHREADS=(INTEGER)**: This will call
+ * *blosc_set_nthreads(BLOSC_NTHREADS)* before the proper decompression
+ * process starts.
+ *
+ * **BLOSC_NOLOCK=(ANY VALUE)**: This will call *blosc2_decompress_ctx*
+ * under the hood, with the *numinternalthreads* parameter set to the
+ * same value as the last call to *blosc_set_nthreads*.
+ *
+ */
+BLOSC_EXPORT int blosc2_decompress(const void* src, size_t srcsize,
+                                   void* dest, size_t destsize);
 
 /**
  * @brief Context interface to Blosc compression. This does not require a call

--- a/blosc/blosc2.h
+++ b/blosc/blosc2.h
@@ -753,8 +753,8 @@ BLOSC_EXPORT int blosc2_set_maskout(blosc2_context *ctx, bool *maskout, int nblo
  * simultaneously in those scenarios.
  *
  * @param context A blosc2_context struct with the different compression params.
- * @param nbytes The number of bytes to be compressed from the @p src buffer.
  * @param src The buffer containing the data to be compressed.
+ * @param srcsize The number of bytes to be compressed from the @p src buffer.
  * @param dest The buffer where the compressed data will be put.
  * @param destsize The size in bytes of the @p dest buffer.
  *
@@ -767,7 +767,7 @@ BLOSC_EXPORT int blosc2_set_maskout(blosc2_context *ctx, bool *maskout, int nblo
  * and compression settings.
  */
 BLOSC_EXPORT int blosc2_compress_ctx(
-        blosc2_context* context, size_t nbytes, const void* src, void* dest,
+        blosc2_context* context, const void* src, size_t srcsize, void* dest,
         size_t destsize);
 
 

--- a/blosc/blosc2.h
+++ b/blosc/blosc2.h
@@ -771,9 +771,9 @@ BLOSC_EXPORT int blosc2_set_maskout(blosc2_context *ctx, bool *maskout, int nblo
  * *BLOSC_TYPESIZE* environment vars will also be honored.
  *
  */
-BLOSC_EXPORT int blosc2_compress(int clevel, int doshuffle, size_t typesize,
-                                 const void* src, size_t srcsize, void* dest,
-                                 size_t destsize);
+BLOSC_EXPORT int blosc2_compress(int clevel, int doshuffle, int32_t typesize,
+                                 const void* src, int32_t srcsize, void* dest,
+                                 int32_t destsize);
 
 
 /**
@@ -817,8 +817,8 @@ BLOSC_EXPORT int blosc2_compress(int clevel, int doshuffle, size_t typesize,
  * same value as the last call to *blosc_set_nthreads*.
  *
  */
-BLOSC_EXPORT int blosc2_decompress(const void* src, size_t srcsize,
-                                   void* dest, size_t destsize);
+BLOSC_EXPORT int blosc2_decompress(const void* src, int32_t srcsize,
+                                   void* dest, int32_t destsize);
 
 /**
  * @brief Context interface to Blosc compression. This does not require a call
@@ -841,8 +841,8 @@ BLOSC_EXPORT int blosc2_decompress(const void* src, size_t srcsize,
  * and compression settings.
  */
 BLOSC_EXPORT int blosc2_compress_ctx(
-        blosc2_context* context, const void* src, size_t srcsize, void* dest,
-        size_t destsize);
+        blosc2_context* context, const void* src, int32_t srcsize, void* dest,
+        int32_t destsize);
 
 
 /**
@@ -878,7 +878,7 @@ BLOSC_EXPORT int blosc2_compress_ctx(
  * then 0 (zero) or a negative value will be returned instead.
  */
 BLOSC_EXPORT int blosc2_decompress_ctx(blosc2_context* context, const void* src,
-                                       size_t srcsize, void* dest, size_t destsize);
+                                       int32_t srcsize, void* dest, int32_t destsize);
 
 /**
  * @brief Context interface counterpart for #blosc_getitem.
@@ -890,7 +890,7 @@ BLOSC_EXPORT int blosc2_decompress_ctx(blosc2_context* context, const void* src,
  * some error happens.
  */
 BLOSC_EXPORT int blosc2_getitem_ctx(blosc2_context* context, const void* src,
-                                    size_t srcsize, int start, int nitems, void* dest);
+                                    int32_t srcsize, int start, int nitems, void* dest);
 
 
 /*********************************************************************
@@ -1015,7 +1015,7 @@ BLOSC_EXPORT int blosc2_schunk_append_chunk(blosc2_schunk *schunk, uint8_t *chun
  * @return The number of chunks in super-chunk. If some problem is
  * detected, this number will be negative.
  */
-BLOSC_EXPORT int blosc2_schunk_append_buffer(blosc2_schunk *schunk, void *src, size_t nbytes);
+BLOSC_EXPORT int blosc2_schunk_append_buffer(blosc2_schunk *schunk, void *src, int32_t nbytes);
 
 /**
  * @brief Decompress and return the @p nchunk chunk of a super-chunk.
@@ -1034,7 +1034,7 @@ BLOSC_EXPORT int blosc2_schunk_append_buffer(blosc2_schunk *schunk, void *src, s
  * @return The size of the decompressed chunk. If some problem is
  * detected, a negative code is returned instead.
  */
-BLOSC_EXPORT int blosc2_schunk_decompress_chunk(blosc2_schunk *schunk, int nchunk, void *dest, size_t nbytes);
+BLOSC_EXPORT int blosc2_schunk_decompress_chunk(blosc2_schunk *schunk, int nchunk, void *dest, int32_t nbytes);
 
 /**
  * @brief Return a compressed chunk that is part of a super-chunk in the @p chunk parameter.

--- a/blosc/frame.c
+++ b/blosc/frame.c
@@ -556,7 +556,7 @@ int64_t blosc2_schunk_to_frame(blosc2_schunk *schunk, blosc2_frame *frame) {
     off_chunk = malloc(off_nbytes + BLOSC_MAX_OVERHEAD);
     blosc2_context *cctx = blosc2_create_cctx(BLOSC2_CPARAMS_DEFAULTS);
     cctx->typesize = 8;
-    off_cbytes = blosc2_compress_ctx(cctx, off_nbytes, data_tmp, off_chunk,
+    off_cbytes = blosc2_compress_ctx(cctx, data_tmp, off_nbytes, off_chunk,
                                      off_nbytes + BLOSC_MAX_OVERHEAD);
     blosc2_free_ctx(cctx);
     if (off_cbytes < 0) {
@@ -1240,7 +1240,7 @@ void* frame_append_chunk(blosc2_frame* frame, void* chunk, blosc2_schunk* schunk
   blosc2_context* cctx = blosc2_create_cctx(BLOSC2_CPARAMS_DEFAULTS);
   cctx->typesize = 8;
   void* off_chunk = malloc((size_t)off_nbytes + BLOSC_MAX_OVERHEAD);
-  int32_t new_off_cbytes = blosc2_compress_ctx(cctx, (size_t)off_nbytes, offsets,
+  int32_t new_off_cbytes = blosc2_compress_ctx(cctx, offsets, (size_t)off_nbytes,
           off_chunk, (size_t)off_nbytes + BLOSC_MAX_OVERHEAD);
   blosc2_free_ctx(cctx);
   int64_t offset;

--- a/blosc/frame.h
+++ b/blosc/frame.h
@@ -43,7 +43,7 @@
 void* frame_append_chunk(blosc2_frame* frame, void* chunk, blosc2_schunk* schunk);
 int frame_get_chunk(blosc2_frame *frame, int nchunk, uint8_t **chunk, bool *needs_free);
 int frame_decompress_chunk(blosc2_context *dctx, blosc2_frame *frame, int nchunk,
-                           void *dest, size_t nbytes);
+                           void *dest, int32_t nbytes);
 int frame_update_header(blosc2_frame* frame, blosc2_schunk* schunk, bool new);
 int frame_update_trailer(blosc2_frame* frame, blosc2_schunk* schunk);
 

--- a/blosc/schunk.c
+++ b/blosc/schunk.c
@@ -213,7 +213,7 @@ int blosc2_schunk_append_buffer(blosc2_schunk *schunk, void *src, size_t nbytes)
   uint8_t* chunk = malloc(nbytes + BLOSC_MAX_OVERHEAD);
 
   /* Compress the src buffer using super-chunk context */
-  int cbytes = blosc2_compress_ctx(schunk->cctx, nbytes, src, chunk,
+  int cbytes = blosc2_compress_ctx(schunk->cctx, src, nbytes, chunk,
                                    nbytes + BLOSC_MAX_OVERHEAD);
   if (cbytes < 0) {
     free(chunk);
@@ -432,7 +432,7 @@ int blosc2_update_usermeta(blosc2_schunk *schunk, uint8_t *content, int32_t cont
   // Compress the usermeta chunk
   void* usermeta_chunk = malloc(content_len + BLOSC_MAX_OVERHEAD);
   blosc2_context *cctx = blosc2_create_cctx(cparams);
-  int usermeta_cbytes = blosc2_compress_ctx(cctx, content_len, content, usermeta_chunk,
+  int usermeta_cbytes = blosc2_compress_ctx(cctx, content, content_len, usermeta_chunk,
                                             content_len + BLOSC_MAX_OVERHEAD);
   blosc2_free_ctx(cctx);
   if (usermeta_cbytes < 0) {

--- a/blosc/schunk.c
+++ b/blosc/schunk.c
@@ -209,7 +209,7 @@ int blosc2_schunk_append_chunk(blosc2_schunk *schunk, uint8_t *chunk, bool copy)
 
 
 /* Append a data buffer to a super-chunk. */
-int blosc2_schunk_append_buffer(blosc2_schunk *schunk, void *src, size_t nbytes) {
+int blosc2_schunk_append_buffer(blosc2_schunk *schunk, void *src, int32_t nbytes) {
   uint8_t* chunk = malloc(nbytes + BLOSC_MAX_OVERHEAD);
 
   /* Compress the src buffer using super-chunk context */
@@ -228,7 +228,7 @@ int blosc2_schunk_append_buffer(blosc2_schunk *schunk, void *src, size_t nbytes)
 
 /* Decompress and return a chunk that is part of a super-chunk. */
 int blosc2_schunk_decompress_chunk(blosc2_schunk *schunk, int nchunk,
-                                   void *dest, size_t nbytes) {
+                                   void *dest, int32_t nbytes) {
 
   uint8_t* src;
   int chunksize;
@@ -240,9 +240,9 @@ int blosc2_schunk_decompress_chunk(blosc2_schunk *schunk, int nchunk,
     }
     src = schunk->data[nchunk];
     int nbytes_ = sw32_(src + 4);
-    if (nbytes < (size_t)nbytes_) {
+    if (nbytes < nbytes_) {
       fprintf(stderr, "Buffer size is too small for the decompressed buffer "
-                      "('%zd' bytes, but '%d' are needed)\n", nbytes, nbytes_);
+                      "('%d' bytes, but '%d' are needed)\n", nbytes, nbytes_);
       return -11;
     }
     int cbytes = sw32_(src + 12);
@@ -466,7 +466,7 @@ int32_t blosc2_get_usermeta(blosc2_schunk* schunk, uint8_t** content) {
   blosc_cbuffer_sizes(schunk->usermeta, &nbytes, &cbytes, &blocksize);
   *content = malloc(nbytes);
   blosc2_context *dctx = blosc2_create_dctx(BLOSC2_DPARAMS_DEFAULTS);
-  int usermeta_nbytes = blosc2_decompress_ctx(dctx, schunk->usermeta, schunk->usermeta_len, *content, nbytes);
+  int usermeta_nbytes = blosc2_decompress_ctx(dctx, schunk->usermeta, schunk->usermeta_len, *content, (int32_t)nbytes);
   blosc2_free_ctx(dctx);
   if (usermeta_nbytes < 0) {
     return -1;

--- a/examples/compress_file.c
+++ b/examples/compress_file.c
@@ -32,7 +32,7 @@
 
 int main(int argc, char* argv[]) {
   static int32_t data[CHUNKSIZE];
-  size_t isize;
+  int32_t isize;
   int64_t nbytes, cbytes;
   blosc_timestamp_t last, current;
   double ttotal;

--- a/examples/contexts.c
+++ b/examples/contexts.c
@@ -57,7 +57,7 @@ int main(void) {
   cctx = blosc2_create_cctx(cparams);
 
   /* Do the actual compression */
-  csize = blosc2_compress_ctx(cctx, isize, data, data_out, osize);
+  csize = blosc2_compress_ctx(cctx, data, isize, data_out, osize);
   if (csize == 0) {
     printf("Buffer is uncompressible.  Giving up.\n");
     return 1;

--- a/examples/delta_schunk_ex.c
+++ b/examples/delta_schunk_ex.c
@@ -36,7 +36,7 @@
 int main(void) {
   static int64_t data[CHUNKSIZE];
   static int64_t data_dest[CHUNKSIZE];
-  const size_t isize = CHUNKSIZE * sizeof(int64_t);
+  const int32_t isize = CHUNKSIZE * sizeof(int64_t);
   int dsize = 0;
   int64_t nbytes, cbytes;
   blosc2_cparams cparams = BLOSC2_CPARAMS_DEFAULTS;

--- a/tests/fuzz/fuzz_compress.c
+++ b/tests/fuzz/fuzz_compress.c
@@ -38,7 +38,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
   if (output == NULL)
     return 0;
 
-  if (blosc_compress(level, filter, 1, size, data, output, size) == 0) {
+  if (blosc2_compress(level, filter, 1, data, size, output, size) == 0) {
     /* Cannot compress src buffer into dest */
     free(output);
     return 0;

--- a/tests/fuzz/fuzz_decompress.c
+++ b/tests/fuzz/fuzz_decompress.c
@@ -30,11 +30,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
 
   output = malloc(cbytes);
   if (output != NULL) {
-    blosc2_context *dctx;
-    blosc2_dparams dparams = BLOSC2_DPARAMS_DEFAULTS;
-    dctx = blosc2_create_dctx(dparams);
-    blosc2_decompress_ctx(dctx, data, size, output, cbytes);
-    blosc2_free_ctx(dctx);
+    blosc2_decompress(data, size, output, cbytes);
     free(output);
   }
   return 0;

--- a/tests/fuzz/fuzz_decompress.c
+++ b/tests/fuzz/fuzz_decompress.c
@@ -30,7 +30,11 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
 
   output = malloc(cbytes);
   if (output != NULL) {
-    blosc_decompress(data, output, cbytes);
+    blosc2_context *dctx;
+    blosc2_dparams dparams = BLOSC2_DPARAMS_DEFAULTS;
+    dctx = blosc2_create_dctx(dparams);
+    blosc2_decompress_ctx(dctx, data, size, output, cbytes);
+    blosc2_free_ctx(dctx);
     free(output);
   }
   return 0;

--- a/tests/test_contexts.c
+++ b/tests/test_contexts.c
@@ -44,7 +44,7 @@ int main(void) {
   cctx = blosc2_create_cctx(cparams);
 
   /* Compress with clevel=5 and shuffle active  */
-  csize = blosc2_compress_ctx(cctx, isize, data, data_out, osize);
+  csize = blosc2_compress_ctx(cctx, data, isize, data_out, osize);
   if (csize == 0) {
     printf("Buffer is uncompressible.  Giving up.\n");
     return EXIT_FAILURE;

--- a/tests/test_frame.c
+++ b/tests/test_frame.c
@@ -36,7 +36,7 @@ char *fname;
 static char* test_frame(void) {
   static int32_t data[CHUNKSIZE];
   static int32_t data_dest[CHUNKSIZE];
-  size_t isize = CHUNKSIZE * sizeof(int32_t);
+  int32_t isize = CHUNKSIZE * sizeof(int32_t);
   int dsize;
   int64_t nbytes, cbytes;
   blosc2_cparams cparams = BLOSC2_CPARAMS_DEFAULTS;

--- a/tests/test_maskout.c
+++ b/tests/test_maskout.c
@@ -185,7 +185,7 @@ int main(void) {
   blosc2_cparams cparams = BLOSC2_CPARAMS_DEFAULTS;
   cparams.blocksize = blocksize;
   blosc2_context *cctx = blosc2_create_cctx(cparams);
-  cbytes = blosc2_compress_ctx(cctx, bytesize, src, dest, bytesize + BLOSC_MAX_OVERHEAD);
+  cbytes = blosc2_compress_ctx(cctx, src, bytesize, dest, bytesize + BLOSC_MAX_OVERHEAD);
 
   // Build a mask
   for (int i=0; i < nblocks; i++) {

--- a/tests/test_prefilter.c
+++ b/tests/test_prefilter.c
@@ -68,7 +68,7 @@ static char *test_prefilter1(void) {
   cparams.pparams = &pparams;
   cctx = blosc2_create_cctx(cparams);
 
-  csize = blosc2_compress_ctx(cctx, isize, data, data_out, osize);
+  csize = blosc2_compress_ctx(cctx, data, isize, data_out, osize);
   mu_assert("Compression error", csize > 0);
 
   /* Create a context for decompression */
@@ -105,7 +105,7 @@ static char *test_prefilter2(void) {
   cparams.pparams = &pparams;
   cctx = blosc2_create_cctx(cparams);
 
-  csize = blosc2_compress_ctx(cctx, isize, data, data_out, osize);
+  csize = blosc2_compress_ctx(cctx, data, isize, data_out, osize);
   mu_assert("Buffer is uncompressible", csize != 0);
   mu_assert("Compression error", csize > 0);
 


### PR DESCRIPTION
This PR makes the following changes:

* Adds secure versions of `blosc_compress` and `blosc_decompress` for blosc2 called `blosc2_compress` and `blosc2_decompress`
* Cleans up parameter order in `blosc2_compress_ctx` to be similar to `blosc2_decompress_ctx` - should be `src` followed by `srcsize`.
  * Cleans up parameter order in `initialize_context_compression`  as well
* Changes fuzzers to use blosc2 secure versions of compress and decompress.

This PR should resolve OSS-fuzz issue: https://oss-fuzz.com/testcase-detail/4799687189331968.

```
Running 1 inputs
Running: /home/nathan/Source/c-blosc2/build/tests/fuzz/decompress_fuzzer /home/nathan/Downloads/clusterfuzz-testcase-decompress_fuzzer-4799687189331968
==124013==WARNING: MemorySanitizer: use-of-uninitialized-value
    #0 0x4ed820 in initialize_context_decompression /home/nathan/Source/c-blosc2/blosc/blosc2.c:1587:33
    #1 0x4ec4a5 in blosc_run_decompression_with_context /home/nathan/Source/c-blosc2/blosc/blosc2.c:2101:11
    #2 0x4ede48 in blosc2_decompress /home/nathan/Source/c-blosc2/blosc/blosc2.c:2192:12
    #3 0x4ee140 in blosc_decompress /home/nathan/Source/c-blosc2/blosc/blosc2.c:2203:10
    #4 0x49e8a3 in LLVMFuzzerTestOneInput /home/nathan/Source/c-blosc2/tests/fuzz/fuzz_decompress.c:33:5
    #5 0x49ee64 in main /home/nathan/Source/c-blosc2/tests/fuzz/standalone.c:32:7
    #6 0x7ffff6ee583f in __libc_start_main /build/glibc-e6zv40/glibc-2.23/csu/../csu/libc-start.c:291
    #7 0x4255c8 in _start (/home/nathan/Source/c-blosc2/build/tests/fuzz/decompress_fuzzer+0x4255c8)

  Uninitialized value was created by a heap allocation
    #0 0x4517ed in malloc /tmp/final/llvm.src/projects/compiler-rt/lib/msan/msan_interceptors.cc:916:3
    #1 0x49e842 in LLVMFuzzerTestOneInput /home/nathan/Source/c-blosc2/tests/fuzz/fuzz_decompress.c:31:12
    #2 0x49ee64 in main /home/nathan/Source/c-blosc2/tests/fuzz/standalone.c:32:7
    #3 0x7ffff6ee583f in __libc_start_main /build/glibc-e6zv40/glibc-2.23/csu/../csu/libc-start.c:291

SUMMARY: MemorySanitizer: use-of-uninitialized-value /home/nathan/Source/c-blosc2/blosc/blosc2.c:1587:33 in initialize_context_decompression
Exiting
```