### PR TITLE
Fixed ASAN error due to invalid header length.

### DIFF
--- a/blosc/frame.c
+++ b/blosc/frame.c
@@ -423,8 +423,8 @@ int get_header_info(blosc2_frame *frame, int32_t *header_len, int64_t *frame_len
     swap_store(typesize, framep + FRAME_TYPESIZE, sizeof(*typesize));
   }
 
-  if (*header_len > *frame_len) {
-    BLOSC_TRACE_ERROR("Header length exceeds length of the frame.");
+  if (*header_len <= 0 || *header_len > *frame_len) {
+    BLOSC_TRACE_ERROR("Header length is invalid or exceeds length of the frame.");
     return -1;
   }
 


### PR DESCRIPTION
https://oss-fuzz.com/testcase-detail/6021380745330688
In this instance header length ended up being less than zero.
