### PR TITLE
Fixed UBSAN unknown read when content_len < 0 in frame_get_vlmetalayers.

### DIFF
--- a/blosc/frame.c
+++ b/blosc/frame.c
@@ -1419,6 +1419,9 @@ static int get_vlmeta_from_trailer(blosc2_frame_s* frame, blosc2_schunk* schunk,
       return BLOSC2_ERROR_READ_BUFFER;
     }
     big_store(&content_len, content_marker + 1, sizeof(content_len));
+    if (content_len < 0) {
+      return BLOSC2_ERROR_DATA;
+    }
     metalayer->content_len = content_len;
 
     // Finally, read the content


### PR DESCRIPTION
https://oss-fuzz.com/testcase-detail/4622970490322944

This is one instance where I missed from #230.