### PR TITLE
Fixed UBSAN divide-by-zero in blosc2_chunk_zeros for typesize.

### DIFF
--- a/blosc/blosc2.c
+++ b/blosc/blosc2.c
@@ -3410,8 +3410,8 @@ int blosc2_chunk_zeros(const size_t nbytes, const size_t typesize, void* dest, s
   uint8_t* dest_ = dest;
   int32_t nbytes_ = (int32_t)nbytes;
 
-  if (typesize > 255) {
-    BLOSC_TRACE_ERROR("typesize cannot be larger than 255 bytes");
+  if (typesize == 0 || typesize > 255) {
+    BLOSC_TRACE_ERROR("typesize cannot be 0 or larger than 255 bytes");
     return -1;
   }
 


### PR DESCRIPTION
https://oss-fuzz.com/testcase-detail/5554582694526976
https://oss-fuzz.com/testcase-detail/6074262517579776

```
Running 1 inputs
Running: c-blosc2/build/tests/fuzz/decompress_frame_fuzzer clusterfuzz-testcase-decompress_frame_fuzzer-5554582694526976
../blosc/blosc2.c:3418:14: runtime error: division by zero
    0x55555586c11a in blosc2_chunk_zeros ../blosc/blosc2.c:3418
    0x555555887cd0 in frame_special_chunk ../blosc/frame.c:1569
    0x555555888831 in frame_get_lazychunk ../blosc/frame.c:1715
    0x55555588ec4e in frame_decompress_chunk ../blosc/frame.c:2504
    0x555555879166 in blosc2_schunk_decompress_chunk ../blosc/schunk.c:615
    0x5555557ecbec in LLVMFuzzerTestOneInput ../tests/fuzz/fuzz_decompress_frame.c:33
    0x5555557ed04b in main ../tests/fuzz/standalone.c:32
    0x7ffff74590b2 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x270b2)
    0x5555557ec92d in _start (/home/nathan/Source/c-blosc2/build/tests/fuzz/decompress_frame_fuzzer+0x29892d)

SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior ../blosc/blosc2.c:3418:14 in 
```