### PR TITLE
Fixed ASAN unknown-read when reading stream 

### DIFF
--- a/blosc/blosc2.c
+++ b/blosc/blosc2.c
@@ -1160,9 +1160,9 @@ static int blosc_d(
         }
         uint8_t value = -cbytes;
         memset(_dest, value, (unsigned int) neblock);
-        nbytes = neblock;
-        cbytes = 0;  // everything is encoded in the cbytes token
       }
+      nbytes = neblock;
+      cbytes = 0;  // everything is encoded in the cbytes token
     }
     else if (cbytes == neblock) {
       memcpy(_dest, src, (unsigned int)neblock);


### PR DESCRIPTION
https://oss-fuzz.com/testcase-detail/4727058852872192

At the bottom of the loop `src += cbytes`. If `cbytes` is not set to 0 then it will seek backwards. Same for `nbytes`.