### PR TITLE
Fixed ASAN error when reading blosc version in blosc_getitem.

### DIFF
--- a/blosc/frame.c
+++ b/blosc/frame.c
@@ -410,6 +410,11 @@ int get_header_info(blosc2_frame *frame, int32_t *header_len, int64_t *frame_len
     swap_store(typesize, framep + FRAME_TYPESIZE, sizeof(*typesize));
   }
 
+  if (*header_len > *frame_len) {
+    BLOSC_TRACE_ERROR("Header length exceeds length of the frame.");
+    return -1;
+  }
+
   // Codecs
   uint8_t frame_codecs = framep[FRAME_CODECS];
   if (clevel != NULL) {


### PR DESCRIPTION
It seems we need to check to see if header length exceeds frame length which will stop the error from even happening.
  https://oss-fuzz.com/testcase-detail/6522073996460032