### PR TITLE
Fixed ASAN global buffer overflow error due to src not being at least 32 bytes.

### DIFF
--- a/examples/frame_simple.c
+++ b/examples/frame_simple.c
@@ -74,10 +74,11 @@ int main(void) {
   }
 
   // Add some usermeta data
-  int umlen = blosc2_update_usermeta(schunk, (uint8_t *) "This is a usermeta content...", 32,
+  int umlen = blosc2_update_usermeta(schunk, (uint8_t *) "This is a usermeta content.....", 32,
                                      BLOSC2_CPARAMS_DEFAULTS);
   if (umlen < 0) {
     printf("Cannot write usermeta chunk");
+    return -1;
   }
 
   /* Gather some info */


### PR DESCRIPTION
```
Blosc version info: 2.0.0.beta.6.dev ($Date:: 2020-04-21 #$)
=================================================================
==110318==ERROR: AddressSanitizer: global-buffer-overflow on address 0x0000004d69be at pc 0x00000049262a bp 0x7ffc85e64040 sp 0x7ffc85e63808
READ of size 32 at 0x0000004d69be thread T0
    #0 0x492629 in __asan_memcpy /tmp/final/llvm.src/projects/compiler-rt/lib/asan/asan_interceptors_memintrinsics.cc:22:3
    #1 0x7f6e21e31815 in serial_blosc /home/nathan/Source/c-blosc2/build/../blosc/blosc2.c:1135:9
    #2 0x7f6e21df5e8f in do_job /home/nathan/Source/c-blosc2/build/../blosc/blosc2.c:1328:15
    #3 0x7f6e21df4f14 in blosc_compress_context /home/nathan/Source/c-blosc2/build/../blosc/blosc2.c:1787:17
    #4 0x7f6e21df69f2 in blosc2_compress_ctx /home/nathan/Source/c-blosc2/build/../blosc/blosc2.c:1841:12
    #5 0x7f6e21e50629 in blosc2_update_usermeta /home/nathan/Source/c-blosc2/build/../blosc/schunk.c:435:25
    #6 0x4c313d in main /home/nathan/Source/c-blosc2/build/../examples/frame_simple.c:77:15
    #7 0x7f6e20ec883f in __libc_start_main /build/glibc-e6zv40/glibc-2.23/csu/../csu/libc-start.c:291
    #8 0x41b2d8 in _start (/home/nathan/Source/c-blosc2/build/examples/frame_simple+0x41b2d8)

0x0000004d69be is located 34 bytes to the left of global variable '<string literal>' defined in '../examples/frame_simple.c:80:12' (0x4d69e0) of size 28
  '<string literal>' is ascii string 'Cannot write usermeta chunk'
0x0000004d69be is located 0 bytes to the right of global variable '<string literal>' defined in '../examples/frame_simple.c:77:58' (0x4d69a0) of size 30
  '<string literal>' is ascii string 'This is a usermeta content...'
SUMMARY: AddressSanitizer: global-buffer-overflow /tmp/final/llvm.src/projects/compiler-rt/lib/asan/asan_interceptors_memintrinsics.cc:22:3 in __asan_memcpy
Shadow bytes around the buggy address:
  0x000080092ce0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 05
  0x000080092cf0: f9 f9 f9 f9 00 00 01 f9 f9 f9 f9 f9 00 00 06 f9
  0x000080092d00: f9 f9 f9 f9 00 00 00 00 00 00 00 00 f9 f9 f9 f9
  0x000080092d10: 00 00 f9 f9 f9 f9 f9 f9 00 00 00 00 00 00 00 00
  0x000080092d20: 00 00 00 00 00 00 06 f9 f9 f9 f9 f9 00 07 f9 f9
=>0x000080092d30: f9 f9 f9 f9 00 00 00[06]f9 f9 f9 f9 00 00 00 04
  0x000080092d40: f9 f9 f9 f9 00 00 00 00 00 00 00 00 00 00 00 00
  0x000080092d50: 00 00 00 00 00 07 f9 f9 f9 f9 f9 f9 00 00 00 00
  0x000080092d60: 05 f9 f9 f9 f9 f9 f9 f9 00 00 00 00 00 02 f9 f9
  0x000080092d70: f9 f9 f9 f9 00 00 00 00 00 05 f9 f9 f9 f9 f9 f9
  0x000080092d80: 00 00 00 00 03 f9 f9 f9 f9 f9 f9 f9 00 00 05 f9
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==110318==ABORTING
```

This also returns -1 when there is an error instead of continuing to process.

BTW, this one is not caught by OSS-fuzz, because OSS-fuzz only tests against fuzzers not unit tests. We will eventually need a `fuzz_frame_compress` and `fuzz_frame_decompress` fuzzers but I leave that for the future because I don't have enough insider knowledge yet.