### PR TITLE
Prevent ASAN 64-bit memory allocation in fuzzers.

### DIFF
--- a/tests/fuzz/fuzz_compress_chunk.c
+++ b/tests/fuzz/fuzz_compress_chunk.c
@@ -46,6 +46,12 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
 
   blosc_cbuffer_sizes(output, &nbytes, &cbytes, &blocksize);
 
+  /* Don't allow address sanitizer to allocate more than INT32_MAX */
+  if (cbytes >= INT32_MAX) {
+    free(output);
+    return 0;
+  }
+
   input = malloc(cbytes);
   if (input != NULL) {
     blosc_decompress(output, input, cbytes);

--- a/tests/fuzz/fuzz_decompress_frame.c
+++ b/tests/fuzz/fuzz_decompress_frame.c
@@ -25,7 +25,12 @@ int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
     blosc_destroy();
     return 0;
   }
-
+  /* Don't allow address sanitizer to allocate more than INT32_MAX */
+  if (schunk->nbytes >= INT32_MAX) {
+    blosc2_schunk_free(schunk);
+    blosc_destroy();
+    return 0;
+  }
   /* Decompress data */
   uint8_t *uncompressed_data = (uint8_t *)malloc((size_t)schunk->nbytes+1);
   if (uncompressed_data != NULL) {


### PR DESCRIPTION
https://oss-fuzz.com/testcase-detail/5005175230169088
Also see https://github.com/google/sanitizers/issues/802.