### PR TITLE
Fixed frame metalayer loading memory leaks

### DIFF
--- a/blosc/blosc2.h
+++ b/blosc/blosc2.h
@@ -1071,6 +1071,7 @@ typedef struct blosc2_schunk {
   //!< Pointer to storage info.
   blosc2_frame* frame;
   //!< Pointer to frame used as store for chunks.
+  bool avoid_frame_free;   //!< Whether the frame can be freed (false) or not (true).
   //!<uint8_t* ctx;
   //!< Context for the thread holder. NULL if not acquired.
   blosc2_context* cctx;

--- a/blosc/frame.c
+++ b/blosc/frame.c
@@ -282,6 +282,9 @@ void *new_header_frame(blosc2_schunk *schunk, blosc2_frame *frame) {
 
   // Now, deal with metalayers
   int16_t nmetalayers = schunk->nmetalayers;
+  if (nmetalayers < 0 || nmetalayers > BLOSC2_MAX_METALAYERS) {
+    return NULL;
+  }
 
   // Make space for the header of metalayers (array marker, size, map of offsets)
   h2 = realloc(h2, (size_t)hsize + 1 + 1 + 2 + 1 + 2);
@@ -1220,6 +1223,12 @@ int frame_get_metalayers(blosc2_frame* frame, blosc2_schunk* schunk) {
   }
   swap_store(&nmetalayers, idxp, sizeof(uint16_t));
   idxp += 2;
+  if (nmetalayers < 0 || nmetalayers > BLOSC2_MAX_METALAYERS) {
+    if (frame->sdata == NULL) {
+      free(header);
+    }
+    return -1;
+  }
   schunk->nmetalayers = nmetalayers;
 
   // Populate the metalayers and its serialized values

--- a/blosc/frame.c
+++ b/blosc/frame.c
@@ -1420,6 +1420,7 @@ blosc2_schunk* blosc2_frame_to_schunk(blosc2_frame* frame, bool copy) {
       // If not the chunks won't be in the frame
       fp = fopen(frame->urlpath, "rb");
       if (fp == NULL) {
+        free(data_chunk);
         free(offsets);
         blosc2_schunk_free(schunk);
         return NULL;


### PR DESCRIPTION
https://oss-fuzz.com/testcase-detail/4783158937649152

There are a few commits, you might want to review them one by one. 

https://github.com/Blosc/c-blosc2/pull/204/commits/888435d0697ff7516ea5cb6f48c7648a1b3df848 changes it so that all `schunk` is freed through `blosc2_schunk_free`, this helps on failure, so that the entire object is freed properly. I have also added a `avoid_frame_free` to `schunk` similar to how `frame` has `avoid_sdata_free` which helps to know when `schunk` should free `frame` or not.

https://github.com/Blosc/c-blosc2/pull/204/commits/c0a8138ff991ba192612c154f4e61e520cabbe2a is improved in that it checks against the `header_len` and not the `frame_len` which prevents invalid data earlier when `header_len` is too small.