### PR TITLE
Fixed ASAN heap-buffer-overflow reading chunk outside of frame boundary.

### DIFF
--- a/blosc/frame.c
+++ b/blosc/frame.c
@@ -1743,7 +1743,11 @@ int get_coffset(blosc2_frame_s* frame, int32_t header_len, int64_t cbytes, int32
   int rc = blosc_getitem(coffsets, nchunk, 1, offset);
   if (rc < 0) {
     BLOSC_TRACE_ERROR("Problems retrieving a chunk offset.");
+  } else if (*offset > frame->len) {
+    BLOSC_TRACE_ERROR("Cannot read chunk %d outside of frame boundary.", nchunk);
+    rc = BLOSC2_ERROR_READ_BUFFER;
   }
+
   return rc;
 }
 


### PR DESCRIPTION
https://oss-fuzz.com/testcase-detail/6462229769748480