### PR TITLE
Lazychunk2

### DIFF
--- a/README_CHUNK_FORMAT.rst
+++ b/README_CHUNK_FORMAT.rst
@@ -1,15 +1,25 @@
 Blosc Chunk Format
 ==================
 
-The chunk is composed of a header and a blocks section::
+A regular chunk is composed of a header and a blocks section::
 
-    +---------+--------+---------+
-    |  header | blocks | trailer |
-    +---------+--------+---------+
+    +---------+--------+
+    |  header | blocks |
+    +---------+--------+
 
-These three sections are described below.
+Also, there are the so-called lazy chunks that do not have the actual compressed data,
+but only metainformation about how to read it. Lazy chunks typically appear when reading
+data from persistent media.  A lazy chunk has the header and bstarts sections in place
+and in addition, they have an additional trailer for allowing to read the data blocks::
 
-*Note:* All integer types are stored in little endian.
+    +---------+---------+---------+
+    |  header | bstarts | trailer |
+    +---------+---------+---------+
+
+All these sections are described below.  Note that the bstarts section is described as
+part of the blocks section.
+
+*Note:* All integer types in this document are stored in little endian.
 
 
 Header
@@ -131,10 +141,7 @@ for encoding blocks with a filter pipeline::
         Whether the codec is stored in a byte previous to this compressed buffer
         or it is in the global `flags` for chunk.
     :bit 3 (``0x08``):
-        Whether the chunk is 'lazy' or not.  A lazy chunk has the header and bstarts
-        in place, but not the actual block data.  In addition, they have an additional
-        trailer for making it easy to read the data blocks.  In general, lazy chunks
-        appear when reading data from disk.
+        Whether the chunk is 'lazy' or not.
     :bits 4 and 5:
         Indicate run-lengths for the entire chunk.
 
@@ -255,4 +262,4 @@ Here it is its structure::
     (``int64_t``) The offset of the chunk in the frame (sequential super-chunk).
 
 :bsize0 .. bsizeN:
-    (``int32_t``) The sizes in bytes for every stream.
+    (``int32_t``) The sizes in bytes for every block.

--- a/README_CHUNK_FORMAT.rst
+++ b/README_CHUNK_FORMAT.rst
@@ -255,4 +255,4 @@ Here it is its structure::
     (``int64_t``) The offset of the chunk in the frame (sequential super-chunk).
 
 :bsize0 .. bsizeN:
-    (``int32_t``) The sizes in bytes for every block.
+    (``int32_t``) The sizes in bytes for every stream.

--- a/blosc/blosc2.c
+++ b/blosc/blosc2.c
@@ -993,6 +993,9 @@ static int blosc_d(
   uint8_t *tmp3 = thread_context->tmp4;
   int32_t compformat = (context->header_flags & (uint8_t)0xe0) >> 5u;
   int dont_split = (context->header_flags & (uint8_t)0x10) >> 4u;
+  int memcpyed = context->header_flags & (uint8_t)BLOSC_MEMCPYED;
+  int32_t chunk_nbytes = *(int32_t*)(src + BLOSC2_CHUNK_NBYTES);
+  int32_t chunk_cbytes = *(int32_t*)(src + BLOSC2_CHUNK_CBYTES);
   //uint8_t blosc_version_format = src[BLOSC2_CHUNK_VERSION];
   int nstreams;
   int32_t neblock;
@@ -1052,26 +1055,27 @@ static int blosc_d(
       fp = fopen(chunkpath, "rb");
       free(chunkpath);
       // The offset of the block is src_offset
-      fseek(fp, 0 + src_offset, SEEK_SET);
+      fseek(fp, src_offset, SEEK_SET);
     }
     else {
       fp = fopen(urlpath, "rb");
       // The offset of the block is src_offset
       fseek(fp, chunk_offset + src_offset, SEEK_SET);
     }
-    size_t rbytes = fread((void*)(src + src_offset), 1, block_csize, fp);
+    // We can make use of tmp3 because it will be used after src is not needed anymore
+    size_t rbytes = fread(tmp3, 1, block_csize, fp);
     fclose(fp);
     if ((int32_t)rbytes != block_csize) {
       BLOSC_TRACE_ERROR("Cannot read the (lazy) block out of the fileframe.");
       return -13;
     }
+    src = tmp3;
+    src_offset = 0;
+    srcsize = block_csize;
   }
 
   // If the chunk is memcpyed, we just have to copy the block to dest and return
-  int memcpyed = src[BLOSC2_CHUNK_FLAGS] & (uint8_t)BLOSC_MEMCPYED;
   if (memcpyed) {
-    int32_t chunk_nbytes = *(int32_t*)(src + BLOSC2_CHUNK_NBYTES);
-    int32_t chunk_cbytes = *(int32_t*)(src + BLOSC2_CHUNK_CBYTES);
     if (chunk_nbytes + context->header_overhead != chunk_cbytes) {
       return -1;
     }
@@ -1080,11 +1084,14 @@ static int blosc_d(
       /* Not enough input to copy block */
       return -1;
     }
-    memcpy(dest + dest_offset, src + context->header_overhead + nblock * context->blocksize, bsize_);
+    if (!is_lazy) {
+      src += context->header_overhead + nblock * context->blocksize;
+    }
+    memcpy(dest + dest_offset, src, bsize_);
     return bsize_;
   }
 
-  if (src_offset <= 0 || src_offset >= srcsize) {
+  if (!is_lazy && (src_offset <= 0 || src_offset >= srcsize)) {
     /* Invalid block src offset encountered */
     return -1;
   }
@@ -2593,7 +2600,7 @@ int _blosc_getitem(blosc2_context* context, const void* src, int32_t srcsize,
       scontext->tmp = my_malloc(scontext->tmp_nbytes);
       scontext->tmp2 = scontext->tmp + blocksize;
       scontext->tmp3 = scontext->tmp + blocksize + ebsize;
-      scontext->tmp4 = scontext->tmp + 2 * blocksize + ebsize;
+      scontext->tmp4 = scontext->tmp + (size_t)2 * blocksize + ebsize;
       scontext->tmp_blocksize = (int32_t)blocksize;
     }
 
@@ -2734,7 +2741,7 @@ static void t_blosc_do_job(void *ctxt)
     thcontext->tmp = my_malloc(thcontext->tmp_nbytes);
     thcontext->tmp2 = thcontext->tmp + blocksize;
     thcontext->tmp3 = thcontext->tmp + blocksize + ebsize;
-    thcontext->tmp4 = thcontext->tmp + 2 * blocksize + ebsize;
+    thcontext->tmp4 = thcontext->tmp + (size_t)2 * blocksize + ebsize;
     thcontext->tmp_blocksize = blocksize;
   }
 


### PR DESCRIPTION
This PR removes the need for allocating the compressed data blocks in lazy chunks, making the process of reading from persistent storage less memory demanding.