### PR TITLE
Fixed heap-buffer-overflow error when decoding variable literal length.

### DIFF
--- a/internal-complibs/lizard-1.0/lizard_decompress_liz.h
+++ b/internal-complibs/lizard-1.0/lizard_decompress_liz.h
@@ -62,17 +62,19 @@ FORCE_INLINE int Lizard_decompress_LIZv1(
             if ((length=(token & MAX_SHORT_LITLEN)) == MAX_SHORT_LITLEN) {
                 if (unlikely(ctx->literalsPtr > iend - 1)) { LIZARD_LOG_DECOMPRESS_LIZv1("1"); goto _output_error; } 
                 length = *ctx->literalsPtr;
+                ctx->literalsPtr++;
                 if unlikely(length >= 254) {
                     if (length == 254) {
-                        length = MEM_readLE16(ctx->literalsPtr+1);
+                        if (unlikely(ctx->literalsPtr > iend - 2)) { LIZARD_LOG_DECOMPRESS_LIZv1("1"); goto _output_error; }  /* overflow detection */
+                        length = MEM_readLE16(ctx->literalsPtr);
                         ctx->literalsPtr += 2;
                     } else {
-                        length = MEM_readLE24(ctx->literalsPtr+1);
+                        if (unlikely(ctx->literalsPtr > iend - 3)) { LIZARD_LOG_DECOMPRESS_LIZv1("1"); goto _output_error; }  /* overflow detection */
+                        length = MEM_readLE24(ctx->literalsPtr);
                         ctx->literalsPtr += 3;
                     }
                 }
                 length += MAX_SHORT_LITLEN;
-                ctx->literalsPtr++;
                 if (unlikely((size_t)(op+length)<(size_t)(op))) { LIZARD_LOG_DECOMPRESS_LIZv1("2"); goto _output_error; }  /* overflow detection */
                 if (unlikely((size_t)(ctx->literalsPtr+length)<(size_t)(ctx->literalsPtr))) { LIZARD_LOG_DECOMPRESS_LIZv1("3"); goto _output_error; }   /* overflow detection */
             }


### PR DESCRIPTION
### Heap-buffer-overflow READ 2 · Lizard_decompress_safe

```
    #0 0x760da0 in MEM_read16 c-blosc2/internal-complibs/lizard-1.0/entropy/mem.h:146:14
    #1 0x760da0 in MEM_readLE16 c-blosc2/internal-complibs/lizard-1.0/entropy/mem.h:226:16
    #2 0x760da0 in MEM_readLE24 c-blosc2/internal-complibs/lizard-1.0/entropy/mem.h:246:12
    #3 0x760da0 in Lizard_decompress_LIZv1 c-blosc2/internal-complibs/lizard-1.0/lizard_decompress_liz.h:70:34
    #4 0x760da0 in Lizard_decompress_generic c-blosc2/internal-complibs/lizard-1.0/lizard_decompress.c:241:19
    #5 0x760da0 in Lizard_decompress_safe c-blosc2/internal-complibs/lizard-1.0/lizard_decompress.c:269:12
    #6 0x5bab43 in lizard_wrap_decompress c-blosc2/blosc/blosc2.c:407:12
    #7 0x5bab43 in blosc_d c-blosc2/blosc/blosc2.c:1118:18
    #8 0x5b098c in serial_blosc c-blosc2/blosc/blosc2.c:1219:16
    #9 0x5b098c in do_job c-blosc2/blosc/blosc2.c:1377:15
    #10 0x5b7389 in blosc_run_decompression_with_context c-blosc2/blosc/blosc2.c:2159:13
    #11 0x5b7d4b in blosc2_decompress c-blosc2/blosc/blosc2.c:2227:12
    #12 0x5613c3 in LLVMFuzzerTestOneInput c-blosc2/tests/fuzz/fuzz_decompress_chunk.c:34:5

SUMMARY: AddressSanitizer: heap-buffer-overflow (/mnt/scratch0/clusterfuzz/bot/builds/clusterfuzz-builds_c-blosc2_c26e8220b80bfc0b5ac207ffcb887c5ee8c63325/revisions/decompress_chunk_fuzzer+0x760da0)
```
https://oss-fuzz.com/testcase-detail/5137671143555072