### PR TITLE
Reserve most significant byte of an offset for special values

### DIFF
--- a/README_CFRAME_FORMAT.rst
+++ b/README_CFRAME_FORMAT.rst
@@ -204,8 +204,8 @@ The codification for the offsets is as follows::
                                    |
                                    +--> Byte for special values
 
-If the most significant bit (7) of the most significant byte above (byte N, as little endian is used) is set,
-that represents a chunk with a run-length of special values.  The supported special values are:
+The most significant byte above (byte N, as little endian is used) is reserved
+to represent a chunk with a run-length of special values.  The supported special values are:
 
 :special_values:
     (``uint8``) Flags for special values.
@@ -225,7 +225,7 @@ that represents a chunk with a run-length of special values.  The supported spec
         :``6``:
             Reserved.
         :``7``:
-            Indicates a special value.  If not set, a regular value.
+            Reserved.
 
 
 Trailer

--- a/blosc/frame.c
+++ b/blosc/frame.c
@@ -2118,7 +2118,7 @@ void* frame_append_chunk(blosc2_frame_s* frame, void* chunk, blosc2_schunk* schu
 
   // Add the new offset
   int special_value = (chunk_[BLOSC2_CHUNK_BLOSC2_FLAGS] & 0x30) >> 4;
-  uint64_t offset_value = ((uint64_t)1 << 63);
+  uint64_t offset_value = 0;
   switch (special_value) {
     case BLOSC2_ZERO_RUNLEN:
       // Zero chunk.  Code it in a special way.
@@ -2287,7 +2287,7 @@ void* frame_insert_chunk(blosc2_frame_s* frame, int nchunk, void* chunk, blosc2_
 
   // Add the new offset
   int special_value = (chunk_[BLOSC2_CHUNK_BLOSC2_FLAGS] & 0x30) >> 4;
-  uint64_t offset_value = ((uint64_t)1 << 63);
+  uint64_t offset_value = 0;
   switch (special_value) {
     case BLOSC2_ZERO_RUNLEN:
       // Zero chunk.  Code it in a special way.
@@ -2492,7 +2492,7 @@ void* frame_update_chunk(blosc2_frame_s* frame, int nchunk, void* chunk, blosc2_
 
   // Add the new offset
   int special_value = (chunk_[BLOSC2_CHUNK_BLOSC2_FLAGS] & 0x30) >> 4;
-  uint64_t offset_value = ((uint64_t)1 << 63);
+  uint64_t offset_value = 0;
   switch (special_value) {
     case BLOSC2_ZERO_RUNLEN:
       // Zero chunk.  Code it in a special way.


### PR DESCRIPTION
If the most significant byte of an offset is reserved for special values, there is no need to set the most significant bit of that byte to 1. 