### PR TITLE
Fixed UBSAN unknown read when trying to access invalid off_cbytes.

### DIFF
--- a/blosc/blosc2.c
+++ b/blosc/blosc2.c
@@ -1209,8 +1209,8 @@ static int blosc_d(
   int32_t compformat = (context->header_flags & (uint8_t)0xe0) >> 5u;
   int dont_split = (context->header_flags & (uint8_t)0x10) >> 4u;
   int memcpyed = context->header_flags & (uint8_t)BLOSC_MEMCPYED;
-  int32_t chunk_nbytes = *(int32_t*)(src + BLOSC2_CHUNK_NBYTES);
-  int32_t chunk_cbytes = *(int32_t*)(src + BLOSC2_CHUNK_CBYTES);
+  int32_t chunk_nbytes = sw32_(src + BLOSC2_CHUNK_NBYTES);
+  int32_t chunk_cbytes = sw32_(src + BLOSC2_CHUNK_CBYTES);
   //uint8_t blosc_version_format = src[BLOSC2_CHUNK_VERSION];
   int nstreams;
   int32_t neblock;

--- a/blosc/blosc2.c
+++ b/blosc/blosc2.c
@@ -2553,10 +2553,7 @@ int _blosc_getitem(blosc2_context* context, blosc_header* header, const void* sr
   return ntbytes;
 }
 
-
-/* Specific routine optimized for decompression a small number of
-   items out of a compressed chunk.  Public non-contextual API. */
-int blosc_getitem(const void* src, int start, int nitems, void* dest) {
+int blosc2_getitem(const void* src, int32_t srcsize, int start, int nitems, void* dest, int32_t destsize) {
   blosc2_context context;
   int result;
 
@@ -2567,13 +2564,19 @@ int blosc_getitem(const void* src, int start, int nitems, void* dest) {
   context.nthreads = 1;  // force a serial decompression; fixes #95
 
   /* Call the actual getitem function */
-  result = blosc2_getitem_ctx(&context, src, INT32_MAX, start, nitems, dest, INT32_MAX);
+  result = blosc2_getitem_ctx(&context, src, srcsize, start, nitems, dest, destsize);
 
   /* Release resources */
   if (context.serial_context != NULL) {
     free_thread_context(context.serial_context);
   }
   return result;
+}
+
+/* Specific routine optimized for decompression a small number of
+   items out of a compressed chunk.  Public non-contextual API. */
+int blosc_getitem(const void* src, int start, int nitems, void* dest) {
+  return blosc2_getitem(src, INT32_MAX, start, nitems, dest, INT32_MAX);
 }
 
 int blosc2_getitem_ctx(blosc2_context* context, const void* src, int32_t srcsize,

--- a/blosc/blosc2.h
+++ b/blosc/blosc2.h
@@ -446,13 +446,13 @@ BLOSC_EXPORT int blosc_getitem(const void* src, int start, int nitems, void* des
  * The items are returned in @p dest buffer. The dest buffer should have enough space
  * for storing all items. This function is a more secure version of #blosc_getitem.
  *
- * @param src The compressed buffer from data will be decompressed.
- * @param srcsize Size of the compressed buffer from data will be decompressed.
+ * @param src The compressed buffer holding the data to be retrieved.
+ * @param srcsize Size of the compressed buffer.
  * @param start The position of the first item (of @p typesize size) from where data
  * will be retrieved.
  * @param nitems The number of items (of @p typesize size) that will be retrieved.
- * @param dest The buffer where the decompressed data retrieved will be put.
- * @param destsize Size of the buffer where decompressed data received.
+ * @param dest The buffer where the retrieved data will be stored decompressed.
+ * @param destsize Size of the buffer where retrieved data will be stored.
  *
  * @return The number of bytes copied to @p dest or a negative value if
  * some error happens.

--- a/blosc/blosc2.h
+++ b/blosc/blosc2.h
@@ -623,6 +623,24 @@ BLOSC_EXPORT int blosc_free_resources(void);
  */
 BLOSC_EXPORT void blosc_cbuffer_sizes(const void* cbuffer, size_t* nbytes,
                                       size_t* cbytes, size_t* blocksize);
+/**
+ * @brief Get information about a compressed buffer, namely the number of
+ * uncompressed bytes (@p nbytes) and compressed (@p cbytes). It also
+ * returns the @p blocksize (which is used internally for doing the
+ * compression by blocks).
+ *
+ * @param cbuffer The buffer of compressed data.
+ * @param nbytes The pointer where the number of uncompressed bytes will be put.
+ * @param cbytes The pointer where the number of compressed bytes will be put.
+ * @param blocksize The pointer where the block size will be put.
+ *
+ * You only need to pass the first BLOSC_EXTENDED_HEADER_LENGTH bytes of a
+ * compressed buffer for this call to work.
+ *
+ * @return On failure, returns negative value.
+ */
+BLOSC_EXPORT int blosc2_cbuffer_sizes(const void* cbuffer, int32_t* nbytes,
+                                      int32_t* cbytes, int32_t* blocksize);
 
 /**
  * @brief Checks that the compressed buffer starting at @cbuffer of length @cbytes may
@@ -636,10 +654,10 @@ BLOSC_EXPORT void blosc_cbuffer_sizes(const void* cbuffer, size_t* nbytes,
  * @param cbytes The number of compressed bytes.
  * @param nbytes The pointer where the number of uncompressed bytes will be put.
  *
- * @return On failure, returns -1.
+ * @return On failure, returns negative value.
  */
 BLOSC_EXPORT int blosc_cbuffer_validate(const void* cbuffer, size_t cbytes,
-                                         size_t* nbytes);
+                                        size_t* nbytes);
 
 /**
  * @brief Get information about a compressed buffer, namely the type size

--- a/blosc/blosc2.h
+++ b/blosc/blosc2.h
@@ -441,6 +441,24 @@ BLOSC_EXPORT int blosc2_chunk_repeatval(size_t nbytes, size_t typesize,
  */
 BLOSC_EXPORT int blosc_getitem(const void* src, int start, int nitems, void* dest);
 
+/**
+ * @brief Get @p nitems (of @p typesize size) in @p src buffer starting in @p start.
+ * The items are returned in @p dest buffer. The dest buffer should have enough space
+ * for storing all items. This function is a more secure version of #blosc_getitem.
+ *
+ * @param src The compressed buffer from data will be decompressed.
+ * @param srcsize Size of the compressed buffer from data will be decompressed.
+ * @param start The position of the first item (of @p typesize size) from where data
+ * will be retrieved.
+ * @param nitems The number of items (of @p typesize size) that will be retrieved.
+ * @param dest The buffer where the decompressed data retrieved will be put.
+ * @param destsize Size of the buffer where decompressed data received.
+ *
+ * @return The number of bytes copied to @p dest or a negative value if
+ * some error happens.
+ */
+BLOSC_EXPORT int blosc2_getitem(const void* src, int32_t srcsize, int start, int nitems,
+                                void* dest, int32_t destsize);
 
 /**
   Pointer to a callback function that executes `dojob(jobdata + i*jobdata_elsize)` for `i = 0 to numjobs-1`,

--- a/blosc/frame.c
+++ b/blosc/frame.c
@@ -998,6 +998,7 @@ uint8_t* get_coffsets(blosc2_frame_s *frame, int32_t header_len, int64_t cbytes,
   if (off_cbytes != NULL) {
     *off_cbytes = coffsets_cbytes;
   }
+
   FILE* fp = NULL;
   uint8_t* coffsets = malloc((size_t)coffsets_cbytes);
   if (frame->sframe) {
@@ -1670,15 +1671,16 @@ int sort_offset(const void* a, const void* b) {
 
 
 int get_coffset(blosc2_frame_s* frame, int32_t header_len, int64_t cbytes, int32_t nchunk, int64_t *offset) {
+  int32_t off_cbytes;
   // Get the offset to nchunk
-  uint8_t *coffsets = get_coffsets(frame, header_len, cbytes, NULL);
+  uint8_t *coffsets = get_coffsets(frame, header_len, cbytes, &off_cbytes);
   if (coffsets == NULL) {
     BLOSC_TRACE_ERROR("Cannot get the offset for chunk %d for the frame.", nchunk);
     return BLOSC2_ERROR_DATA;
   }
 
   // Get the 64-bit offset
-  int rc = blosc_getitem(coffsets, nchunk, 1, offset);
+  int rc = blosc2_getitem(coffsets, frame->len - off_cbytes, nchunk, 1, offset, sizeof(int64_t));
   if (rc < 0) {
     BLOSC_TRACE_ERROR("Problems retrieving a chunk offset.");
   } else if (*offset > frame->len) {

--- a/blosc/frame.c
+++ b/blosc/frame.c
@@ -953,7 +953,7 @@ int64_t frame_from_schunk(blosc2_schunk *schunk, blosc2_frame_s *frame) {
 uint8_t* get_coffsets(blosc2_frame_s *frame, int32_t header_len, int64_t cbytes, int32_t *off_cbytes) {
   if (frame->coffsets != NULL) {
     if (off_cbytes != NULL) {
-      *off_cbytes = *(int32_t *) (frame->coffsets + BLOSC2_CHUNK_CBYTES);
+      *off_cbytes = sw32_(frame->coffsets + BLOSC2_CHUNK_CBYTES);
     }
     return frame->coffsets;
   }
@@ -971,7 +971,7 @@ uint8_t* get_coffsets(blosc2_frame_s *frame, int32_t header_len, int64_t cbytes,
     // For in-memory frames, the coffset is just one pointer away
     uint8_t* off_start = frame->cframe + off_pos;
     if (off_cbytes != NULL) {
-      *off_cbytes = *(int32_t*) (off_start + BLOSC2_CHUNK_CBYTES);
+      *off_cbytes = sw32_(off_start + BLOSC2_CHUNK_CBYTES);
     }
     return off_start;
   }

--- a/blosc/frame.c
+++ b/blosc/frame.c
@@ -972,6 +972,10 @@ uint8_t* get_coffsets(blosc2_frame_s *frame, int32_t header_len, int64_t cbytes,
     uint8_t* off_start = frame->cframe + off_pos;
     if (off_cbytes != NULL) {
       *off_cbytes = sw32_(off_start + BLOSC2_CHUNK_CBYTES);
+      if (*off_cbytes > frame->len) {
+        BLOSC_TRACE_ERROR("Cannot read the cbytes outside of frame boundary.");
+        return NULL;
+      }
     }
     return off_start;
   }

--- a/blosc/frame.c
+++ b/blosc/frame.c
@@ -972,7 +972,7 @@ uint8_t* get_coffsets(blosc2_frame_s *frame, int32_t header_len, int64_t cbytes,
     uint8_t* off_start = frame->cframe + off_pos;
     if (off_cbytes != NULL) {
       *off_cbytes = sw32_(off_start + BLOSC2_CHUNK_CBYTES);
-      if (*off_cbytes > frame->len) {
+      if (*off_cbytes < 0 || *off_cbytes > frame->len) {
         BLOSC_TRACE_ERROR("Cannot read the cbytes outside of frame boundary.");
         return NULL;
       }


### PR DESCRIPTION
- Added `blosc2_getitem` function which adds to `blosc_getitem` params `srcsize` and `destsize` to make sure we don't read past frame boundary, or write past destination buffer.

https://oss-fuzz.com/testcase-detail/5507944642904064.