### PR TITLE
Fixed ASAN segv on unknown address due to overflow in get_coffsets

### DIFF
--- a/blosc/frame.c
+++ b/blosc/frame.c
@@ -873,7 +873,8 @@ uint8_t* get_coffsets(blosc2_frame_s *frame, int32_t header_len, int64_t cbytes,
   if (frame->cframe != NULL) {
     int64_t off_pos = header_len + cbytes;
     // Check that there is enough room to read Blosc header
-    if (off_pos < 0 || off_pos + BLOSC_EXTENDED_HEADER_LENGTH > frame->len) {
+    if (off_pos < 0 || off_pos + BLOSC_EXTENDED_HEADER_LENGTH < 0 ||
+        off_pos + BLOSC_EXTENDED_HEADER_LENGTH > frame->len) {
       BLOSC_TRACE_ERROR("Cannot read the offsets outside of frame boundary.");
       return NULL;
     }


### PR DESCRIPTION
`off_pos + BLOSC_EXTENDED_HEADER_LENGTH` overflows.
https://oss-fuzz.com/testcase-detail/6244500680867840