### PR TITLE
Add BLOSC_TRACE macro

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
-===============================================================
+=============================================================================
  C-Blosc2: A simple, compressed, fast and persistent data store library for C
-===============================================================
+=============================================================================
 
 :Author: The Blosc Development Team
 :Contact: blosc@blosc.org
@@ -143,6 +143,14 @@ C-Blosc2 comes with support for a highly optimized version of the LZ4 codec pres
    $ sudo apt-get update && sudo apt-get install intel-ipp-64bit-2019.X  # replace .X by the latest version
 
 Check `Intel IPP website <https://software.intel.com/en-us/articles/intel-integrated-performance-primitives-intel-ipp-install-guide>`_ for instructions on how to install it for other platforms.
+
+
+Display error messages
+~~~~~~~~~~~~~~~~~~~~~~
+
+By default error messages are disabled. To activate it, you only need to activate the Blosc tracing machinery setting
+the `BLOSC_TRACE` environment variable.
+
 
 Mailing list
 ============

--- a/README.rst
+++ b/README.rst
@@ -148,7 +148,7 @@ Check `Intel IPP website <https://software.intel.com/en-us/articles/intel-integr
 Display error messages
 ~~~~~~~~~~~~~~~~~~~~~~
 
-By default error messages are disabled. To display it, you only need to activate the Blosc tracing machinery setting
+By default error messages are disabled. To display them, you just need to activate the Blosc tracing machinery by setting
 the ``BLOSC_TRACE`` environment variable.
 
 

--- a/README.rst
+++ b/README.rst
@@ -148,7 +148,7 @@ Check `Intel IPP website <https://software.intel.com/en-us/articles/intel-integr
 Display error messages
 ~~~~~~~~~~~~~~~~~~~~~~
 
-By default error messages are disabled. To activate it, you only need to activate the Blosc tracing machinery setting
+By default error messages are disabled. To display it, you only need to activate the Blosc tracing machinery setting
 the ``BLOSC_TRACE`` environment variable.
 
 

--- a/README.rst
+++ b/README.rst
@@ -149,7 +149,7 @@ Display error messages
 ~~~~~~~~~~~~~~~~~~~~~~
 
 By default error messages are disabled. To activate it, you only need to activate the Blosc tracing machinery setting
-the `BLOSC_TRACE` environment variable.
+the ``BLOSC_TRACE`` environment variable.
 
 
 Mailing list

--- a/blosc/blosc2.c
+++ b/blosc/blosc2.c
@@ -107,7 +107,7 @@ int release_threadpool(blosc2_context *context);
 #define WAIT_INIT(RET_VAL, CONTEXT_PTR)  \
   rc = pthread_barrier_wait(&(CONTEXT_PTR)->barr_init); \
   if (rc != 0 && rc != PTHREAD_BARRIER_SERIAL_THREAD) { \
-    printf("Could not wait on barrier (init): %d\n", rc); \
+    BLOSC_TRACE_ERROR("Could not wait on barrier (init): %d", rc); \
     return((RET_VAL));                            \
   }
 #else
@@ -129,7 +129,7 @@ int release_threadpool(blosc2_context *context);
 #define WAIT_FINISH(RET_VAL, CONTEXT_PTR)   \
   rc = pthread_barrier_wait(&(CONTEXT_PTR)->barr_finish); \
   if (rc != 0 && rc != PTHREAD_BARRIER_SERIAL_THREAD) { \
-    printf("Could not wait on barrier (finish)\n"); \
+    BLOSC_TRACE_ERROR("Could not wait on barrier (finish)"); \
     return((RET_VAL));                              \
   }
 #else
