### PR TITLE
Fixed ASAN null-dereference write when unable to create thread context memory

### DIFF
--- a/blosc/blosc2.h
+++ b/blosc/blosc2.h
@@ -275,6 +275,7 @@ enum {
   BLOSC2_ERROR_SCHUNK_COPY = -23,     //!< Super-chunk copy failure
   BLOSC2_ERROR_FRAME_TYPE = -24,      //!< Wrong type for frame
   BLOSC2_ERROR_FILE_TRUNCATE = -25,   //!< File truncate failure
+  BLOSC2_ERROR_THREAD_CREATE = -26,   //!< Thread or thread context creation failure
 
 };
 


### PR DESCRIPTION
ASAN (32-bit) https://oss-fuzz.com/testcase-detail/4589997492666368