### PR TITLE
Rename Extended-Frame to Disperse-Frame

### DIFF
--- a/README_DFRAME_FORMAT.rst
+++ b/README_DFRAME_FORMAT.rst
@@ -1,8 +1,8 @@
-Blosc2 Disperse-Frame Format
-============================
+Blosc2 Dispersed-Frame Format
+=============================
 
-Blosc (as of version 2.0.0) has an disperse-frame format that allows for the storage of different Blosc data chunks
-disperse, on-disk.
+Blosc (as of version 2.0.0) has a dispersed-frame format that allows for the storage of different Blosc data chunks
+dispersed, on-disk.
 
 When creating a dframe one must denote the `storage.sequential` as false and provide a name (which will be a directory)
 in `storage.urlpath` for the dframe to be stored. It is recommended to name the directory with the `.b2dframe`

--- a/README_DFRAME_FORMAT.rst
+++ b/README_DFRAME_FORMAT.rst
@@ -33,7 +33,7 @@ Examples
 
 Structure example
 ^^^^^^^^^^^^^^^^^
-As shown below, an dframe of 4 chunks will be composed of a directory with each chunk file and the frame file::
+As shown below, a dframe of 4 chunks will be composed of a directory with each chunk file and the frame file::
 
  dir.b2dframe/
  │

--- a/README_DFRAME_FORMAT.rst
+++ b/README_DFRAME_FORMAT.rst
@@ -1,14 +1,14 @@
-Blosc2 Extended-Frame Format
+Blosc2 Disperse-Frame Format
 ============================
 
-Blosc (as of version 2.0.0) has an extended-frame format that allows for the storage of different Blosc data chunks
-sparse, on-disk.
+Blosc (as of version 2.0.0) has an disperse-frame format that allows for the storage of different Blosc data chunks
+disperse, on-disk.
 
-When creating an eframe one must denote the `storage.sequential` as false and provide a name (which will be a directory)
-in `storage.urlpath` for the eframe to be stored. It is recommended to name the directory with the `.b2eframe`
+When creating a dframe one must denote the `storage.sequential` as false and provide a name (which will be a directory)
+in `storage.urlpath` for the dframe to be stored. It is recommended to name the directory with the `.b2dframe`
 extension.
 
-An eframe is made up of a frame file and the chunks stored in the same directory on-disk.
+A dframe is made up of a frame file and the chunks stored in the same directory on-disk.
 The frame follows the format described in the `frame format <README_FRAME_FORMAT.rst>`_ document, with the difference
 that the frame's chunks section is made up only of the index chunk which will have the indexes to each chunk. The frame
 file name is always `chunks.b2frame`.
@@ -33,9 +33,9 @@ Examples
 
 Structure example
 ^^^^^^^^^^^^^^^^^
-As shown below, an eframe of 4 chunks will be composed of a directory with each chunk file and the frame file::
+As shown below, an dframe of 4 chunks will be composed of a directory with each chunk file and the frame file::
 
- dir.b2eframe/
+ dir.b2dframe/
  │
  ├── 00000000.chunk
  │
@@ -58,7 +58,7 @@ after an insertion in the 2nd position::
 
  Before                                 After
 
- dir.b2eframe/                          dir.b2eframe/
+ dir.b2dframe/                          dir.b2dframe/
  │                                      │
  ├── 00000000.chunk                     ├── 00000000.chunk
  │                                      │

--- a/blosc/CMakeLists.txt
+++ b/blosc/CMakeLists.txt
@@ -61,7 +61,7 @@ include_directories(${BLOSC_INCLUDE_DIRS})
 # library sources
 set(SOURCES blosc2.c blosc2-common.h blosclz.c fastcopy.c fastcopy.h schunk.c frame.c btune.c btune.h
         context.h delta.c delta.h shuffle-generic.c bitshuffle-generic.c trunc-prec.c trunc-prec.h
-        timestamp.c eframe.c directories.c)
+        timestamp.c dframe.c directories.c)
 if(NOT CMAKE_SYSTEM_PROCESSOR STREQUAL arm64)
     if(COMPILER_SUPPORT_SSE2)
         message(STATUS "Adding run-time support for SSE2")

