### PR TITLE
Check block offset to ensure it is not negative during decompression.

### DIFF
--- a/blosc/blosc2.c
+++ b/blosc/blosc2.c
@@ -964,8 +964,8 @@ int pipeline_d(blosc2_context* context, const int32_t bsize, uint8_t* dest,
 /* Decompress & unshuffle a single block */
 static int blosc_d(
     struct thread_context* thread_context, int32_t bsize,
-    int32_t leftoverblock, const uint8_t* src, int32_t srcsize, uint8_t* dest,
-    int32_t offset, uint8_t* tmp, uint8_t* tmp2) {
+    int32_t leftoverblock, const uint8_t* src, int32_t srcsize, int32_t src_offset,
+    uint8_t* dest, int32_t dest_offset, uint8_t* tmp, uint8_t* tmp2) {
   blosc2_context* context = thread_context->parent_context;
   uint8_t* filters = context->filters;
   uint8_t *tmp3 = thread_context->tmp4;
@@ -981,13 +981,20 @@ static int blosc_d(
   int32_t ntbytes = 0;           /* number of uncompressed bytes in block */
   uint8_t* _dest;
   int32_t typesize = context->typesize;
-  int32_t nblock = offset / context->blocksize;
+  int32_t nblock = dest_offset / context->blocksize;
   const char* compname;
 
   if (context->block_maskout != NULL && context->block_maskout[nblock]) {
     // Do not decompress, but act as if we successfully decompressed everything
     return bsize;
   }
+
+  if (src_offset <= 0 || src_offset >= srcsize) {
+    /* Invalid block src offset encountered */
+    return -1;
+  }
+
+  src += src_offset;
 
   int last_filter_index = last_filter(filters, 'd');
 
@@ -997,7 +1004,7 @@ static int blosc_d(
    _dest = tmp;
   } else {
     // If no filters, or only DELTA in pipeline
-   _dest = dest + offset;
+   _dest = dest + dest_offset;
   }
 
   /* The number of compressed data streams for this block */
@@ -1011,13 +1018,13 @@ static int blosc_d(
 
   neblock = bsize / nstreams;
   for (int j = 0; j < nstreams; j++) {
-    if (src + sizeof(int32_t) >= src_end) {
+    if (src + sizeof(int32_t) > src_end) {
       /* Not enough input to read compressed size */
       return -1;
     }
     cbytes = sw32_(src);      /* amount of compressed bytes */
     src += sizeof(int32_t);
-    if (src + cbytes >= src_end) {
+    if (src + cbytes > src_end) {
       /* Not enough input to read compressed size */
       return -1;
     }
@@ -1096,7 +1103,7 @@ static int blosc_d(
   } /* Closes j < nstreams */
 
   if (last_filter_index >= 0) {
-    int errcode = pipeline_d(context, bsize, dest, offset, tmp, tmp2, tmp3,
+    int errcode = pipeline_d(context, bsize, dest, dest_offset, tmp, tmp2, tmp3,
                              last_filter_index);
     if (errcode < 0)
       return errcode;
@@ -1167,7 +1174,7 @@ static int serial_blosc(struct thread_context* thread_context) {
       else {
         /* Regular decompression */
         cbytes = blosc_d(thread_context, bsize, leftoverblock,
-                         context->src + sw32_(bstarts + j), context->srcsize,
+                         context->src, context->srcsize, sw32_(bstarts + j),
                          context->dest, j * context->blocksize, tmp, tmp2);
       }
     }
@@ -2341,7 +2348,7 @@ int _blosc_getitem(blosc2_context* context, const void* src, int32_t srcsize,
       bool get_single_block = ((startb == 0) && (bsize == nitems * typesize));
       uint8_t* tmp2 = get_single_block ? dest : scontext->tmp2;
       cbytes = blosc_d(context->serial_context, bsize, leftoverblock,
-                       (uint8_t*)src + sw32_(bstarts + j), srcsize,
+                       src, srcsize, sw32_(bstarts + j),
                        tmp2, 0, scontext->tmp, scontext->tmp3);
       if (cbytes < 0) {
         ntbytes = cbytes;
@@ -2541,7 +2548,7 @@ static void t_blosc_do_job(void *ctxt)
           cbytes = -1;
         } else {
           cbytes = blosc_d(thcontext, bsize, leftoverblock,
-                            src + sw32_(bstarts + nblock_), srcsize,
+                            src, srcsize, sw32_(bstarts + nblock_),
                             dest, nblock_ * blocksize, tmp, tmp2);
         }
       }


### PR DESCRIPTION
This fixes OSS-Fuzz issue https://oss-fuzz.com/testcase-detail/6044542246322176.

```
==47798==AddressSanitizer: libc interceptors initialized
|| `[0x10007fff8000, 0x7fffffffffff]` || HighMem    ||
|| `[0x02008fff7000, 0x10007fff7fff]` || HighShadow ||
|| `[0x00008fff7000, 0x02008fff6fff]` || ShadowGap  ||
|| `[0x00007fff8000, 0x00008fff6fff]` || LowShadow  ||
|| `[0x000000000000, 0x00007fff7fff]` || LowMem     ||
MemToShadow(shadow): 0x00008fff7000 0x000091ff6dff 0x004091ff6e00 0x02008fff6fff
redzone=16
max_redzone=2048
quarantine_size_mb=256M
thread_local_quarantine_size_kb=1024K
malloc_context_size=30
SHADOW_SCALE: 3
SHADOW_GRANULARITY: 8
SHADOW_OFFSET: 0x7fff8000
==47798==Installed the sigaction for signal 11
==47798==Installed the sigaction for signal 7
==47798==Installed the sigaction for signal 8
==47798==T0: stack [0x7fffff7ff000,0x7ffffffff000) size 0x800000; local=0x7fffffffdb24
==47798==AddressSanitizer Init done
Running 1 inputs
Running: /home/nathan/Source/c-blosc2/build/tests/fuzz/decompress_fuzzer /home/nathan/Downloads/clusterfuzz-testcase-minimized-decompress_fuzzer-6044542246322176.fuzz
AddressSanitizer:DEADLYSIGNAL
=================================================================
==47798==ERROR: AddressSanitizer: SEGV on unknown address 0x603ffffff811 (pc 0x00000058ec88 bp 0x7fffffffcca0 sp 0x7fffffffcc50 T0)
==47798==The signal is caused by a READ memory access.
    #0 0x58ec87 in sw32_ /home/nathan/Source/c-blosc2/build/../blosc/blosc-private.h
    #1 0x593de3 in blosc_d /home/nathan/Source/c-blosc2/build/../blosc/blosc2.c:1018:14
    #2 0x5be745 in serial_blosc /home/nathan/Source/c-blosc2/build/../blosc/blosc2.c:1174:18
    #3 0x57fb4a in do_job /home/nathan/Source/c-blosc2/build/../blosc/blosc2.c:1333:15
    #4 0x58ac30 in blosc_run_decompression_with_context /home/nathan/Source/c-blosc2/build/../blosc/blosc2.c:2128:15
    #5 0x58f4b4 in blosc2_decompress /home/nathan/Source/c-blosc2/build/../blosc/blosc2.c:2197:12
    #6 0x4cc4e3 in LLVMFuzzerTestOneInput /home/nathan/Source/c-blosc2/build/../tests/fuzz/fuzz_decompress.c:33:5
    #7 0x4ccad3 in main /home/nathan/Source/c-blosc2/build/../tests/fuzz/standalone.c:32:7
    #8 0x7ffff6ee583f in __libc_start_main /build/glibc-e6zv40/glibc-2.23/csu/../csu/libc-start.c:291
    #9 0x424c68 in _start (/home/nathan/Source/c-blosc2/build/tests/fuzz/decompress_fuzzer+0x424c68)

AddressSanitizer can not provide additional info.
SUMMARY: AddressSanitizer: SEGV /home/nathan/Source/c-blosc2/build/../blosc/blosc-private.h in sw32_
```