@@ -177,7 +177,7 @@ static uint8_t* my_malloc(size_t size) {
 #endif  /* _WIN32 */
 
   if (block == NULL || res != 0) {
-    printf("Error allocating memory!");
+    BLOSC_TRACE_ERROR("Error allocating memory!");
     return NULL;
   }
 
@@ -285,7 +285,6 @@ int blosc_compcode_to_compname(int compcode, const char** compname) {
 
   return code;
 }
-
 
 /* Get the compressor code for the compressor name. -1 if it is not available */
 int blosc_compname_to_compcode(const char* compname) {
@@ -521,8 +520,8 @@ static int zstd_wrap_decompress(struct thread_context* thread_context,
         (void*)output, maxout, (void*)input, compressed_length);
   }
   if (ZSTD_isError(code) != ZSTD_error_no_error) {
-    fprintf(stderr, "Error in ZSTD decompression: '%s'.  Giving up.\n",
-            ZDICT_getErrorName(code));
+    BLOSC_TRACE_ERROR("Error in ZSTD decompression: '%s'.  Giving up.",
+                      ZDICT_getErrorName(code));
     return 0;
   }
   return (int)code;
@@ -626,7 +625,7 @@ uint8_t* pipeline_c(struct thread_context* thread_context, const int32_t bsize,
     pparams.ctx = context;
 
     if (context->prefilter(&pparams) != 0) {
-      fprintf(stderr, "Execution of prefilter function failed\n");
+      BLOSC_TRACE_ERROR("Execution of prefilter function failed");
       return NULL;
     }
 
@@ -665,7 +664,7 @@ uint8_t* pipeline_c(struct thread_context* thread_context, const int32_t bsize,
         break;
       default:
         if (filters[i] != BLOSC_NOFILTER) {
-          fprintf(stderr, "Filter %d not handled during compression\n", filters[i]);
+          BLOSC_TRACE_ERROR("Filter %d not handled during compression\n", filters[i]);
           return NULL;
         }
     }
@@ -847,8 +846,8 @@ static int blosc_c(struct thread_context* thread_context, int32_t bsize,
 
     else {
       blosc_compcode_to_compname(context->compcode, &compname);
-      fprintf(stderr, "Blosc has not been compiled with '%s' ", compname);
-      fprintf(stderr, "compression support.  Please use one having it.");
+      BLOSC_TRACE_ERROR("Blosc has not been compiled with '%s' compression support."
+                        "Please use one having it.", compname);
       return -5;    /* signals no compression support */
     }
 
@@ -947,8 +946,9 @@ int pipeline_d(blosc2_context* context, const int32_t bsize, uint8_t* dest,
         break;
       default:
         if (filters[i] != BLOSC_NOFILTER) {
-          fprintf(stderr, "Filter %d not handled during decompression\n",
-                  filters[i]);
+          BLOSC_TRACE_ERROR("Filter %d not handled during decompression.",
+                            filters[i]);
+
           errcode = -1;
         }
     }
@@ -997,11 +997,11 @@ static int blosc_d(
   if (is_lazy) {
     // The chunk is on disk, so just lazily load the block
     if (context->schunk == NULL) {
-      fprintf(stderr, "Lazy chunk needs an associated super-chunk");
+      BLOSC_TRACE_ERROR("Lazy chunk needs an associated super-chunk.");
       return -11;
     }
     if (context->schunk->frame == NULL) {
-      fprintf(stderr, "Lazy chunk needs an associated frame");
+      BLOSC_TRACE_ERROR("Lazy chunk needs an associated frame.");
       return -12;
     }
     char *fname = context->schunk->frame->fname;
@@ -1019,7 +1019,7 @@ static int blosc_d(
     size_t rbytes = fread((void*)(src + src_offset), 1, block_csize, fp);
     fclose(fp);
     if (rbytes != block_csize) {
-      fprintf(stderr, "Cannot read the (lazy) block out of the fileframe.\n");
+      BLOSC_TRACE_ERROR("Cannot read the (lazy) block out of the fileframe.");
       return -13;
     }
   }
@@ -1140,10 +1140,10 @@ static int blosc_d(
   #endif /*  HAVE_ZSTD */
       else {
         compname = clibcode_to_clibname(compformat);
-        fprintf(stderr,
+        BLOSC_TRACE_ERROR(
                 "Blosc has not been compiled with decompression "
-                    "support for '%s' format. ", compname);
-        fprintf(stderr, "Please recompile for adding this support.\n");
+                "support for '%s' format.  "
+                "Please recompile for adding this support.", compname);
         return -5;    /* signals no decompression support */
       }
 
@@ -1290,12 +1290,12 @@ static void init_thread_context(struct thread_context* thread_context, blosc2_co
   int hash_size = 0;
   status = ippsEncodeLZ4HashTableGetSize_8u(&hash_size);
   if (status != ippStsNoErr) {
-    fprintf(stderr, "Error in ippsEncodeLZ4HashTableGetSize_8u");
+      BLOSC_TRACE_ERROR("Error in ippsEncodeLZ4HashTableGetSize_8u.");
   }
   Ipp8u *hash_table = ippsMalloc_8u(hash_size);
   status = ippsEncodeLZ4HashTableInit_8u(hash_table, inlen);
   if (status != ippStsNoErr) {
-    fprintf(stderr, "Error in ippsEncodeLZ4HashTableInit_8u");
+    BLOSC_TRACE_ERROR("Error in ippsEncodeLZ4HashTableInit_8u.");
   }
   thread_context->lz4_hash_table = hash_table;
 #endif
@@ -1335,7 +1335,7 @@ void free_thread_context(struct thread_context* thread_context) {
 
 int check_nthreads(blosc2_context* context) {
   if (context->nthreads <= 0) {
-    fprintf(stderr, "Error.  nthreads must be a positive integer");
+    BLOSC_TRACE_ERROR("nthreads must be a positive integer.");
     return -1;
   }
 
@@ -1465,37 +1465,37 @@ static int initialize_context_compression(
   /* Check buffer size limits */
   if (srcsize > BLOSC_MAX_BUFFERSIZE) {
     if (warnlvl > 0) {
-      fprintf(stderr, "Input buffer size cannot exceed %d bytes\n",
-              BLOSC_MAX_BUFFERSIZE);
+      BLOSC_TRACE_ERROR("Input buffer size cannot exceed %d bytes.",
+                        BLOSC_MAX_BUFFERSIZE);
     }
     return 0;
   }
 
   if (destsize < BLOSC_MAX_OVERHEAD) {
     if (warnlvl > 0) {
-      fprintf(stderr, "Output buffer size should be larger than %d bytes\n",
-              BLOSC_MAX_OVERHEAD);
+      BLOSC_TRACE_ERROR("Output buffer size should be larger than %d bytes.",
+                        BLOSC_MAX_OVERHEAD);
     }
     return 0;
   }
 
   if (destsize < BLOSC_MAX_OVERHEAD) {
     if (warnlvl > 0) {
-      fprintf(stderr, "Output buffer size should be larger than %d bytes\n",
-              BLOSC_MAX_OVERHEAD);
+      BLOSC_TRACE_ERROR("Output buffer size should be larger than %d bytes.",
+                        BLOSC_MAX_OVERHEAD);
     }
     return -2;
   }
   if (destsize < BLOSC_MAX_OVERHEAD) {
-    fprintf(stderr, "Output buffer size should be larger than %d bytes\n",
-            BLOSC_MAX_OVERHEAD);
+    BLOSC_TRACE_ERROR("Output buffer size should be larger than %d bytes.",
+                      BLOSC_MAX_OVERHEAD);
     return -1;
   }
 
   /* Compression level */
   if (clevel < 0 || clevel > 9) {
     /* If clevel not in 0..9, print an error */
-    fprintf(stderr, "`clevel` parameter must be between 0 and 9!\n");
+    BLOSC_TRACE_ERROR("`clevel` parameter must be between 0 and 9!.");
     return -10;
   }
 
@@ -1579,8 +1579,9 @@ static int initialize_context_decompression(blosc2_context* context, const void*
                       context->nblocks + 1 : context->nblocks;
 
   if (context->block_maskout != NULL && context->block_maskout_nitems != context->nblocks) {
-    fprintf(stderr, "The number of items in block_maskout (%d) must match the number"
-                    " of blocks in chunk (%d)", context->block_maskout_nitems, context->nblocks);
+    BLOSC_TRACE_ERROR("The number of items in block_maskout (%d) must match the number"
+                      " of blocks in chunk (%d).",
+                      context->block_maskout_nitems, context->nblocks);
     return -2;
   }
 
@@ -1721,8 +1722,9 @@ static int write_compression_header(blosc2_context* context,
     default: {
       const char* compname;
       compname = clibcode_to_clibname(compformat);
-      fprintf(stderr, "Blosc has not been compiled with '%s' ", compname);
-      fprintf(stderr, "compression support.  Please use one having it.");
+      BLOSC_TRACE_ERROR("Blosc has not been compiled with '%s' "
+                        "compression support.  Please use one having it.",
+                        compname);
       return -5;    /* signals no compression support */
       break;
     }
@@ -1871,7 +1873,7 @@ int blosc2_compress_ctx(blosc2_context* context, const void* src, int32_t srcsiz
   int error, cbytes;
 
   if (context->do_compress != 1) {
-    fprintf(stderr, "Context is not meant for compression.  Giving up.\n");
+    BLOSC_TRACE_ERROR("Context is not meant for compression.  Giving up.");
     return -10;
   }
 
@@ -1900,8 +1902,8 @@ int blosc2_compress_ctx(blosc2_context* context, const void* src, int32_t srcsiz
     if (context->compcode != BLOSC_ZSTD) {
       const char* compname;
       compname = clibcode_to_clibname(context->compcode);
-      fprintf(stderr, "Codec %s does not support dicts.  Giving up.\n",
-              compname);
+      BLOSC_TRACE_ERROR("Codec %s does not support dicts.  Giving up.",
+                        compname);
       return -20;
     }
 
@@ -1937,8 +1939,8 @@ int blosc2_compress_ctx(blosc2_context* context, const void* src, int32_t srcsiz
     //size_t dict_actual_size = ZDICT_optimizeTrainFromBuffer_fastCover(dict_buffer, dict_maxsize, samples_buffer, samples_sizes, nblocks, &fast_cover_params);
 
     if (ZDICT_isError(dict_actual_size) != ZSTD_error_no_error) {
-      fprintf(stderr, "Error in ZDICT_trainFromBuffer(): '%s'."
-              "  Giving up.\n", ZDICT_getErrorName(dict_actual_size));
+      BLOSC_TRACE_ERROR("Error in ZDICT_trainFromBuffer(): '%s'."
+                        "  Giving up.", ZDICT_getErrorName(dict_actual_size));
       return -20;
     }
     assert(dict_actual_size > 0);
@@ -2172,7 +2174,7 @@ int blosc2_decompress_ctx(blosc2_context* context, const void* src, int32_t srcs
   int result;
 
   if (context->do_compress != 0) {
-    fprintf(stderr, "Context is not meant for decompression.  Giving up.\n");
+    BLOSC_TRACE_ERROR("Context is not meant for decompression.  Giving up.");
     return -10;
   }
 
@@ -2320,12 +2322,12 @@ int _blosc_getitem(blosc2_context* context, const void* src, int32_t srcsize,
 
   /* Check region boundaries */
   if ((start < 0) || (start * typesize > nbytes)) {
-    fprintf(stderr, "`start` out of bounds");
+    BLOSC_TRACE_ERROR("`start` out of bounds.");
     return -1;
   }
 
   if ((stop < 0) || (stop * typesize > nbytes)) {
-    fprintf(stderr, "`start`+`nitems` out of bounds");
+    BLOSC_TRACE_ERROR("`start`+`nitems` out of bounds.");
     return -1;
   }
 
@@ -2428,7 +2430,7 @@ int blosc_getitem(const void* src, int start, int nitems, void* dest) {
     // Support for lazy chunks exists only for Blosc2, and needs the context.
     context.blosc2_flags = _src[BLOSC2_CHUNK_BLOSC2_FLAGS];
     if (context.blosc2_flags & 0x08) {
-      fprintf(stderr, "blosc_getitem does not support lazy chunks.  Use blosc2_getitem_ctx instead.");
+      BLOSC_TRACE_ERROR("blosc_getitem does not support lazy chunks.  Use blosc2_getitem_ctx instead.");
       return -2;
     }
   }
@@ -2728,8 +2730,8 @@ int init_threadpool(blosc2_context *context) {
                             (void *)thread_context);
       #endif
       if (rc2) {
-        fprintf(stderr, "ERROR; return code from pthread_create() is %d\n", rc2);
-        fprintf(stderr, "\tError detail: %s\n", strerror(rc2));
+        BLOSC_TRACE_ERROR("Return code from pthread_create() is %d.\n"
+                          "\tError detail: %s\n", rc2, strerror(rc2));
         return (-1);
       }
     }
@@ -3043,8 +3045,8 @@ int release_threadpool(blosc2_context *context) {
       for (t = 0; t < context->threads_started; t++) {
         rc = pthread_join(context->threads[t], &status);
         if (rc) {
-          fprintf(stderr, "ERROR; return code from pthread_join() is %d\n", rc);
-          fprintf(stderr, "\tError detail: %s\n", strerror(rc));
+          BLOSC_TRACE_ERROR("Return code from pthread_join() is %d\n"
+                            "\tError detail: %s.", rc, strerror(rc));
         }
       }
 

--- a/blosc/blosc2.h
+++ b/blosc/blosc2.h
@@ -45,7 +45,7 @@ extern "C" {
     do { \
          const char *__e = getenv("BLOSC_TRACE"); \
          if (!__e) { break; } \
-         fprintf(stderr, "[%s] - " msg (%s:%s)"\n", #cat, ##__VA_ARGS__, __FILE__, __LINE__); \
+         fprintf(stderr, "[%s] - " msg " (%s:%d)\n", #cat, ##__VA_ARGS__, __FILE__, __LINE__); \
        } while(0)
 
 

--- a/blosc/blosc2.h
+++ b/blosc/blosc2.h
@@ -45,7 +45,7 @@ extern "C" {
     do { \
          const char *__e = getenv("BLOSC_TRACE"); \
          if (!__e) { break; } \
-         fprintf(stderr, "[%s] - " msg "\n", #cat, ##__VA_ARGS__); \
+         fprintf(stderr, "[%s] - " msg (%s:%s)"\n", #cat, ##__VA_ARGS__, __FILE__, __LINE__); \
        } while(0)
 
 

--- a/blosc/blosc2.h
+++ b/blosc/blosc2.h
@@ -38,6 +38,17 @@ extern "C" {
 #define BLOSC_VERSION_DATE     "$Date:: 2020-04-21 #$"    /* date version */
 
 
+/* Tracing macros */
+#define BLOSC_TRACE_ERROR(msg, ...) BLOSC_TRACE(error, msg, ##__VA_ARGS__)
+#define BLOSC_TRACE_WARNING(msg, ...) BLOSC_TRACE(warning, msg, ##__VA_ARGS__)
+#define BLOSC_TRACE(cat, msg, ...) \
+    do { \
+         const char *__e = getenv("BLOSC_TRACE"); \
+         if (!__e) { break; } \
+         fprintf(stderr, "[%s] - " msg "\n", #cat, ##__VA_ARGS__); \
+       } while(0)
+
+
 /* The VERSION_FORMAT symbols below should be just 1-byte long */
 enum {
   /* Blosc format version, starting at 1

--- a/blosc/btune.c
+++ b/blosc/btune.c
@@ -30,7 +30,7 @@ static bool is_HCR(blosc2_context * context) {
     case BLOSC_ZSTD :
       return true;
     default :
-      fprintf(stderr, "Error in is_COMP_HCR: codec %d not handled\n",
+      BLOSC_TRACE_ERROR("Error in is_COMP_HCR: codec %d not handled.",
               context->compcode);
   }
   return false;

--- a/blosc/frame.c
+++ b/blosc/frame.c
@@ -70,7 +70,7 @@ void swap_store(void *dest, const void *pa, int size) {
                 pa2_[0] = pa_[1];
                 break;
             default:
-                fprintf(stderr, "Unhandled size: %d\n", size);
+              BLOSC_TRACE_ERROR("Unhandled size: %d.", size);
         }
     }
     memcpy(dest, pa2_, size);
@@ -423,7 +423,7 @@ int get_header_info(blosc2_frame *frame, int32_t *header_len, int64_t *frame_len
   if (filters != NULL && filters_meta != NULL) {
     uint8_t nfilters = framep[FRAME_FILTER_PIPELINE];
     if (nfilters > BLOSC2_MAX_FILTERS) {
-      fprintf(stderr, "Error: the number of filters in frame header are too large for Blosc2");
+      BLOSC_TRACE_ERROR("The number of filters in frame header are too large for Blosc2.");
       return -1;
     }
     uint8_t *filters_ = framep + FRAME_FILTER_PIPELINE + 1;
@@ -474,7 +474,7 @@ int update_frame_len(blosc2_frame* frame, int64_t len) {
     swap_store(&swap_len, &len, sizeof(int64_t));
     size_t wbytes = fwrite(&swap_len, 1, sizeof(int64_t), fp);
     if (wbytes != sizeof(int64_t)) {
-      fprintf(stderr, "Error: cannot write the frame length in header");
+      BLOSC_TRACE_ERROR("Cannot write the frame length in header.");
       return -1;
     }
     fclose(fp);
@@ -485,7 +485,7 @@ int update_frame_len(blosc2_frame* frame, int64_t len) {
 
 int frame_update_trailer(blosc2_frame* frame, blosc2_schunk* schunk) {
   if (frame->len == 0) {
-    fprintf(stderr, "Error: the trailer cannot be updated on empty frames");
+  BLOSC_TRACE_ERROR("The trailer cannot be updated on empty frames.");
   }
 
   // Create the trailer in msgpack (see the frame format document)
@@ -533,7 +533,7 @@ int frame_update_trailer(blosc2_frame* frame, blosc2_schunk* schunk) {
   int ret = get_header_info(frame, &header_len, &frame_len, &nbytes, &cbytes, &chunksize, &nchunks,
                             NULL, NULL, NULL, NULL, NULL);
   if (ret < 0) {
-    fprintf(stderr, "unable to get meta info from frame");
+    BLOSC_TRACE_ERROR("Unable to get meta info from frame.");
     return -1;
   }
 
@@ -545,7 +545,7 @@ int frame_update_trailer(blosc2_frame* frame, blosc2_schunk* schunk) {
   if (frame->sdata != NULL) {
     frame->sdata = realloc(frame->sdata, (size_t)(trailer_offset + trailer_len));
     if (frame->sdata == NULL) {
-      fprintf(stderr, "Error: cannot realloc space for the frame.");
+      BLOSC_TRACE_ERROR("Cannot realloc space for the frame.");
       return -1;
     }
     memcpy(frame->sdata + trailer_offset, trailer, trailer_len);
@@ -555,7 +555,7 @@ int frame_update_trailer(blosc2_frame* frame, blosc2_schunk* schunk) {
     fseek(fp, trailer_offset, SEEK_SET);
     size_t wbytes = fwrite(trailer, 1, trailer_len, fp);
     if (wbytes != (size_t)trailer_len) {
-      fprintf(stderr, "Error: cannot write the trailer length in trailer");
+      BLOSC_TRACE_ERROR("Cannot write the trailer length in trailer.");
       return -2;
     }
     fclose(fp);
@@ -697,7 +697,7 @@ int64_t blosc2_schunk_to_sframe(blosc2_schunk* schunk, uint8_t** sframe) {
     frame = blosc2_frame_new(NULL);
     sdata_len = blosc2_frame_from_schunk(schunk, frame);
     if (sdata_len < 0) {
-      fprintf(stderr, "Error during the conversion of schunk to frame\n");
+      BLOSC_TRACE_ERROR("Error during the conversion of schunk to frame.");
       return sdata_len;
     }
     sdata = frame->sdata;
@@ -716,7 +716,7 @@ int64_t blosc2_schunk_to_sframe(blosc2_schunk* schunk, uint8_t** sframe) {
 int64_t blosc2_frame_to_file(blosc2_frame *frame, const char *fname) {
   // make sure that we are using an in-memory frame
   if (frame->fname != NULL) {
-    fprintf(stderr, "Error: the original frame must be in-memory");
+    BLOSC_TRACE_ERROR("The original frame must be in-memory.");
     return -1;
   }
   FILE* fp = fopen(fname, "wb");
@@ -735,7 +735,7 @@ blosc2_frame* blosc2_frame_from_file(const char *fname) {
   FILE* fp = fopen(fname, "rb");
   size_t rbytes = fread(header, 1, FRAME_HEADER_MINLEN, fp);
   if (rbytes != FRAME_HEADER_MINLEN) {
-    fprintf(stderr, "Error: cannot read from file '%s'\n", fname);
+    BLOSC_TRACE_ERROR("Cannot read from file '%s'.", fname);
     fclose(fp);
     return NULL;
   }
@@ -752,7 +752,7 @@ blosc2_frame* blosc2_frame_from_file(const char *fname) {
   rbytes = fread(trailer, 1, FRAME_TRAILER_MINLEN, fp);
   fclose(fp);
   if (rbytes != FRAME_TRAILER_MINLEN) {
-    fprintf(stderr, "Error: cannot read from file '%s'\n", fname);
+    BLOSC_TRACE_ERROR("Cannot read from file '%s'.", fname);
     return NULL;
   }
   int trailer_offset = FRAME_TRAILER_MINLEN - FRAME_TRAILER_LEN_OFFSET;
@@ -828,7 +828,7 @@ uint8_t* get_coffsets(blosc2_frame *frame, int32_t header_len, int64_t cbytes, i
   fseek(fp, header_len + cbytes, SEEK_SET);
   size_t rbytes = fread(coffsets, 1, (size_t)coffsets_cbytes, fp);
   if (rbytes != (size_t)coffsets_cbytes) {
-    fprintf(stderr, "Error: cannot read the offsets out of the fileframe.\n");
+    BLOSC_TRACE_ERROR("Cannot read the offsets out of the fileframe.");
     fclose(fp);
     return NULL;
   }
@@ -848,7 +848,8 @@ int frame_update_header(blosc2_frame* frame, blosc2_schunk* schunk, bool new) {
   }
 
   if (new && schunk->cbytes > 0) {
-    fprintf(stderr, "Error: new metalayers cannot be added after actual data has been appended\n");
+    BLOSC_TRACE_ERROR("New metalayers cannot be added after actual data "
+                      "has been appended.");
     return -1;
   }
 
@@ -881,7 +882,7 @@ int frame_update_header(blosc2_frame* frame, blosc2_schunk* schunk, bool new) {
   }
 
   if (!new && prev_h2len != h2len) {
-    fprintf(stderr, "Error: the new metalayer sizes should be equal the existing ones");
+    BLOSC_TRACE_ERROR("The new metalayer sizes should be equal the existing ones.");
     return -2;
   }
 
@@ -916,12 +917,12 @@ int32_t frame_get_usermeta(blosc2_frame* frame, uint8_t** usermeta) {
   int ret = get_header_info(frame, &header_len, &frame_len, &nbytes, &cbytes, &chunksize, &nchunks,
                             NULL, NULL, NULL, NULL, NULL);
   if (ret < 0) {
-    fprintf(stderr, "Unable to get the header info from frame");
+    BLOSC_TRACE_ERROR("Unable to get the header info from frame.");
     return -1;
   }
   int64_t trailer_offset = get_trailer_offset(frame, header_len, cbytes);
   if (trailer_offset < 0) {
-    fprintf(stderr, "Unable to get the trailer offset from frame");
+    BLOSC_TRACE_ERROR("Unable to get the trailer offset from frame.");
     return -1;
   }
 
@@ -934,7 +935,7 @@ int32_t frame_get_usermeta(blosc2_frame* frame, uint8_t** usermeta) {
     fseek(fp, trailer_offset + FRAME_TRAILER_USERMETA_LEN_OFFSET, SEEK_SET);
     size_t rbytes = fread(&usermeta_len_network, 1, sizeof(int32_t), fp);
     if (rbytes != sizeof(int32_t)) {
-      fprintf(stderr, "Cannot access the usermeta_len out of the fileframe.\n");
+      BLOSC_TRACE_ERROR("Cannot access the usermeta_len out of the fileframe.");
       fclose(fp);
       return -1;
     }
@@ -957,7 +958,7 @@ int32_t frame_get_usermeta(blosc2_frame* frame, uint8_t** usermeta) {
     fseek(fp, trailer_offset + FRAME_TRAILER_USERMETA_OFFSET, SEEK_SET);
     size_t rbytes = fread(*usermeta, 1, usermeta_len, fp);
     if (rbytes != (size_t)usermeta_len) {
-      fprintf(stderr, "Error: cannot read the complete usermeta chunk in frame. %ld != %ld \n",
+      BLOSC_TRACE_ERROR("Cannot read the complete usermeta chunk in frame. %ld != %ld.",
               (long)rbytes, (long)usermeta_len);
       return -1;
     }
@@ -979,7 +980,7 @@ int frame_get_metalayers(blosc2_frame* frame, blosc2_schunk* schunk) {
   int ret = get_header_info(frame, &header_len, &frame_len, &nbytes, &cbytes, &chunksize, &nchunks,
                             NULL, NULL, NULL, NULL, NULL);
   if (ret < 0) {
-    fprintf(stderr, "Unable to get the header info from frame");
+    BLOSC_TRACE_ERROR("Unable to get the header info from frame.");
     return -1;
   }
 
@@ -996,7 +997,7 @@ int frame_get_metalayers(blosc2_frame* frame, blosc2_schunk* schunk) {
       fclose(fp);
     }
     if (rbytes != (size_t) header_len) {
-      fprintf(stderr, "Cannot access the header out of the fileframe.\n");
+      BLOSC_TRACE_ERROR("Cannot access the header out of the fileframe.");
       free(header);
       return -2;
     }
@@ -1115,7 +1116,7 @@ blosc2_schunk* blosc2_frame_to_schunk(blosc2_frame* frame, bool copy) {
                             &schunk->chunksize, &schunk->nchunks, &schunk->typesize,
                             &schunk->compcode, &schunk->clevel, schunk->filters, schunk->filters_meta);
   if (ret < 0) {
-    fprintf(stderr, "unable to get meta info from frame");
+    BLOSC_TRACE_ERROR("Unable to get meta info from frame.");
     free(schunk);
     return NULL;
   }
@@ -1148,7 +1149,7 @@ blosc2_schunk* blosc2_frame_to_schunk(blosc2_frame* frame, bool copy) {
     blosc2_free_ctx(schunk->cctx);
     blosc2_free_ctx(schunk->dctx);
     free(schunk);
-    fprintf(stderr, "Error: cannot get the offsets for the frame\n");
+    BLOSC_TRACE_ERROR("Cannot get the offsets for the frame.");
     return NULL;
   }
 
@@ -1163,7 +1164,7 @@ blosc2_schunk* blosc2_frame_to_schunk(blosc2_frame* frame, bool copy) {
     blosc2_free_ctx(schunk->cctx);
     blosc2_free_ctx(schunk->dctx);
     free(schunk);
-    fprintf(stderr, "Error: cannot decompress the offsets chunk");
+    BLOSC_TRACE_ERROR("Cannot decompress the offsets chunk.");
     return NULL;
   }
 
@@ -1259,7 +1260,7 @@ blosc2_schunk* blosc2_frame_to_schunk(blosc2_frame* frame, bool copy) {
     blosc2_free_ctx(schunk->cctx);
     blosc2_free_ctx(schunk->dctx);
     free(schunk);
-    fprintf(stderr, "Error: cannot access the metalayers");
+    BLOSC_TRACE_ERROR("Cannot access the metalayers.");
     return NULL;
   }
 
@@ -1268,7 +1269,7 @@ blosc2_schunk* blosc2_frame_to_schunk(blosc2_frame* frame, bool copy) {
     blosc2_free_ctx(schunk->cctx);
     blosc2_free_ctx(schunk->dctx);
     free(schunk);
-    fprintf(stderr, "Error: cannot access the usermeta chunk");
+    BLOSC_TRACE_ERROR("Cannot access the usermeta chunk.");
     return NULL;
   }
   schunk->usermeta = usermeta;
@@ -1296,7 +1297,7 @@ int64_t get_coffset(blosc2_frame* frame, int32_t header_len, int64_t cbytes, int
   int64_t offset;
   uint8_t *coffsets = get_coffsets(frame, header_len, cbytes, NULL);
   if (coffsets == NULL) {
-    fprintf(stderr, "Error: cannot get the offset for chunk %d for the frame\n", nchunk);
+  BLOSC_TRACE_ERROR("Cannot get the offset for chunk %d for the frame.", nchunk);
     return -3;
   }
 
@@ -1304,7 +1305,7 @@ int64_t get_coffset(blosc2_frame* frame, int32_t header_len, int64_t cbytes, int
   if (rc < 0) {
     size_t nbytes_, cbytes_, blocksize_;
     blosc_cbuffer_sizes(coffsets, &nbytes_, &cbytes_, &blocksize_);
-    fprintf(stderr, "Error: problems retrieving a chunk offset");
+    BLOSC_TRACE_ERROR("Problems retrieving a chunk offset.");
     return -4;
   }
   return offset;
@@ -1333,13 +1334,13 @@ int frame_get_chunk(blosc2_frame *frame, int nchunk, uint8_t **chunk, bool *need
   int ret = get_header_info(frame, &header_len, &frame_len, &nbytes, &cbytes, &chunksize, &nchunks,
                             NULL, NULL, NULL, NULL, NULL);
   if (ret < 0) {
-    fprintf(stderr, "unable to get meta info from frame");
+    BLOSC_TRACE_ERROR("Unable to get meta info from frame.");
     return -1;
   }
 
   if (nchunk >= nchunks) {
-    fprintf(stderr, "nchunk ('%d') exceeds the number of chunks "
-                    "('%d') in frame\n", nchunk, nchunks);
+    BLOSC_TRACE_ERROR("nchunk ('%d') exceeds the number of chunks "
+                    "('%d') in frame.", nchunk, nchunks);
     return -2;
   }
 
@@ -1352,7 +1353,7 @@ int frame_get_chunk(blosc2_frame *frame, int nchunk, uint8_t **chunk, bool *need
     fseek(fp, header_len + offset + BLOSC2_CHUNK_CBYTES, SEEK_SET);
     size_t rbytes = fread(&chunk_cbytes, 1, sizeof(chunk_cbytes), fp);
     if (rbytes != sizeof(chunk_cbytes)) {
-      fprintf(stderr, "Cannot read the cbytes for chunk in the fileframe.\n");
+      BLOSC_TRACE_ERROR("Cannot read the cbytes for chunk in the fileframe.");
       return -5;
     }
     chunk_cbytes = sw32_(&chunk_cbytes);
@@ -1360,7 +1361,7 @@ int frame_get_chunk(blosc2_frame *frame, int nchunk, uint8_t **chunk, bool *need
     fseek(fp, header_len + offset, SEEK_SET);
     rbytes = fread(*chunk, 1, (size_t)chunk_cbytes, fp);
     if (rbytes != (size_t)chunk_cbytes) {
-      fprintf(stderr, "Cannot read the chunk out of the fileframe.\n");
+      BLOSC_TRACE_ERROR("Cannot read the chunk out of the fileframe.");
       return -6;
     }
     fclose(fp);
@@ -1398,13 +1399,13 @@ int frame_get_lazychunk(blosc2_frame *frame, int nchunk, uint8_t **chunk, bool *
   int ret = get_header_info(frame, &header_len, &frame_len, &nbytes, &cbytes, &chunksize, &nchunks,
                             NULL, NULL, NULL, NULL, NULL);
   if (ret < 0) {
-    fprintf(stderr, "unable to get meta info from frame");
+    BLOSC_TRACE_ERROR("Unable to get meta info from frame.");
     return -1;
   }
 
   if (nchunk >= nchunks) {
-    fprintf(stderr, "nchunk ('%d') exceeds the number of chunks "
-                    "('%d') in frame\n", nchunk, nchunks);
+    BLOSC_TRACE_ERROR("nchunk ('%d') exceeds the number of chunks "
+                      "('%d') in frame.", nchunk, nchunks);
     return -2;
   }
 
@@ -1423,7 +1424,7 @@ int frame_get_lazychunk(blosc2_frame *frame, int nchunk, uint8_t **chunk, bool *
     fseek(fp, header_len + offset, SEEK_SET);
     size_t rbytes = fread(header, 1, BLOSC_MIN_HEADER_LENGTH, fp);
     if (rbytes != BLOSC_MIN_HEADER_LENGTH) {
-      fprintf(stderr, "Cannot read the header for chunk in the fileframe.\n");
+      BLOSC_TRACE_ERROR("Cannot read the header for chunk in the fileframe.");
       return -5;
     }
     blosc_cbuffer_sizes(header, &chunk_nbytes, &chunk_cbytes, &chunk_blocksize);
@@ -1441,7 +1442,7 @@ int frame_get_lazychunk(blosc2_frame *frame, int nchunk, uint8_t **chunk, bool *
     rbytes = fread(*chunk, 1, lazy_partial_len, fp);
     fclose(fp);
     if (rbytes != lazy_partial_len) {
-      fprintf(stderr, "Cannot read the (lazy) chunk out of the fileframe.\n");
+      BLOSC_TRACE_ERROR("Cannot read the (lazy) chunk out of the fileframe.");
       return -6;
     }
 
@@ -1508,7 +1509,7 @@ void* frame_append_chunk(blosc2_frame* frame, void* chunk, blosc2_schunk* schunk
   int rc = get_header_info(frame, &header_len, &frame_len, &nbytes, &cbytes, &chunksize, &nchunks,
                            NULL, NULL, NULL, NULL, NULL);
   if (rc < 0) {
-    fprintf(stderr, "unable to get meta info from frame");
+    BLOSC_TRACE_ERROR("Unable to get meta info from frame.");
     return NULL;
   }
 
@@ -1521,8 +1522,8 @@ void* frame_append_chunk(blosc2_frame* frame, void* chunk, blosc2_schunk* schunk
   int64_t new_cbytes = cbytes + cbytes_chunk;
 
   if ((nchunks > 0) && (nbytes_chunk > chunksize)) {
-    fprintf(stderr, "appending chunks with a larger chunksize than frame is not allowed yet"
-                    "%d != %d", nbytes_chunk, chunksize);
+    BLOSC_TRACE_ERROR("Appending chunks with a larger chunksize than frame is "
+                      "not allowed yet %d != %d.", nbytes_chunk, chunksize);
     return NULL;
   }
 
@@ -1532,8 +1533,8 @@ void* frame_append_chunk(blosc2_frame* frame, void* chunk, blosc2_schunk* schunk
     bool needs_free;
     int retcode = frame_get_lazychunk(frame, nchunks - 1, &last_chunk, &needs_free);
     if (retcode < 0) {
-      fprintf(stderr,
-              "cannot get the last chunk (in position %d)", nchunks - 1);
+      BLOSC_TRACE_ERROR("Cannot get the last chunk (in position %d).",
+                        nchunks - 1);
       return NULL;
     }
     int32_t last_nbytes = sw32_(last_chunk + BLOSC2_CHUNK_NBYTES);
@@ -1541,10 +1542,9 @@ void* frame_append_chunk(blosc2_frame* frame, void* chunk, blosc2_schunk* schunk
       free(last_chunk);
     }
     if ((last_nbytes < chunksize) && (nbytes < chunksize)) {
-      fprintf(stderr,
-              "appending two consecutive chunks with a chunksize smaller than the frame chunksize"
-              "is not allowed yet: "
-              "%d != %d", nbytes_chunk, chunksize);
+      BLOSC_TRACE_ERROR("Appending two consecutive chunks with a chunksize smaller "
+                        "than the frame chunksize is not allowed yet: %d != %d.",
+                        nbytes_chunk, chunksize);
       return NULL;
     }
   }
@@ -1556,7 +1556,7 @@ void* frame_append_chunk(blosc2_frame* frame, void* chunk, blosc2_schunk* schunk
     int32_t coffsets_cbytes = 0;
     uint8_t *coffsets = get_coffsets(frame, header_len, cbytes, &coffsets_cbytes);
     if (coffsets == NULL) {
-      fprintf(stderr, "Error: cannot get the offsets for the frame\n");
+      BLOSC_TRACE_ERROR("Cannot get the offsets for the frame.");
       return NULL;
     }
     // Decompress offsets
@@ -1566,7 +1566,7 @@ void* frame_append_chunk(blosc2_frame* frame, void* chunk, blosc2_schunk* schunk
     blosc2_free_ctx(dctx);
     if (prev_nbytes < 0) {
       free(offsets);
-      fprintf(stderr, "Error: cannot decompress the offsets chunk");
+      BLOSC_TRACE_ERROR("Cannot decompress the offsets chunk.");
       return NULL;
     }
   }
@@ -1605,7 +1605,7 @@ void* frame_append_chunk(blosc2_frame* frame, void* chunk, blosc2_schunk* schunk
     /* Make space for the new chunk and copy it */
     frame->sdata = framep = realloc(framep, (size_t)new_frame_len);
     if (framep == NULL) {
-      fprintf(stderr, "cannot realloc space for the frame.");
+      BLOSC_TRACE_ERROR("Cannot realloc space for the frame.");
       return NULL;
     }
     /* Copy the chunk */
@@ -1618,12 +1618,12 @@ void* frame_append_chunk(blosc2_frame* frame, void* chunk, blosc2_schunk* schunk
     fseek(fp, header_len + cbytes, SEEK_SET);
     size_t wbytes = fwrite(chunk, 1, (size_t)cbytes_chunk, fp);  // the new chunk
     if (wbytes != (size_t)cbytes_chunk) {
-      fprintf(stderr, "cannot write the full chunk to fileframe.");
+      BLOSC_TRACE_ERROR("Cannot write the full chunk to fileframe.");
       return NULL;
     }
     wbytes = fwrite(off_chunk, 1, (size_t)new_off_cbytes, fp);  // the new offsets
     if (wbytes != (size_t)new_off_cbytes) {
-      fprintf(stderr, "cannot write the offsets to fileframe.");
+      BLOSC_TRACE_ERROR("Cannot write the offsets to fileframe.");
       return NULL;
     }
     fclose(fp);
@@ -1658,8 +1658,7 @@ int frame_decompress_chunk(blosc2_context *dctx, blosc2_frame *frame, int nchunk
   // Use a lazychunk here in order to do a potential parallel read.
   int chunk_cbytes = frame_get_lazychunk(frame, nchunk, &src, &needs_free);
   if (chunk_cbytes < 0) {
-    fprintf(stderr,
-            "cannot get the chunk in position %d", nchunk);
+    BLOSC_TRACE_ERROR("Cannot get the chunk in position %d.", nchunk);
     return -1;
   }
   if (chunk_cbytes < sizeof(int32_t)) {
@@ -1670,14 +1669,14 @@ int frame_decompress_chunk(blosc2_context *dctx, blosc2_frame *frame, int nchunk
   /* Create a buffer for destination */
   int32_t nbytes_ = sw32_(src + BLOSC2_CHUNK_NBYTES);
   if (nbytes_ > (int32_t)nbytes) {
-    fprintf(stderr, "Not enough space for decompressing in dest");
+    BLOSC_TRACE_ERROR("Not enough space for decompressing in dest.");
     return -1;
   }
 
   /* And decompress it */
   int32_t chunksize = blosc2_decompress_ctx(dctx, src, chunk_cbytes, dest, nbytes);
   if (chunksize < 0 || chunksize != nbytes_) {
-    fprintf(stderr, "Error in decompressing chunk");
+    BLOSC_TRACE_ERROR("Error in decompressing chunk.");
     return -11;
   }
 
@@ -1705,7 +1704,7 @@ int frame_reorder_offsets(blosc2_frame *frame, int *offsets_order, blosc2_schunk
   int32_t coffsets_cbytes = 0;
   uint8_t *coffsets = get_coffsets(frame, header_len, cbytes, &coffsets_cbytes);
   if (coffsets == NULL) {
-    fprintf(stderr, "Error: cannot get the offsets for the frame\n");
+    BLOSC_TRACE_ERROR("Cannot get the offsets for the frame.");
     return -1;
   }
 
@@ -1719,7 +1718,7 @@ int frame_reorder_offsets(blosc2_frame *frame, int *offsets_order, blosc2_schunk
   blosc2_free_ctx(dctx);
   if (prev_nbytes < 0) {
     free(offsets);
-    fprintf(stderr, "Error: cannot decompress the offsets chunk");
+    BLOSC_TRACE_ERROR("Cannot decompress the offsets chunk.");
     return -1;
   }
 
@@ -1753,7 +1752,7 @@ int frame_reorder_offsets(blosc2_frame *frame, int *offsets_order, blosc2_schunk
     /* Make space for the new chunk and copy it */
     frame->sdata = framep = realloc(framep, (size_t)new_frame_len);
     if (framep == NULL) {
-      fprintf(stderr, "cannot realloc space for the frame.");
+      BLOSC_TRACE_ERROR("Cannot realloc space for the frame.");
       return -1;
     }
     /* Copy the offsets */
@@ -1764,7 +1763,7 @@ int frame_reorder_offsets(blosc2_frame *frame, int *offsets_order, blosc2_schunk
     fseek(fp, header_len + cbytes, SEEK_SET);
     size_t wbytes = fwrite(off_chunk, 1, (size_t)new_off_cbytes, fp);  // the new offsets
     if (wbytes != (size_t)new_off_cbytes) {
-      fprintf(stderr, "cannot write the offsets to fileframe.");
+      BLOSC_TRACE_ERROR("Cannot write the offsets to fileframe.");
       return -1;
     }
     fclose(fp);

--- a/blosc/schunk.c
+++ b/blosc/schunk.c
@@ -147,12 +147,12 @@ blosc2_schunk* blosc2_schunk_new(const blosc2_storage storage) {
     // Initialize frame (basically, encode the header)
     int64_t frame_len = blosc2_frame_from_schunk(schunk, frame);
     if (frame_len < 0) {
-      fprintf(stderr, "Error during the conversion of schunk to frame\n");
+      BLOSC_TRACE_ERROR("Error during the conversion of schunk to frame.");
     }
     schunk->frame = frame;
   }
   else if (storage.path != NULL) {
-    fprintf(stderr, "Creating empty sparse schunks on-disk is not supported yet\n");
+    BLOSC_TRACE_ERROR("Creating empty sparse schunks on-disk is not supported yet.");
     return NULL;
   }
 
@@ -164,7 +164,7 @@ blosc2_schunk* blosc2_schunk_new(const blosc2_storage storage) {
 blosc2_schunk *blosc2_schunk_empty(int nchunks, const blosc2_storage storage) {
   blosc2_schunk* schunk = blosc2_schunk_new(storage);
   if (storage.sequential) {
-    fprintf(stderr, "Creating empty frames is not supported yet\n");
+    BLOSC_TRACE_ERROR("Creating empty frames is not supported yet.");
     return NULL;
   }
 
@@ -184,11 +184,11 @@ blosc2_schunk *blosc2_schunk_empty(int nchunks, const blosc2_storage storage) {
 /* Open an existing super-chunk that is on-disk (no copy is made). */
 blosc2_schunk* blosc2_schunk_open(const blosc2_storage storage) {
   if (!storage.sequential) {
-    fprintf(stderr, "Opening sparse super-chunks on-disk is not supported yet\n");
+    BLOSC_TRACE_ERROR("Opening sparse super-chunks on-disk is not supported yet.");
     return NULL;
   }
   if (storage.path == NULL) {
-    fprintf(stderr, "You need to supply a storage.path\n");
+    BLOSC_TRACE_ERROR("You need to supply a storage.path.");
     return NULL;
   }
 
@@ -280,8 +280,8 @@ int blosc2_schunk_append_chunk(blosc2_schunk *schunk, uint8_t *chunk, bool copy)
   }
 
   if (nbytes > schunk->chunksize) {
-    fprintf(stderr, "Appending chunks that have different lengths in the same schunk is not supported yet: "
-                    "%d > %d", nbytes, schunk->chunksize);
+    BLOSC_TRACE_ERROR("Appending chunks that have different lengths in the same schunk "
+                      "is not supported yet: %d > %d.", nbytes, schunk->chunksize);
     return -1;
   }
 
@@ -293,7 +293,7 @@ int blosc2_schunk_append_chunk(blosc2_schunk *schunk, uint8_t *chunk, bool copy)
   // Update super-chunk or frame
   if (schunk->frame == NULL) {
     if (schunk->storage->path != NULL) {
-      printf("The persistent sparse storage is not supported yet");
+      BLOSC_TRACE_ERROR("The persistent sparse storage is not supported yet.");
       return -1;
     }
     // Check that we are not appending a small chunk after another small chunk
@@ -301,10 +301,9 @@ int blosc2_schunk_append_chunk(blosc2_schunk *schunk, uint8_t *chunk, bool copy)
       uint8_t* last_chunk = schunk->data[nchunks - 1];
       int32_t last_nbytes = sw32_(last_chunk + BLOSC2_CHUNK_NBYTES);
       if ((last_nbytes < schunk->chunksize) && (nbytes < schunk->chunksize)) {
-        fprintf(stderr,
-                "appending two consecutive chunks with a chunksize smaller than the schunk chunksize"
-                "is not allowed yet: "
-                "%d != %d", nbytes, schunk->chunksize);
+        BLOSC_TRACE_ERROR(
+                "Appending two consecutive chunks with a chunksize smaller than the schunk chunksize "
+                "is not allowed yet: %d != %d.", nbytes, schunk->chunksize);
         return -1;
       }
     }
@@ -330,7 +329,7 @@ int blosc2_schunk_append_chunk(blosc2_schunk *schunk, uint8_t *chunk, bool copy)
   }
   else {
     if (frame_append_chunk(schunk->frame, chunk, schunk) == NULL) {
-      fprintf(stderr, "Problems appending a chunk");
+      BLOSC_TRACE_ERROR("Problems appending a chunk.");
       return -1;
     }
   }
@@ -352,8 +351,8 @@ int blosc2_schunk_insert_chunk(blosc2_schunk *schunk, int nchunk, uint8_t *chunk
   }
 
   if (nbytes > schunk->chunksize) {
-    fprintf(stderr, "Inserting chunks that have different lengths in the same schunk is not supported yet: "
-                    "%d > %d", nbytes, schunk->chunksize);
+    BLOSC_TRACE_ERROR("Inserting chunks that have different lengths in the same schunk "
+                      "is not supported yet: %d > %d.", nbytes, schunk->chunksize);
     return -1;
   }
 
@@ -369,10 +368,9 @@ int blosc2_schunk_insert_chunk(blosc2_schunk *schunk, int nchunk, uint8_t *chunk
       uint8_t* last_chunk = schunk->data[nchunks - 1];
       int32_t last_nbytes = sw32_(last_chunk + BLOSC2_CHUNK_NBYTES);
       if ((last_nbytes < schunk->chunksize) && (nbytes < schunk->chunksize)) {
-        fprintf(stderr,
-                "appending two consecutive chunks with a chunksize smaller than the schunk chunksize"
-                "is not allowed yet: "
-                "%d != %d", nbytes, schunk->chunksize);
+        BLOSC_TRACE_ERROR("Appending two consecutive chunks with a chunksize smaller "
+                          "than the schunk chunksize is not allowed yet:  %d != %d",
+                          nbytes, schunk->chunksize);
         return -1;
       }
     }
@@ -403,7 +401,7 @@ int blosc2_schunk_insert_chunk(blosc2_schunk *schunk, int nchunk, uint8_t *chunk
   }
 
   else {
-    fprintf(stderr, "Not allowed yet");
+    BLOSC_TRACE_ERROR("Frames are not allowed yet.");
     return -1;
   }
   return schunk->nchunks;
@@ -420,8 +418,8 @@ int blosc2_schunk_update_chunk(blosc2_schunk *schunk, int nchunk, uint8_t *chunk
   }
 
   if ((schunk->chunksize != 0) && (nbytes > schunk->chunksize)) {
-    fprintf(stderr, "Inserting chunks that have different lengths in the same schunk is not supported yet: "
-                    "%d > %d", nbytes, schunk->chunksize);
+    BLOSC_TRACE_ERROR("Inserting chunks that have different lengths in the same schunk "
+                      "is not supported yet: %d > %d.", nbytes, schunk->chunksize);
     return -1;
   }
 
@@ -455,9 +453,9 @@ int blosc2_schunk_update_chunk(blosc2_schunk *schunk, int nchunk, uint8_t *chunk
         last_nbytes = sw32_(last_chunk + BLOSC2_CHUNK_NBYTES);
       }
       if ((last_nbytes < schunk->chunksize) && (nbytes < schunk->chunksize)) {
-        fprintf(stderr,
-                "appending two consecutive chunks with a chunksize smaller than the schunk chunksize"
-                "is not allowed yet: %d != %d", nbytes, schunk->chunksize);
+        BLOSC_TRACE_ERROR("Appending two consecutive chunks with a chunksize smaller "
+                          "than the schunk chunksize is not allowed yet: %d != %d.",
+                          nbytes, schunk->chunksize);
         return -1;
       }
     }
@@ -480,7 +478,7 @@ int blosc2_schunk_update_chunk(blosc2_schunk *schunk, int nchunk, uint8_t *chunk
     schunk->data[nchunk] = chunk;
   }
   else {
-    fprintf(stderr, "Updating chunks in a frame is not allowed yet");
+    BLOSC_TRACE_ERROR("Updating chunks in a frame is not allowed yet.");
     return -1;
   }
 
@@ -514,8 +512,8 @@ int blosc2_schunk_decompress_chunk(blosc2_schunk *schunk, int nchunk,
   int chunksize;
   if (schunk->frame == NULL) {
     if (nchunk >= schunk->nchunks) {
-      fprintf(stderr, "nchunk ('%d') exceeds the number of chunks "
-                      "('%d') in super-chunk\n", nchunk, schunk->nchunks);
+      BLOSC_TRACE_ERROR("nchunk ('%d') exceeds the number of chunks "
+                        "('%d') in super-chunk.", nchunk, schunk->nchunks);
       return -11;
     }
 
@@ -526,14 +524,14 @@ int blosc2_schunk_decompress_chunk(blosc2_schunk *schunk, int nchunk,
 
     int nbytes_ = sw32_(src + BLOSC2_CHUNK_NBYTES);
     if (nbytes < nbytes_) {
-      fprintf(stderr, "Buffer size is too small for the decompressed buffer "
-                      "('%d' bytes, but '%d' are needed)\n", nbytes, nbytes_);
+      BLOSC_TRACE_ERROR("Buffer size is too small for the decompressed buffer "
+                        "('%d' bytes, but '%d' are needed).", nbytes, nbytes_);
       return -11;
     }
     int cbytes = sw32_(src + BLOSC2_CHUNK_CBYTES);
     chunksize = blosc2_decompress_ctx(schunk->dctx, src, cbytes, dest, nbytes);
     if (chunksize < 0 || chunksize != nbytes_) {
-      fprintf(stderr, "Error in decompressing chunk");
+      BLOSC_TRACE_ERROR("Error in decompressing chunk.");
       return -11;
     }
   } else {
@@ -561,8 +559,8 @@ int blosc2_schunk_get_chunk(blosc2_schunk *schunk, int nchunk, uint8_t **chunk, 
   }
 
   if (nchunk >= schunk->nchunks) {
-    fprintf(stderr, "nchunk ('%d') exceeds the number of chunks "
-                    "('%d') in schunk\n", nchunk, schunk->nchunks);
+    BLOSC_TRACE_ERROR("nchunk ('%d') exceeds the number of chunks "
+                      "('%d') in schunk.", nchunk, schunk->nchunks);
     return -2;
   }
 
@@ -593,8 +591,8 @@ int blosc2_schunk_get_lazychunk(blosc2_schunk *schunk, int nchunk, uint8_t **chu
   }
 
   if (nchunk >= schunk->nchunks) {
-    fprintf(stderr, "nchunk ('%d') exceeds the number of chunks "
-                    "('%d') in schunk\n", nchunk, schunk->nchunks);
+    BLOSC_TRACE_ERROR("nchunk ('%d') exceeds the number of chunks "
+                      "('%d') in schunk.", nchunk, schunk->nchunks);
     return -2;
   }
 
@@ -615,7 +613,7 @@ int blosc2_schunk_get_lazychunk(blosc2_schunk *schunk, int nchunk, uint8_t **chu
  */
 int blosc2_has_metalayer(blosc2_schunk *schunk, const char *name) {
   if (strlen(name) > BLOSC2_METALAYER_NAME_MAXLEN) {
-    fprintf(stderr, "metalayers cannot be larger than %d chars\n", BLOSC2_METALAYER_NAME_MAXLEN);
+    BLOSC_TRACE_ERROR("Metalayers cannot be larger than %d chars.", BLOSC2_METALAYER_NAME_MAXLEN);
     return -1;
   }
 
@@ -634,13 +632,13 @@ int blosc2_schunk_reorder_offsets(blosc2_schunk *schunk, int *offsets_order) {
   for (int i = 0; i < schunk->nchunks; ++i) {
     int index = offsets_order[i];
     if (index >= schunk->nchunks) {
-      fprintf(stderr, "Error: index is bigger than the number of chunks\n");
+      BLOSC_TRACE_ERROR("Index is bigger than the number of chunks.");
       return -1;
     }
     if (index_check[index] == false) {
       index_check[index] = true;
     } else {
-      fprintf(stderr, "Error: index is yet used\n");
+      BLOSC_TRACE_ERROR("Index is yet used.");
       return -1;
     }
   }
@@ -683,12 +681,12 @@ int metalayer_flush(blosc2_schunk* schunk) {
   }
   rc = frame_update_header(schunk->frame, schunk, true);
   if (rc < 0) {
-    fprintf(stderr, "Error: unable to update metalayers into frame\n");
+    BLOSC_TRACE_ERROR("Unable to update metalayers into frame.");
     return -1;
   }
   rc = frame_update_trailer(schunk->frame, schunk);
   if (rc < 0) {
-    fprintf(stderr, "Error: unable to update trailer into frame\n");
+    BLOSC_TRACE_ERROR("Unable to update trailer into frame.");
     return -2;
   }
   return rc;
@@ -702,7 +700,7 @@ int metalayer_flush(blosc2_schunk* schunk) {
 int blosc2_add_metalayer(blosc2_schunk *schunk, const char *name, uint8_t *content, uint32_t content_len) {
   int nmetalayer = blosc2_has_metalayer(schunk, name);
   if (nmetalayer >= 0) {
-    fprintf(stderr, "metalayer \"%s\" already exists", name);
+    BLOSC_TRACE_ERROR("Metalayer \"%s\" already exists.", name);
     return -2;
   }
 
@@ -734,13 +732,13 @@ int blosc2_add_metalayer(blosc2_schunk *schunk, const char *name, uint8_t *conte
 int blosc2_update_metalayer(blosc2_schunk *schunk, const char *name, uint8_t *content, uint32_t content_len) {
   int nmetalayer = blosc2_has_metalayer(schunk, name);
   if (nmetalayer < 0) {
-    fprintf(stderr, "metalayer \"%s\" not found\n", name);
+    BLOSC_TRACE_ERROR("Metalayer \"%s\" not found.", name);
     return nmetalayer;
   }
 
   blosc2_metalayer *metalayer = schunk->metalayers[nmetalayer];
   if (content_len > (uint32_t)metalayer->content_len) {
-    fprintf(stderr, "`content_len` cannot exceed the existing size of %d bytes", metalayer->content_len);
+    BLOSC_TRACE_ERROR("`content_len` cannot exceed the existing size of %d bytes.", metalayer->content_len);
     return nmetalayer;
   }
 
@@ -751,7 +749,7 @@ int blosc2_update_metalayer(blosc2_schunk *schunk, const char *name, uint8_t *co
   if (schunk->frame != NULL) {
     int rc = frame_update_header(schunk->frame, schunk, false);
     if (rc < 0) {
-      fprintf(stderr, "Error: unable to update meta info from frame");
+      BLOSC_TRACE_ERROR("Unable to update meta info from frame.");
       return -1;
     }
   }
@@ -770,7 +768,7 @@ int blosc2_get_metalayer(blosc2_schunk *schunk, const char *name, uint8_t **cont
                          uint32_t *content_len) {
   int nmetalayer = blosc2_has_metalayer(schunk, name);
   if (nmetalayer < 0) {
-    fprintf(stderr, "metalayer \"%s\" not found\n", name);
+    BLOSC_TRACE_ERROR("Metalayer \"%s\" not found.", name);
     return nmetalayer;
   }
   *content_len = (uint32_t)schunk->metalayers[nmetalayer]->content_len;
@@ -784,7 +782,7 @@ int blosc2_get_metalayer(blosc2_schunk *schunk, const char *name, uint8_t **cont
 int blosc2_update_usermeta(blosc2_schunk *schunk, uint8_t *content, int32_t content_len,
                            blosc2_cparams cparams) {
   if ((uint32_t) content_len > (1u << 31u)) {
-    fprintf(stderr, "Error: content_len cannot exceed 2 GB");
+    BLOSC_TRACE_ERROR("content_len cannot exceed 2 GB.");
     return -1;
   }
 

--- a/tests/test_insert_chunk.c
+++ b/tests/test_insert_chunk.c
@@ -31,7 +31,6 @@ static char* test_insert_schunk(void) {
 
   /* Initialize the Blosc compressor */
   blosc_init();
-  BLOSC_TRACE_ERROR("HOLA");
 
   /* Create a super-chunk container */
   cparams.typesize = sizeof(int32_t);

--- a/tests/test_insert_chunk.c
+++ b/tests/test_insert_chunk.c
@@ -31,6 +31,7 @@ static char* test_insert_schunk(void) {
 
   /* Initialize the Blosc compressor */
   blosc_init();
+  BLOSC_TRACE_ERROR("HOLA");
 
   /* Create a super-chunk container */
   cparams.typesize = sizeof(int32_t);


### PR DESCRIPTION
Macro `BLOSC_TRACE_ERROR()` is implemented. It can be used to print messages to stderr when the env variable `BLOSC_TRACE` is defined.
