### PR TITLE
Btune plugin

### DIFF
--- a/blosc/CMakeLists.txt
+++ b/blosc/CMakeLists.txt
@@ -50,7 +50,7 @@ endif()
 include_directories(${BLOSC_INCLUDE_DIRS})
 
 # library sources
-set(SOURCES blosc2.c blosc2-common.h blosclz.c fastcopy.c fastcopy.h schunk.c frame.c btune.c btune.h
+set(SOURCES blosc2.c blosc2-common.h blosclz.c fastcopy.c fastcopy.h schunk.c frame.c stune.c stune.h
         context.h delta.c delta.h shuffle-generic.c bitshuffle-generic.c trunc-prec.c trunc-prec.h
         timestamp.c sframe.c directories.c)
 if(NOT CMAKE_SYSTEM_PROCESSOR STREQUAL arm64)

--- a/blosc/blosc2.h
+++ b/blosc/blosc2.h
@@ -718,6 +718,21 @@ BLOSC_EXPORT const char* blosc_cbuffer_complib(const void* cbuffer);
 
 typedef struct blosc2_context_s blosc2_context;   /* opaque type */
 
+typedef struct {
+  void (*btune_init)(void * config, blosc2_context* cctx, blosc2_context* dctx);
+  //!< Initialize BTune.
+  void (*btune_next_blocksize)(blosc2_context * context);
+  //!< Only compute the next blocksize. Only it is executed if BTune is not initialized.
+  void (*btune_next_cparams)(blosc2_context * context);
+  //!< Compute the next cparams. Only is executed if BTune is initialized.
+  void (*btune_update)(blosc2_context * context, double ctime);
+  //!< Update the BTune parameters.
+  void (*btune_free)(blosc2_context * context);
+  //!< Free the BTune.
+  void *btune_config;
+  //!> BTune configuration.
+}blosc2_btune;
+
 /**
  * @brief The parameters for a prefilter function.
  *
@@ -795,6 +810,8 @@ typedef struct {
   //!< The prefilter function.
   blosc2_prefilter_params *preparams;
   //!< The prefilter parameters.
+  blosc2_btune *udbtune;
+  //!< The user-defined BTune parameters.
 } blosc2_cparams;
 
 /**
@@ -803,7 +820,7 @@ typedef struct {
 static const blosc2_cparams BLOSC2_CPARAMS_DEFAULTS = {
         BLOSC_BLOSCLZ, 5, 0, 8, 1, 0, NULL,
         {0, 0, 0, 0, 0, BLOSC_SHUFFLE}, {0, 0, 0, 0, 0, 0},
-        NULL, NULL };
+        NULL, NULL, NULL};
 
 /**
   @brief The parameters for creating a context for decompression purposes.
@@ -1178,7 +1195,9 @@ typedef struct blosc2_schunk {
   //<! The array of variable-length metalayers.
   int16_t nvlmetalayers;
   //!< The number of variable-length metalayers.
+  blosc2_btune *udbtune;
 } blosc2_schunk;
+
 
 /**
  * @brief Create a new super-chunk.

--- a/blosc/context.h
+++ b/blosc/context.h
@@ -103,7 +103,8 @@ struct blosc2_context_s {
   /* 1 if we are compressing, 0 if decompressing */
   void *btune;
   /* Entry point for BTune persistence between runs */
-
+  blosc2_btune *udbtune;
+  /* User-defined BTune parameters */
   /* Threading */
   int nthreads;
   int new_nthreads;

--- a/blosc/frame.c
+++ b/blosc/frame.c
@@ -244,13 +244,10 @@ void *new_header_frame(blosc2_schunk *schunk, blosc2_frame_s *frame) {
   uint8_t* mp_meta = h2 + FRAME_FILTER_PIPELINE + 1 + FRAME_FILTER_PIPELINE_MAX;
   int nfilters = 0;
   for (int i = 0; i < BLOSC2_MAX_FILTERS; i++) {
-    if (schunk->filters[i] != BLOSC_NOFILTER) {
-      mp_filters[nfilters] = schunk->filters[i];
-      mp_meta[nfilters] = schunk->filters_meta[i];
-      nfilters++;
-    }
+      mp_filters[i] = schunk->filters[i];
+      mp_meta[i] = schunk->filters_meta[i];
   }
-  *h2p = (uint8_t)nfilters;
+  *h2p = (uint8_t)BLOSC2_MAX_FILTERS;
   h2p += 1;
   h2p += 16;
   if (h2p - h2 != FRAME_HEADER_MINLEN) {

--- a/blosc/stune.c
+++ b/blosc/stune.c
@@ -9,7 +9,7 @@
 
 #include <stdbool.h>
 #include <stdio.h>
-#include "btune.h"
+#include "stune.h"
 
 
 /* Whether a codec is meant for High Compression Ratios
@@ -34,8 +34,11 @@ static bool is_HCR(blosc2_context * context) {
   return false;
 }
 
+void blosc_stune_init(void * config, blosc2_context* cctx, blosc2_context* dctx) {
+}
+
 // Set the automatic blocksize 0 to its real value
-void btune_next_blocksize(blosc2_context *context) {
+void blosc_stune_next_blocksize(blosc2_context *context) {
   int32_t clevel = context->clevel;
   int32_t typesize = context->typesize;
   int32_t nbytes = context->sourcesize;
@@ -148,15 +151,15 @@ void btune_next_blocksize(blosc2_context *context) {
   context->blocksize = blocksize;
 }
 
-void btune_next_cparams(blosc2_context * context) {
+void blosc_stune_next_cparams(blosc2_context * context) {
     BLOSC_UNUSED_PARAM(context);
 }
 
-void btune_update(blosc2_context * context, double ctime) {
+void blosc_stune_update(blosc2_context * context, double ctime) {
     BLOSC_UNUSED_PARAM(context);
     BLOSC_UNUSED_PARAM(ctime);
 }
 
-void btune_free(blosc2_context * context) {
+void blosc_stune_free(blosc2_context * context) {
     BLOSC_UNUSED_PARAM(context);
 }

--- a/blosc/stune.h
+++ b/blosc/stune.h
@@ -7,8 +7,8 @@
   See LICENSE.txt for details about copyright and rights to use.
 **********************************************************************/
 
-#ifndef BTUNE_H
-#define BTUNE_H
+#ifndef STUNE_H
+#define STUNE_H
 
 #include "context.h"
 
@@ -21,15 +21,25 @@
 #define MAX_STREAMS 16 /* Cannot be larger than 128 */
 
 
-BLOSC_EXPORT void btune_init(void * config, blosc2_context* cctx, blosc2_context* dctx);
+void blosc_stune_init(void * config, blosc2_context* cctx, blosc2_context* dctx);
 
-void btune_next_blocksize(blosc2_context * context);
+void blosc_stune_next_blocksize(blosc2_context * context);
 
-void btune_next_cparams(blosc2_context * context);
+void blosc_stune_next_cparams(blosc2_context * context);
 
-void btune_update(blosc2_context * context, double ctime);
+void blosc_stune_update(blosc2_context * context, double ctime);
 
-void btune_free(blosc2_context * context);
+void blosc_stune_free(blosc2_context * context);
+
+static blosc2_btune BTUNE_DEFAULTS = {
+    .btune_init = blosc_stune_init,
+    .btune_free = blosc_stune_free,
+    .btune_update = blosc_stune_update,
+    .btune_next_cparams = blosc_stune_next_cparams,
+    .btune_next_blocksize = blosc_stune_next_blocksize,
+    .btune_config = NULL,
+};
+
 
 /* Conditions for splitting a block before compressing with a codec. */
 static int split_block(blosc2_context* context, int32_t typesize,
@@ -51,4 +61,4 @@ static int split_block(blosc2_context* context, int32_t typesize,
      (blocksize / typesize) >= BLOSC_MIN_BUFFERSIZE);
 }
 
-#endif  /* BTUNE_H */
+#endif  /* STUNE_H */


### PR DESCRIPTION
This implements a plugin capability for users to specify their own tuning functions for adjusting compression parameters like `clevel`, `compressor`, `shuffle/bitshuffle` and others.  This allows for dynamically doing that while e.g. doing appends into a super-chunk, so that the compression parameters can change (tuned) from one chunk to another. 