### PR TITLE
Use VERSION_GREATER to compare cmake versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,7 +74,7 @@ if(NOT WIN32)
 endif()
 
 cmake_minimum_required(VERSION 2.8.10)
-if(${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION} GREATER 3.4)
+if(${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION} VERSION_GREATER 3.4)
   cmake_policy(SET CMP0063 NEW)
 endif()
 project(blosc LANGUAGES C)


### PR DESCRIPTION
Using "GREATER" to compare cmake versions does not work as expected for version > 3.10.

See also: https://cmake.org/cmake/help/latest/variable/CMAKE_VERSION.html