### PR TITLE
Fixed UBSAN integer overflow when multiplying blocksize by 2.

### DIFF
--- a/blosc/blosc2.c
+++ b/blosc/blosc2.c
@@ -1333,7 +1333,7 @@ static void init_thread_context(struct thread_context* thread_context, blosc2_co
   thread_context->tmp = my_malloc(thread_context->tmp_nbytes);
   thread_context->tmp2 = thread_context->tmp + context->blocksize;
   thread_context->tmp3 = thread_context->tmp + context->blocksize + ebsize;
-  thread_context->tmp4 = thread_context->tmp + 2 * context->blocksize + ebsize;
+  thread_context->tmp4 = thread_context->tmp + (size_t)2 * context->blocksize + ebsize;
   thread_context->tmp_blocksize = context->blocksize;
   #if defined(HAVE_ZSTD)
   thread_context->zstd_cctx = NULL;


### PR DESCRIPTION
https://oss-fuzz.com/testcase-detail/6248150975250432

```
Running 1 inputs
Running: c-blosc2/build/tests/fuzz/decompress_frame_fuzzer clusterfuzz-testcase-decompress_frame_fuzzer-6248150975250432
../blosc/blosc2.c:1336:50: runtime error: signed integer overflow: 1355677696 * 2 cannot be represented in type 'int'
    0x55555585ae96 in init_thread_context ../blosc/blosc2.c:1336
    0x55555585b0a8 in create_thread_context ../blosc/blosc2.c:1365
    0x555555865931 in blosc_getitem ../blosc/blosc2.c:2642
    0x555555887cc2 in get_coffset ../blosc/frame.c:1558
    0x55555588894e in frame_get_lazychunk ../blosc/frame.c:1718
    0x55555588edbd in frame_decompress_chunk ../blosc/frame.c:2512
    0x555555879205 in blosc2_schunk_decompress_chunk ../blosc/schunk.c:615
    0x5555557ecc5d in LLVMFuzzerTestOneInput ../tests/fuzz/fuzz_decompress_frame.c:38
    0x5555557ed0bc in main ../tests/fuzz/standalone.c:32
    0x7ffff74590b2 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x270b2)
    0x5555557ec92d in _start (c-blosc2/build/tests/fuzz/decompress_frame_fuzzer+0x29892d)

SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior ../blosc/blosc2.c:1336:50 in 
Decompression error.  Error code: -10
```
This cast is also applied on line 1332.