### PR TITLE
Sanity check for compressed and uncompressed sizes in frame header

### DIFF
--- a/blosc/frame.c
+++ b/blosc/frame.c
@@ -444,6 +444,12 @@ int get_header_info(blosc2_frame *frame, int32_t *header_len, int64_t *frame_len
       }
       *nchunks += 1;
     }
+
+    // Sanity check for compressed sizes
+    if ((*cbytes < 0) || (*nbytes > 0 && *cbytes == 0) || ((int64_t)*nchunks * *chunksize < *nbytes)) {
+      BLOSC_TRACE_ERROR("Invalid compressed size in frame header.");
+      return -1;
+    }
   } else {
     *nchunks = 0;
   }

--- a/blosc/frame.c
+++ b/blosc/frame.c
@@ -439,6 +439,7 @@ int get_header_info(blosc2_frame *frame, int32_t *header_len, int64_t *frame_len
     *nchunks = (int32_t) (*nbytes / *chunksize);
     if (*nbytes % *chunksize > 0) {
       if (*nchunks == INT32_MAX) {
+        BLOSC_TRACE_ERROR("Number of chunks exceeds maximum allowed.");
         return -1;
       }
       *nchunks += 1;


### PR DESCRIPTION
Should inadvertently resolve https://oss-fuzz.com/testcase-detail/5131542452109312.