### PR TITLE
Fixed MSAN use-of-uninitialized in ZSTD_checkContinuity. 

### DIFF
--- a/blosc/blosc2.c
+++ b/blosc/blosc2.c
@@ -1115,6 +1115,10 @@ static int blosc_d(
   }
 
   neblock = bsize / nstreams;
+  if (neblock == 0) {
+    /* Not enough space to output bytes */
+    return -1;
+  }
   for (int j = 0; j < nstreams; j++) {
     if (srcsize < (signed)sizeof(int32_t)) {
       /* Not enough input to read compressed size */


### PR DESCRIPTION
In this instance `bsize = 1` and `nstream > 1` (while debugging was 2) resulting in `neblock` being 0 and `zstd_wrap_decompress` being called with `maxout` of 0. 

Maybe there is some other better check I could also be doing?

https://oss-fuzz.com/testcase-detail/6243129091031040