### PR TITLE
Fixed UBSAN null-dereference WRITE in frame_get_usermeta

### DIFF
--- a/blosc/frame.c
+++ b/blosc/frame.c
@@ -944,6 +944,10 @@ int32_t frame_get_usermeta(blosc2_frame* frame, uint8_t** usermeta) {
   int32_t usermeta_len;
   swap_store(&usermeta_len, &usermeta_len_network, sizeof(int32_t));
 
+  if (usermeta_len < 0) {
+    BLOSC_TRACE_ERROR("Invalid usermeta length.");
+    return -1;
+  }
   if (usermeta_len == 0) {
     *usermeta = NULL;
     return 0;


### PR DESCRIPTION
`usermeta_len` is less than zero.
```
    frame_get_usermeta c-blosc2/blosc/frame.c:954:5
    blosc2_frame_to_schunk c-blosc2/blosc/frame.c:1267:18
    blosc2_schunk_open_sframe c-blosc2/blosc/schunk.c:263:27
    LLVMFuzzerTestOneInput c-blosc2/tests/fuzz/fuzz_decompress_frame.c:23:27
```
https://oss-fuzz.com/testcase-detail/5126682469728256
