### PR TITLE
Fixed MSAN use-of-uninitialized in tinfl_decompress when invalid dist.

### DIFF
--- a/internal-complibs/miniz-2.0.8/miniz.c
+++ b/internal-complibs/miniz-2.0.8/miniz.c
@@ -2663,7 +2663,7 @@ tinfl_status tinfl_decompress(tinfl_decompressor *r, const mz_uint8 *pIn_buf_nex
                 }
 
                 dist_from_out_buf_start = pOut_buf_cur - pOut_buf_start;
-                if ((dist > dist_from_out_buf_start || dist_from_out_buf_start == 0) && (decomp_flags & TINFL_FLAG_USING_NON_WRAPPING_OUTPUT_BUF))
+                if ((dist == 0 || dist > dist_from_out_buf_start || dist_from_out_buf_start == 0) && (decomp_flags & TINFL_FLAG_USING_NON_WRAPPING_OUTPUT_BUF))
                 {
                     TINFL_CR_RETURN_FOREVER(37, TINFL_STATUS_FAILED);
                 }


### PR DESCRIPTION
In this instance `dist` was 31 which `s_dist_base` translates as 0.

https://github.com/Blosc/c-blosc2/blob/452c3a9d2ba548718a590245f88c217dc2a99b88/internal-complibs/miniz-2.0.8/miniz.c#L2655-L2657

https://oss-fuzz.com/testcase-detail/4863557237473280