### PR TITLE
Fixed UBSAN signed interger overflow if nchunks is INT32_MAX.

### DIFF
--- a/blosc/frame.c
+++ b/blosc/frame.c
@@ -438,6 +438,9 @@ int get_header_info(blosc2_frame *frame, int32_t *header_len, int64_t *frame_len
     // We can compute the number of chunks only when the frame has actual data
     *nchunks = (int32_t) (*nbytes / *chunksize);
     if (*nbytes % *chunksize > 0) {
+      if (*nchunks == INT32_MAX) {
+        return -1;
+      }
       *nchunks += 1;
     }
   } else {


### PR DESCRIPTION
```
Running 1 inputs
Running: c-blosc2/build/tests/fuzz/decompress_frame_fuzzer clusterfuzz-testcase-minimized-decompress_frame_fuzzer-4723741237706752
../blosc/frame.c:441:16: runtime error: signed integer overflow: 2147483647 + 1 cannot be represented in type 'int'
    #0 0x4a8135 in get_header_info c-blosc2/build/../blosc/frame.c:441:16
    #1 0x4ac036 in blosc2_frame_to_schunk c-blosc2/build/../blosc/frame.c:1111:13
    #2 0x49fec2 in blosc2_schunk_open_sframe c-blosc2/build/../blosc/schunk.c:263:27
    #3 0x42ea60 in LLVMFuzzerTestOneInput c-blosc2/build/../tests/fuzz/fuzz_decompress_frame.c:23:27
    #4 0x42ee1c in main c-blosc2/build/../tests/fuzz/standalone.c:32:7
    #5 0x7ffff7c4b0b2 in __libc_start_main /build/glibc-ZN95T4/glibc-2.31/csu/../csu/libc-start.c:308:16
    #6 0x40e67d in _start (c-blosc2/build/tests/fuzz/decompress_frame_fuzzer+0x40e67d)

SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior ../blosc/frame.c:441:16 in 
Error: cannot access the metalayersDone:    clusterfuzz-testcase-minimized-decompress_frame_fuzzer-4723741237706752: (82 bytes)
```
https://oss-fuzz.com/testcase-detail/4723741237706752
