### PR TITLE
Sparse storage

### DIFF
--- a/blosc/blosc2.h
+++ b/blosc/blosc2.h
@@ -906,8 +906,10 @@ BLOSC_EXPORT int blosc2_getitem_ctx(blosc2_context* context, const void* src,
  * the contents included in the schunk.
  */
 typedef struct {
-    bool sparse;  //!< Whether the chunks are sparse or sequential (frame)
-    char* path;   //!< The path for storage; if NULL, that means in-memory
+    bool sparse;
+    //!< Whether the chunks are sparse or sequential (frame).
+    char* path;
+    //!< The path for persistent storage. If NULL, that means in-memory.
 } blosc2_storage;
 
 /**

--- a/blosc/blosc2.h
+++ b/blosc/blosc2.h
@@ -900,6 +900,21 @@ BLOSC_EXPORT int blosc2_getitem_ctx(blosc2_context* context, const void* src,
 #define BLOSC2_MAX_METALAYERS 16
 #define BLOSC2_METALAYER_NAME_MAXLEN 31
 
+/**
+ * @brief This struct is meant for holding storage parameters for a
+ * for a blosc2 container, allowing to specify, for example, how to interpret
+ * the contents included in the schunk.
+ */
+typedef struct {
+    bool sparse;  //!< Whether the chunks are sparse or sequential (frame)
+    char* path;   //!< The path for storage; if NULL, that means in-memory
+} blosc2_storage;
+
+/**
+ * @brief Default struct for #blosc2_storage meant for user initialization.
+ */
+static const blosc2_storage BLOSC2_STORAGE_DEFAULTS = {true, NULL};
+
 typedef struct {
   char* fname;             //!< The name of the file; if NULL, this is in-memory
   uint8_t* sdata;          //!< The in-memory serialized data
@@ -953,6 +968,8 @@ typedef struct blosc2_schunk {
   //!< Pointer to chunk data pointers buffer.
   size_t data_len;
   //!< Length of the chunk data pointers buffer.
+  blosc2_storage* storage;
+  //!< Pointer to storage info.
   blosc2_frame* frame;
   //!< Pointer to frame used as store for chunks.
   //!<uint8_t* ctx;
@@ -994,7 +1011,8 @@ blosc2_new_schunk(blosc2_cparams cparams, blosc2_dparams dparams, blosc2_frame *
  * @return The new super-chunk.
  */
 BLOSC_EXPORT blosc2_schunk *
-blosc2_empty_schunk(blosc2_cparams cparams, blosc2_dparams dparams, int nchunks, blosc2_frame *frame);
+blosc2_empty_schunk(blosc2_cparams cparams, blosc2_dparams dparams, int nchunks,
+                    blosc2_storage *storage);
 
 /**
  * @brief Release resources from a super-chunk.

--- a/blosc/schunk.c
+++ b/blosc/schunk.c
@@ -95,6 +95,11 @@ blosc2_schunk *blosc2_new_schunk(blosc2_cparams cparams, blosc2_dparams dparams,
   dparams.schunk = schunk;
   schunk->dctx = blosc2_create_dctx(dparams);
 
+  // Storage info.  We use defaults here because we don't want to break
+  // the existing `blosc2_new_schunk()` API.
+  schunk->storage = (blosc2_storage*)malloc(sizeof(blosc2_storage));
+  memcpy(schunk->storage, &BLOSC2_STORAGE_DEFAULTS, sizeof(blosc2_storage));
+
   schunk->frame = frame;
   if (frame != NULL) {
     if (frame->len == 0) {
@@ -112,13 +117,19 @@ blosc2_schunk *blosc2_new_schunk(blosc2_cparams cparams, blosc2_dparams dparams,
 
 /* Create an empty super-chunk */
 blosc2_schunk *blosc2_empty_schunk(blosc2_cparams cparams, blosc2_dparams dparams, int nchunks,
-                                 blosc2_frame* frame) {
-  if (frame != NULL) {
-    fprintf(stderr, "Creating empty frames is not allowwed yet\n");
-    return NULL;
+                                   blosc2_storage* storage) {
+  if (storage == NULL) {
+    storage = (blosc2_storage*)malloc(sizeof(blosc2_storage));
+    memcpy(storage, &BLOSC2_STORAGE_DEFAULTS, sizeof(blosc2_storage));
   }
 
   blosc2_schunk* schunk = calloc(1, sizeof(blosc2_schunk));
+
+  if (storage->sparse == false) {
+    fprintf(stderr, "Creating empty frames is not allowed yet\n");
+    return NULL;
+  }
+  schunk->frame = NULL;
 
   schunk->version = 0;     // pre-first version
   for (int i = 0; i < BLOSC2_MAX_FILTERS; i++) {
@@ -137,8 +148,6 @@ blosc2_schunk *blosc2_empty_schunk(blosc2_cparams cparams, blosc2_dparams dparam
   // The decompression context
   dparams.schunk = schunk;
   schunk->dctx = blosc2_create_dctx(dparams);
-
-  schunk->frame = frame;
 
   // Init offsets
   schunk->nchunks = nchunks;
@@ -171,6 +180,10 @@ int blosc2_free_schunk(blosc2_schunk *schunk) {
       free(schunk->metalayers[i]);
     }
     schunk->nmetalayers = 0;
+  }
+
+  if (schunk->storage != NULL) {
+    free(schunk->storage);
   }
 
   if (schunk->usermeta_len > 0) {

--- a/blosc/schunk.c
+++ b/blosc/schunk.c
@@ -102,6 +102,10 @@ blosc2_schunk *blosc2_new_schunk(blosc2_cparams cparams, blosc2_dparams dparams,
 
   schunk->frame = frame;
   if (frame != NULL) {
+    schunk->storage->sparse = false;
+    if (frame->fname != NULL) {
+      schunk->storage->path = frame->fname;
+    }
     if (frame->len == 0) {
       // Initialize frame (basically, encode the header)
       int64_t frame_len = blosc2_schunk_to_frame(schunk, frame);
@@ -126,7 +130,11 @@ blosc2_schunk *blosc2_empty_schunk(blosc2_cparams cparams, blosc2_dparams dparam
   blosc2_schunk* schunk = calloc(1, sizeof(blosc2_schunk));
 
   if (storage->sparse == false) {
-    fprintf(stderr, "Creating empty frames is not allowed yet\n");
+    fprintf(stderr, "Creating empty frames is not supported yet\n");
+    return NULL;
+  }
+  else if (storage->path != NULL) {
+    fprintf(stderr, "Creating empty schunks on-disk is not supported yet\n");
     return NULL;
   }
   schunk->frame = NULL;

--- a/tests/test_empty_schunk.c
+++ b/tests/test_empty_schunk.c
@@ -44,20 +44,9 @@ static char* test_schunk(void) {
   blosc2_add_metalayer(schunk, "metalayer1", (uint8_t*)"my metalayer1", sizeof("my metalayer1"));
   blosc2_add_metalayer(schunk, "metalayer2", (uint8_t*)"my metalayer1", sizeof("my metalayer1"));
 
-  uint8_t *chunk_aux;
   bool needs_free;
-  cbytes = blosc2_schunk_get_chunk(schunk, nchunks / 2, &chunk_aux, &needs_free);
-  mu_assert("ERROR: chunk cannot be retrieved correctly.\n", cbytes == 0);
-  if (needs_free) {
-    free(chunk_aux);
-  }
   int32_t datasize = sizeof(int32_t) * CHUNKSIZE;
   int32_t chunksize = sizeof(int32_t) * CHUNKSIZE + BLOSC_MAX_OVERHEAD;
-
-  chunk_aux = malloc(chunksize);
-  nbytes = blosc2_schunk_decompress_chunk(schunk, nchunks / 2, &chunk_aux, chunksize);
-  mu_assert("ERROR: chunk cannot be retrieved correctly.\n", nbytes == 0);
-  free(chunk_aux);
 
   // Feed it with data
   uint8_t *chunk;
@@ -150,6 +139,10 @@ static char* test_schunk(void) {
 }
 
 static char *all_tests(void) {
+  nchunks = 0;
+  copy = true;
+  mu_run_test(test_schunk);
+
   nchunks = 6;
   copy = true;
   mu_run_test(test_schunk);


### PR DESCRIPTION
New `blosc2_storage` struct.  This opens the door to the implementation of a sparse persistent storage as per our ROADMAP.