### PR TITLE
Fixed ASAN heap-buffer-overflow when reading frame index chunk.

### DIFF
--- a/blosc/blosc2.c
+++ b/blosc/blosc2.c
@@ -2673,6 +2673,11 @@ int blosc2_getitem_ctx(blosc2_context* context, const void* src, int32_t srcsize
   uint8_t* _src = (uint8_t*)(src);
   int result;
 
+  if (srcsize < BLOSC_MIN_HEADER_LENGTH) {
+    /* Not enough input to parse Blosc1 header */
+    return -1;
+  }
+
   /* Minimally populate the context */
   context->typesize = _src[BLOSC2_CHUNK_TYPESIZE];
   context->blocksize = sw32_(_src + BLOSC2_CHUNK_BLOCKSIZE);

--- a/blosc/frame.c
+++ b/blosc/frame.c
@@ -914,17 +914,15 @@ uint8_t* get_coffsets(blosc2_frame *frame, int32_t header_len, int64_t cbytes, i
     return frame->coffsets;
   }
   if (frame->sdata != NULL) {
-    if (header_len + cbytes > frame->len) {
+    int32_t off_pos = header_len + cbytes;
+    // Check that there is enough room to read Blosc header
+    if (off_pos + BLOSC_EXTENDED_HEADER_LENGTH > frame->len) {
       BLOSC_TRACE_ERROR("Cannot read the offsets past frame boundary.");
       return NULL;
     }
     // For in-memory frames, the coffset is just one pointer away
-    uint8_t* off_start = frame->sdata + header_len + cbytes;
+    uint8_t* off_start = frame->sdata + off_pos;
     if (off_cbytes != NULL) {
-      if (header_len + cbytes + BLOSC2_CHUNK_CBYTES + (signed)sizeof(int32_t) > frame->len) {
-        BLOSC_TRACE_ERROR("Cannot read the offsets compressed size past frame boundary.");
-        return NULL;
-      }
       *off_cbytes = *(int32_t*) (off_start + BLOSC2_CHUNK_CBYTES);
     }
     return off_start;


### PR DESCRIPTION
https://oss-fuzz.com/testcase-detail/5963546544439296

@FrancescAlted the `get_coffsets` function is confusing to me. I'm not sure what part it is reading from the frame. I _assume_ that it is reading from the `chunks` section mention in the [FRAME format documentation](https://github.com/Blosc/c-blosc2/blob/master/README_FRAME_FORMAT.rst). And that in the `chunks` section it is trying to read the Blosc chunk called `chunk idx`. Please correct me if I am wrong. The variable names in the section are kind of opaque.

I am assuming:
- `header_len` = frame header length.
- `cbytes` = compressed data size? What exactly is this referring to and why would we seek to this? Does this not include the size of the `chunk idx`?
- I know it is reading into a Blosc chunk because I see it is reading a 32-bit integer at `BLOSC2_CHUNK_CBYTES` offset.

Thanks!