--- a/blosc/blosc2.c
+++ b/blosc/blosc2.c
@@ -1043,7 +1043,7 @@ static int blosc_d(
     int32_t block_csize = block_csizes[nblock];
     // Read the lazy block on disk
     FILE* fp = NULL;
-    if (context->schunk->frame->eframe) {
+    if (context->schunk->frame->dframe) {
       // The chunk is not in the frame
       char* chunkpath = malloc(strlen(context->schunk->frame->urlpath) + 1 + 8 + strlen(".chunk") + 1);
       sprintf(chunkpath, "%s/%08X.chunk", context->schunk->frame->urlpath, nchunk);

--- a/blosc/blosc2.h
+++ b/blosc/blosc2.h
@@ -996,7 +996,7 @@ BLOSC_EXPORT int blosc2_getitem_ctx(blosc2_context* context, const void* src,
  */
 typedef struct {
     bool sequential;
-    //!< Whether the chunks are sequential (frame) or sparse.
+    //!< Whether the chunks are sequential (frame) or dispersed.
     char* urlpath;
     //!< The path for persistent storage. If NULL, that means in-memory.
     blosc2_cparams* cparams;
@@ -1020,7 +1020,7 @@ typedef struct {
   int64_t len;             //!< The current length of the frame in (compressed) bytes
   int64_t maxlen;          //!< The maximum length of the frame; if 0, there is no maximum
   uint32_t trailer_len;    //!< The current length of the trailer in (compressed) bytes
-  bool dframe;             //!< Whether the frame is disperse, on-disk
+  bool dframe;             //!< Whether the frame is dispersed, on-disk
 } blosc2_frame;
 
 /**

--- a/blosc/blosc2.h
+++ b/blosc/blosc2.h
@@ -1013,14 +1013,14 @@ typedef struct {
 static const blosc2_storage BLOSC2_STORAGE_DEFAULTS = {false, NULL, NULL, NULL};
 
 typedef struct {
-  char* urlpath;           //!< The name of the file or directory if it's an eframe; if NULL, this is in-memory
+  char* urlpath;           //!< The name of the file or directory if it's a dframe; if NULL, this is in-memory
   uint8_t* sdata;          //!< The in-memory serialized data
   bool avoid_sdata_free;   //!< Whether the sdata can be freed (false) or not (true).
   uint8_t* coffsets;       //!< Pointers to the (compressed, on-disk) chunk offsets
   int64_t len;             //!< The current length of the frame in (compressed) bytes
   int64_t maxlen;          //!< The maximum length of the frame; if 0, there is no maximum
   uint32_t trailer_len;    //!< The current length of the trailer in (compressed) bytes
-  bool eframe;             //!< Whether the frame is extended (sparse, on-disk)
+  bool dframe;             //!< Whether the frame is disperse, on-disk
 } blosc2_frame;
 
 /**

--- a/blosc/dframe.c
+++ b/blosc/dframe.c
@@ -12,7 +12,7 @@
 #include <string.h>
 #include "blosc2.h"
 #include "frame.h"
-#include "eframe.h"
+#include "dframe.h"
 
 
 #if defined(_WIN32) && !defined(__MINGW32__)
@@ -37,7 +37,7 @@
 
 
 /* Append an existing chunk into an extended frame. */
-void* eframe_create_chunk(blosc2_frame* frame, uint8_t* chunk, int32_t nchunk, int64_t cbytes) {
+void* dframe_create_chunk(blosc2_frame* frame, uint8_t* chunk, int32_t nchunk, int64_t cbytes) {
   // Get directory/nchunk.chunk with 8 zeros of padding
   char* chunkpath = malloc(strlen(frame->urlpath) + 1 + 8 + strlen(".chunk") + 1);
   sprintf(chunkpath, "%s/%08X.chunk", frame->urlpath, nchunk);
@@ -56,7 +56,7 @@ void* eframe_create_chunk(blosc2_frame* frame, uint8_t* chunk, int32_t nchunk, i
 
 
 /*Get chunk from extended frame. */
-int eframe_get_chunk(blosc2_frame* frame, int32_t nchunk, uint8_t** chunk, bool* needs_free){
+int dframe_get_chunk(blosc2_frame* frame, int32_t nchunk, uint8_t** chunk, bool* needs_free){
   //get directory/nchunk.chunk
   char* chunkpath = malloc(strlen(frame->urlpath) + 1 + 8 + strlen(".chunk") + 1);
   sprintf(chunkpath, "%s/%08X.chunk", frame->urlpath, nchunk);

--- a/blosc/dframe.c
+++ b/blosc/dframe.c
@@ -55,7 +55,7 @@ void* dframe_create_chunk(blosc2_frame* frame, uint8_t* chunk, int32_t nchunk, i
 }
 
 
-/*Get chunk from disperse frame. */
+/*Get chunk from dispersed frame. */
 int dframe_get_chunk(blosc2_frame* frame, int32_t nchunk, uint8_t** chunk, bool* needs_free){
   //get directory/nchunk.chunk
   char* chunkpath = malloc(strlen(frame->urlpath) + 1 + 8 + strlen(".chunk") + 1);

--- a/blosc/dframe.c
+++ b/blosc/dframe.c
@@ -36,7 +36,7 @@
 #endif
 
 
-/* Append an existing chunk into an extended frame. */
+/* Append an existing chunk into a dispersed frame. */
 void* dframe_create_chunk(blosc2_frame* frame, uint8_t* chunk, int32_t nchunk, int64_t cbytes) {
   // Get directory/nchunk.chunk with 8 zeros of padding
   char* chunkpath = malloc(strlen(frame->urlpath) + 1 + 8 + strlen(".chunk") + 1);
@@ -55,7 +55,7 @@ void* dframe_create_chunk(blosc2_frame* frame, uint8_t* chunk, int32_t nchunk, i
 }
 
 
-/*Get chunk from extended frame. */
+/*Get chunk from disperse frame. */
 int dframe_get_chunk(blosc2_frame* frame, int32_t nchunk, uint8_t** chunk, bool* needs_free){
   //get directory/nchunk.chunk
   char* chunkpath = malloc(strlen(frame->urlpath) + 1 + 8 + strlen(".chunk") + 1);

--- a/blosc/dframe.h
+++ b/blosc/dframe.h
@@ -6,11 +6,11 @@
   See LICENSE.txt for details about copyright and rights to use.
 **********************************************************************/
 
-#ifndef BLOSC_EFRAME_H
-#define BLOSC_EFRAME_H
+#ifndef BLOSC_DFRAME_H
+#define BLOSC_DFRAME_H
 
 
-void* eframe_create_chunk(blosc2_frame* frame, uint8_t* chunk, int32_t nchunk, int64_t cbytes);
-int eframe_get_chunk(blosc2_frame* frame, int32_t nchunk, uint8_t** chunk, bool* needs_free);
+void* dframe_create_chunk(blosc2_frame* frame, uint8_t* chunk, int32_t nchunk, int64_t cbytes);
+int dframe_get_chunk(blosc2_frame* frame, int32_t nchunk, uint8_t** chunk, bool* needs_free);
 
-#endif //BLOSC_EFRAME_H
+#endif //BLOSC_DFRAME_H

--- a/blosc/schunk.c
+++ b/blosc/schunk.c
@@ -165,7 +165,7 @@ blosc2_schunk* blosc2_schunk_new(const blosc2_storage storage) {
     // We want a frame as storage
     blosc2_frame* frame = blosc2_frame_new(urlpath);
     free(urlpath);
-    frame->eframe = true;
+    frame->dframe = true;
     // Initialize frame (basically, encode the header)
     int64_t frame_len = blosc2_frame_from_schunk(schunk, frame);
     if (frame_len < 0) {
@@ -177,7 +177,7 @@ blosc2_schunk* blosc2_schunk_new(const blosc2_storage storage) {
   if (storage.sequential){
     // We want a frame as storage
     blosc2_frame* frame = blosc2_frame_new(storage.urlpath);
-    frame->eframe = false;
+    frame->dframe = false;
     // Initialize frame (basically, encode the header)
     int64_t frame_len = blosc2_frame_from_schunk(schunk, frame);
     if (frame_len < 0) {
@@ -523,14 +523,14 @@ int blosc2_schunk_update_chunk(blosc2_schunk *schunk, int nchunk, uint8_t *chunk
       case BLOSC2_ZERO_RUNLEN:
         schunk->nbytes += nbytes;
         schunk->nbytes -= nbytes_old;
-        if (schunk->frame->eframe) {
+        if (schunk->frame->dframe) {
           schunk->cbytes -= cbytes_old;
         }
         break;
       case BLOSC2_NAN_RUNLEN:
         schunk->nbytes += nbytes;
         schunk->nbytes -= nbytes_old;
-        if (schunk->frame->eframe) {
+        if (schunk->frame->dframe) {
           schunk->cbytes -= cbytes_old;
         }
         break;
@@ -539,7 +539,7 @@ int blosc2_schunk_update_chunk(blosc2_schunk *schunk, int nchunk, uint8_t *chunk
         schunk->nbytes += nbytes;
         schunk->nbytes -= nbytes_old;
         schunk->cbytes += cbytes;
-        if (schunk->frame->eframe) {
+        if (schunk->frame->dframe) {
           schunk->cbytes -= cbytes_old;
         }
     }

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,7 +1,7 @@
 # sources for examples
 set(SOURCES contexts delta_schunk_ex multithread simple frame_metalayers noinit find_roots)
 if(NOT DEACTIVATE_LZ4)
-    set(SOURCES ${SOURCES} schunk_simple frame_simple eframe_simple frame_backed_schunk compress_file)
+    set(SOURCES ${SOURCES} schunk_simple frame_simple dframe_simple frame_backed_schunk compress_file)
 endif()
 if(NOT DEACTIVATE_ZSTD)
     set(SOURCES ${SOURCES} zstd_dict)

--- a/examples/dframe_simple.c
+++ b/examples/dframe_simple.c
@@ -7,11 +7,11 @@
 
  To compile this program:
 
- $ gcc eframe_simple.c -o eframe_simple -lblosc2
+ $ gcc dframe_simple.c -o dframe_simple -lblosc2
 
  To run:
 
- $ ./eframe_simple
+ $ ./dframe_simple
 */
 
 #include <stdio.h>
@@ -45,7 +45,7 @@ int main(void) {
   cparams.clevel = 9;
   cparams.nthreads = NTHREADS;
   dparams.nthreads = NTHREADS;
-  blosc2_storage storage = {false, "dir1.b2eframe", .cparams=&cparams, .dparams=&dparams};
+  blosc2_storage storage = {false, "dir1.b2dframe", .cparams=&cparams, .dparams=&dparams};
   schunk = blosc2_schunk_new(storage);
 
   blosc_set_timestamp(&last);

--- a/tests/test_dframe.c
+++ b/tests/test_dframe.c
@@ -28,7 +28,7 @@ char* directory;
 char buf[256];
 
 
-static char* test_eframe(void) {
+static char* test_dframe(void) {
   size_t isize = CHUNKSIZE * sizeof(int32_t);
   int32_t* data = malloc(isize);
   int32_t* data_dest = malloc(isize);
@@ -207,7 +207,7 @@ static char* test_eframe(void) {
 }
 
 
-static char* test_eframe_simple(void) {
+static char* test_dframe_simple(void) {
   static int32_t data[CHUNKSIZE];
   static int32_t data_dest[CHUNKSIZE];
   size_t isize = CHUNKSIZE * sizeof(int32_t);
@@ -235,7 +235,7 @@ static char* test_eframe_simple(void) {
       data[i] = i + nchunk;
     }
     int _nchunks = blosc2_schunk_append_buffer(schunk, data, isize);
-    mu_assert("ERROR: bad append in eframe", _nchunks > 0);
+    mu_assert("ERROR: bad append in dframe", _nchunks > 0);
   }
 
   /* Retrieve and decompress the chunks (0-based count) */
@@ -264,27 +264,27 @@ static char* test_eframe_simple(void) {
 
 
 static char *all_tests(void) {
-  directory = "dir1.b2eframe";
+  directory = "dir1.b2dframe";
 
   nchunks = 0;
-  mu_run_test(test_eframe_simple);
+  mu_run_test(test_dframe_simple);
 
   nchunks = 1;
-  mu_run_test(test_eframe_simple);
+  mu_run_test(test_dframe_simple);
 
   nchunks = 2;
-  mu_run_test(test_eframe_simple);
+  mu_run_test(test_dframe_simple);
 
   nchunks = 10;
-  mu_run_test(test_eframe_simple);
+  mu_run_test(test_dframe_simple);
 
   // Check directory with a trailing slash
-  directory = "dir1.b2eframe/";
+  directory = "dir1.b2dframe/";
   nchunks = 0;
-  mu_run_test(test_eframe_simple);
+  mu_run_test(test_dframe_simple);
 
   nchunks = 1;
-  mu_run_test(test_eframe_simple);
+  mu_run_test(test_dframe_simple);
 
   // Iterate over all different parameters
   for (int i = 0; i < (int)sizeof(nchunks_) / (int)sizeof(int); i++) {
@@ -301,12 +301,12 @@ static char *all_tests(void) {
                 filter_pipeline = (bool) ifilter_pipeline;
                 metalayers = (bool) imetalayers;
                 usermeta = (bool) iusermeta;
-                snprintf(buf, sizeof(buf), "test_eframe_nc%d.b2eframe", nchunks);
+                snprintf(buf, sizeof(buf), "test_dframe_nc%d.b2dframe", nchunks);
                 directory = buf;
-                mu_run_test(test_eframe);
-                snprintf(buf, sizeof(buf), "test_eframe_nc%d.b2eframe/", nchunks);
+                mu_run_test(test_dframe);
+                snprintf(buf, sizeof(buf), "test_dframe_nc%d.b2dframe/", nchunks);
                 directory = buf;
-                mu_run_test(test_eframe);
+                mu_run_test(test_dframe);
               }
             }
           }

--- a/tests/test_dframe_lazychunk.c
+++ b/tests/test_dframe_lazychunk.c
@@ -107,7 +107,7 @@ static char* test_lazy_chunk(void) {
 }
 
 static char *all_tests(void) {
-  directory = "dir1.b2eframe/";
+  directory = "dir1.b2dframe/";
   nchunks = 0;
   clevel = 5;
   nthreads = 1;
@@ -143,7 +143,7 @@ static char *all_tests(void) {
   nthreads = 2;
   mu_run_test(test_lazy_chunk);
 
-  directory = "dir1.b2eframe";
+  directory = "dir1.b2dframe";
   nchunks = 0;
   clevel = 5;
   nthreads = 1;

--- a/tests/test_insert_chunk.c
+++ b/tests/test_insert_chunk.c
@@ -51,7 +51,7 @@ test_storage tstorage[] = {
     {false, NULL},  // memory - schunk
     {true, NULL},  // memory - frame
     {true, "test_insert_chunk.b2frame"}, // disk - frame
-    {false, "test_insert_chunk.b2eframe"}, // disk - eframe
+    {false, "test_insert_chunk.b2dframe"}, // disk - dframe
 };
 
 bool tcopy[] = {

--- a/tests/test_reorder_offsets.c
+++ b/tests/test_reorder_offsets.c
@@ -36,7 +36,7 @@ test_storage tstorage[] = {
     // {false, NULL},  // memory - schunk
     // {true, NULL},  // memory - frame
     // {true, "test_reorder_offsets.b2frame"}, // disk - frame
-    {false, "test_reorder_offsets.b2eframe"}, // disk - eframe
+    {false, "test_reorder_offsets.b2dframe"}, // disk - dframe
 };
 
 int32_t tnchunks[] = {5, 12, 24, 33, 1};

--- a/tests/test_update_chunk.c
+++ b/tests/test_update_chunk.c
@@ -48,7 +48,7 @@ test_storage tstorage[] = {
     {false, NULL},  // memory - schunk
     {true, NULL},  // memory - frame
     {true, "test_update_chunk.b2frame"}, // disk - frame
-    {false, "test_update_chunk.b2eframe"}, // disk - eframe
+    {false, "test_update_chunk.b2dframe"}, // disk - dframe
 };
 
 static char* test_update_chunk(void) {


### PR DESCRIPTION
Change name of Extended-Frame to Disperse-Frame in order to be more explicit.