### PR TITLE
Fixed use-of-uninitialized value msan error when copying dist bytes in miniz

### DIFF
--- a/internal-complibs/miniz-2.0.8/miniz.c
+++ b/internal-complibs/miniz-2.0.8/miniz.c
@@ -2663,7 +2663,7 @@ tinfl_status tinfl_decompress(tinfl_decompressor *r, const mz_uint8 *pIn_buf_nex
                 }
 
                 dist_from_out_buf_start = pOut_buf_cur - pOut_buf_start;
-                if ((dist > dist_from_out_buf_start) && (decomp_flags & TINFL_FLAG_USING_NON_WRAPPING_OUTPUT_BUF))
+                if ((dist > dist_from_out_buf_start || dist_from_out_buf_start == 0) && (decomp_flags & TINFL_FLAG_USING_NON_WRAPPING_OUTPUT_BUF))
                 {
                     TINFL_CR_RETURN_FOREVER(37, TINFL_STATUS_FAILED);
                 }


### PR DESCRIPTION
See richgel999/miniz#170 for reproduction details.
OSS-Fuzz: https://oss-fuzz.com/testcase-detail/4921954995535872