### PR TITLE
Fixed ASAN direct-leak of frame in blosc2_frame_to_schunk.

### DIFF
--- a/blosc/frame.c
+++ b/blosc/frame.c
@@ -1307,7 +1307,7 @@ blosc2_schunk* blosc2_frame_to_schunk(blosc2_frame* frame, bool copy) {
 
   blosc2_schunk* schunk = calloc(1, sizeof(blosc2_schunk));
   schunk->frame = frame;
-  schunk->avoid_frame_free = !copy;
+  schunk->avoid_frame_free = copy;
   int ret = get_header_info(frame, &header_len, &frame_len, &schunk->nbytes, &schunk->cbytes,
                             &schunk->chunksize, &schunk->nchunks, &schunk->typesize,
                             &schunk->compcode, &schunk->clevel, schunk->filters, schunk->filters_meta);

--- a/blosc/schunk.c
+++ b/blosc/schunk.c
@@ -293,10 +293,8 @@ blosc2_schunk* blosc2_schunk_open_sframe(uint8_t *sframe, int64_t len) {
   if (frame == NULL) {
     return NULL;
   }
+  // Super-chunk will assume ownership of frame and free it
   blosc2_schunk* schunk = blosc2_frame_to_schunk(frame, false);
-  if (schunk == NULL) {
-    blosc2_frame_free(frame);
-  }
   return schunk;
 }
 


### PR DESCRIPTION
https://oss-fuzz.com/testcase-detail/5854816091897856

This was semi-introduced in my previous direct-leak fix.

I believe this logic is correct - when `blosc2_frame_to_schunk` has `copy = true` then it will copy internally, and it doesn't need a reference to the frame hence `schunk->frame = NULL`. But if `copy = false` then it will need to keep around (and assume ownership of the frame) in otherwords, `schunk->frame = frame`.  So when `copy = true` we can `avoid_frame_free`, but when `copy = false` we assume frame ownership and must free.

Can you check that to make sure I got it right? Or maybe there is a better way to handle this. The function that gets called is `blosc2_schunk_open_sframe`. It creates a `frame` and then uses that to create a `schunk`. It can either keep the `frame` and not copy, or it can free the `frame` and copy.