### PR TITLE
Fixed UBSAN divide-by-zero error in handle_runlen with typesize.

### DIFF
--- a/blosc/blosc2.c
+++ b/blosc/blosc2.c
@@ -2296,6 +2296,10 @@ int handle_runlen(blosc2_context* context, uint8_t* src, uint32_t nbytes, uint8_
   context->header_overhead = BLOSC_EXTENDED_HEADER_LENGTH;  // a Blosc2 chunk
   int32_t cbytes_chunk = src[BLOSC2_CHUNK_CBYTES];
   int32_t typesize = src[BLOSC2_CHUNK_TYPESIZE];
+  // Some checks for malformed headers
+  if (typesize <= 0 || typesize > BLOSC_MAX_TYPESIZE) {
+    return -1;
+  }
   bool all_zeros = src[BLOSC2_CHUNK_BLOSC2_FLAGS] & (BLOSC2_ZERO_RUNLEN << 4);
   bool all_nans = src[BLOSC2_CHUNK_BLOSC2_FLAGS] & (BLOSC2_NAN_RUNLEN << 4);
   if ((cbytes_chunk != context->header_overhead + typesize) && (cbytes_chunk != context->header_overhead)) {


### PR DESCRIPTION
https://oss-fuzz.com/testcase-detail/6044163185442816