### PR TITLE
Fixed UBSAN integer-overflow warning when calculating off_pos in get_coffsets.

### DIFF
--- a/blosc/frame.c
+++ b/blosc/frame.c
@@ -1030,9 +1030,12 @@ uint8_t* get_coffsets(blosc2_frame_s *frame, int32_t header_len, int64_t cbytes,
     return frame->coffsets;
   }
   if (frame->cframe != NULL) {
-    int64_t off_pos = header_len + cbytes;
+    int64_t off_pos = header_len;
+    if (cbytes < INT64_MAX - header_len) {
+      off_pos += cbytes;
+    }
     // Check that there is enough room to read Blosc header
-    if (off_pos < 0 || off_pos + BLOSC_EXTENDED_HEADER_LENGTH < 0 ||
+    if (off_pos < 0 || off_pos > INT64_MAX - BLOSC_EXTENDED_HEADER_LENGTH ||
         off_pos + BLOSC_EXTENDED_HEADER_LENGTH > frame->len) {
       BLOSC_TRACE_ERROR("Cannot read the offsets outside of frame boundary.");
       return NULL;


### PR DESCRIPTION
```
Running: c-blosc2/build/tests/fuzz/decompress_frame_fuzzer clusterfuzz-testcase-decompress_frame_fuzzer-5749817957548032
../blosc/frame.c:1035:15: runtime error: signed integer overflow: 90 + 9223372036854775807 cannot be represented in type 'long'
    0x53b3d9 in get_coffsets /c-blosc2/build/../blosc/frame.c:1035:15
    0x5435d1 in get_coffset /c-blosc2/build/../blosc/frame.c:1733:23
    0x544a86 in frame_get_lazychunk /c-blosc2/build/../blosc/frame.c:1910:9
    0x54f01d in frame_decompress_chunk /c-blosc2/build/../blosc/frame.c:2692:20
    0x51f50c in blosc2_schunk_decompress_chunk /c-blosc2/build/../blosc/schunk.c:768:17
    0x429015 in LLVMFuzzerTestOneInput /c-blosc2/build/../tests/fuzz/fuzz_decompress_frame.c:38:15
    0x4295b3 in main /c-blosc2/build/../tests/fuzz/standalone.c:32:7
    0x7ffff7c430b2 in __libc_start_main /build/glibc-eX1tMB/glibc-2.31/csu/../csu/libc-start.c:308:16
    0x40869d in _start (/c-blosc2/build/tests/fuzz/decompress_frame_fuzzer+0x40869d)
```
https://oss-fuzz.com/testcase-detail/5749817957548032