### PR TITLE
Postfilters runlen

### DIFF
--- a/bench/create_frame.c
+++ b/bench/create_frame.c
@@ -50,7 +50,7 @@ Process finished with exit code 0
 #define NTHREADS 8
 
 // For exercising the optimized zero chunk creators uncomment the line below
-//#define CREATE_ZEROS
+#define CREATE_ZEROS
 
 
 int create_cframe(const char* compname) {
@@ -154,7 +154,7 @@ int main(void) {
 
   create_cframe("blosclz");
   create_cframe("lz4");
-  create_cframe("lz4hc");
-  create_cframe("zlib");
-  create_cframe("zstd");
+//  create_cframe("lz4hc");
+//  create_cframe("zlib");
+//  create_cframe("zstd");
 }

--- a/bench/zero_runlen.c
+++ b/bench/zero_runlen.c
@@ -230,11 +230,6 @@ int check_special_values(int svalue) {
 
 int main(void) {
   int rc;
-  printf("Testing zero detection...");
-  rc = check_special_values(ZERO_DETECTION);
-  if (rc < 0) {
-    return rc;
-  }
   printf("*** Testing special zeros...");
   rc = check_special_values(CHECK_ZEROS);
   if (rc < 0) {
@@ -247,6 +242,11 @@ int main(void) {
   }
   printf("*** Testing special values...");
   rc = check_special_values(CHECK_VALUES);
+  if (rc < 0) {
+    return rc;
+  }
+  printf("Testing zero detection...");
+  rc = check_special_values(ZERO_DETECTION);
   if (rc < 0) {
     return rc;
   }

--- a/bench/zero_runlen.c
+++ b/bench/zero_runlen.c
@@ -57,7 +57,7 @@ int check_special_values(int svalue) {
   cparams.compcode = BLOSC_BLOSCLZ;
   cparams.clevel = 9;
   cparams.nthreads = NTHREADS;
-  blosc2_storage storage = {.cparams=&cparams, .contiguous=true};
+  blosc2_storage storage = {.cparams=&cparams, .contiguous=false};
   schunk = blosc2_schunk_new(&storage);
 
   /* Append the chunks */

--- a/blosc/blosc2.c
+++ b/blosc/blosc2.c
@@ -768,6 +768,7 @@ static int blosc2_initialize_context_from_header(blosc2_context* context, blosc_
     memcpy(context->filters_meta, header->filter_meta, BLOSC2_MAX_FILTERS);
 
     context->filter_flags = filters_to_flags(header->filter_codes);
+    context->runlen_type = (header->blosc2_flags >> 4) & BLOSC2_RUNLEN_MASK;
 
     is_lazy = (context->blosc2_flags & 0x08u);
   }
@@ -1223,17 +1224,73 @@ int pipeline_d(struct thread_context* thread_context, const int32_t bsize, uint8
 }
 
 
+int set_nans(int32_t nbytes, int32_t typesize, const uint8_t* src,
+             uint8_t* dest, int32_t destsize) {
+  int32_t nitems = nbytes / typesize;
+  if (nitems > destsize / typesize) {
+    nitems = destsize / typesize;
+  }
+
+  if (typesize > destsize) {
+    BLOSC_TRACE_ERROR("Not enough space in dest");
+    return BLOSC2_ERROR_WRITE_BUFFER;
+  }
+
+  if (typesize == 4) {
+    float* dest_ = (float*)dest;
+    for (int i = 0; i < nitems; i++) {
+      dest_[i] = nanf("");
+    }
+    return nbytes;
+  }
+  else if (typesize == 8) {
+    double* dest_ = (double*)dest;
+    for (int i = 0; i < nitems; i++) {
+      dest_[i] = nan("");
+    }
+    return nbytes;
+  }
+
+  BLOSC_TRACE_ERROR("Unsupported typesize for NaN");
+  return BLOSC2_ERROR_DATA;
+}
+
+
+int set_values(int32_t nbytes, int32_t typesize, const uint8_t* src,
+               uint8_t* dest, int32_t destsize) {
+  int32_t nitems = nbytes / typesize;
+  if (nitems > destsize / typesize) {
+    nitems = destsize / typesize;
+  }
+
+  if (typesize > destsize) {
+    BLOSC_TRACE_ERROR("Not enough space in dest");
+    return BLOSC2_ERROR_WRITE_BUFFER;
+  }
+  // Get the value at the end of the header
+  void* value = malloc(typesize);
+  BLOSC_ERROR_NULL(value, BLOSC2_ERROR_MEMORY_ALLOC);
+  memcpy(value, src + BLOSC_EXTENDED_HEADER_LENGTH, typesize);
+  // And copy it to dest
+  for (int i = 0; i < nitems; i++) {
+    memcpy(dest + i * typesize, value, typesize);
+  }
+  free(value);
+
+  return nbytes;
+}
+
+
 /* Decompress & unshuffle a single block */
 static int blosc_d(
     struct thread_context* thread_context, int32_t bsize,
-    int32_t leftoverblock, const uint8_t* src, int32_t srcsize, int32_t src_offset,
+    int32_t leftoverblock, bool memcpyed, const uint8_t* src, int32_t srcsize, int32_t src_offset,
     int32_t nblock, uint8_t* dest, int32_t dest_offset, uint8_t* tmp, uint8_t* tmp2) {
   blosc2_context* context = thread_context->parent_context;
   uint8_t* filters = context->filters;
   uint8_t *tmp3 = thread_context->tmp4;
   int32_t compformat = (context->header_flags & (uint8_t)0xe0) >> 5u;
   int dont_split = (context->header_flags & (uint8_t)0x10) >> 4u;
-  int memcpyed = context->header_flags & (uint8_t)BLOSC_MEMCPYED;
   int32_t chunk_nbytes;
   int32_t chunk_cbytes;
   int nstreams;
@@ -1318,19 +1375,34 @@ static int blosc_d(
 
   // If the chunk is memcpyed, we just have to copy the block to dest and return
   if (memcpyed) {
-    if (chunk_nbytes + context->header_overhead != chunk_cbytes) {
-      return BLOSC2_ERROR_WRITE_BUFFER;
-    }
     int bsize_ = leftoverblock ? chunk_nbytes % context->blocksize : bsize;
-    if (chunk_cbytes < context->header_overhead + (nblock * context->blocksize) + bsize_) {
-      /* Not enough input to copy block */
-      return BLOSC2_ERROR_READ_BUFFER;
+    if (!context->runlen_type) {
+      if (chunk_nbytes + context->header_overhead != chunk_cbytes) {
+        return BLOSC2_ERROR_WRITE_BUFFER;
+      }
+      if (chunk_cbytes < context->header_overhead + (nblock * context->blocksize) + bsize_) {
+        /* Not enough input to copy block */
+        return BLOSC2_ERROR_READ_BUFFER;
+      }
     }
     if (!is_lazy) {
       src += context->header_overhead + nblock * context->blocksize;
     }
     if (context->postfilter == NULL) {
-      memcpy(dest + dest_offset, src, bsize_);
+      switch (context->runlen_type) {
+        case BLOSC2_VALUE_RUNLEN:
+          // All repeated values
+          rc = set_values(chunk_nbytes, context->typesize, src, dest, bsize_);
+          break;
+        case BLOSC2_NAN_RUNLEN:
+          rc = set_nans(chunk_nbytes, context->typesize, src, dest, bsize_);
+          break;
+        case BLOSC2_ZERO_RUNLEN:
+          memset(dest, 0, bsize_);
+          break;
+        default:
+          memcpy(dest + dest_offset, src, bsize_);
+      }
     }
     else {
       // Create new postfilter parameters for this block (must be private for each thread)
@@ -1519,6 +1591,10 @@ static int serial_blosc(struct thread_context* thread_context) {
   uint8_t* tmp2 = thread_context->tmp2;
   int dict_training = context->use_dict && (context->dict_cdict == NULL);
   bool memcpyed = context->header_flags & (uint8_t)BLOSC_MEMCPYED;
+  if (!context->do_compress && context->runlen_type) {
+    // Fake a runlen as if its a memcpyed chunk
+    memcpyed = true;
+  }
 
   for (j = 0; j < context->nblocks; j++) {
     if (context->do_compress && !memcpyed && !dict_training) {
@@ -1553,7 +1629,7 @@ static int serial_blosc(struct thread_context* thread_context) {
       // If memcpyed we don't have a bstarts section (because it is not needed)
       int32_t src_offset = memcpyed ?
           context->header_overhead + j * context->blocksize : sw32_(bstarts + j);
-      cbytes = blosc_d(thread_context, bsize, leftoverblock,
+      cbytes = blosc_d(thread_context, bsize, leftoverblock, memcpyed,
                        context->src, context->srcsize, src_offset, j,
                        context->dest, j * context->blocksize, tmp, tmp2);
     }
@@ -1837,19 +1913,23 @@ static int initialize_context_decompression(blosc2_context* context, blosc_heade
     return BLOSC2_ERROR_DATA;
   }
 
-  context->bstarts = (int32_t*)(context->src + context->header_overhead);
-  if (context->header_flags & (uint8_t)BLOSC_MEMCPYED) {
-    /* If chunk is a memcpy, bstarts does not exist */
-    bstarts_end = context->header_overhead;
-  } else {
-    bstarts_end = context->header_overhead + (context->nblocks * sizeof(int32_t));
-  }
+  context->runlen_type = (header->blosc2_flags >> 4) & BLOSC2_RUNLEN_MASK;
 
-  if (srcsize < bstarts_end) {
-    BLOSC_TRACE_ERROR("`bstarts` exceeds length of source buffer.");
-    return BLOSC2_ERROR_READ_BUFFER;
+  if (context->runlen_type == 0) {
+    context->bstarts = (int32_t *) (context->src + context->header_overhead);
+    if (context->header_flags & (uint8_t) BLOSC_MEMCPYED) {
+      /* If chunk is a memcpy, bstarts does not exist */
+      bstarts_end = context->header_overhead;
+    } else {
+      bstarts_end = context->header_overhead + (context->nblocks * sizeof(int32_t));
+    }
+
+    if (srcsize < bstarts_end) {
+      BLOSC_TRACE_ERROR("`bstarts` exceeds length of source buffer.");
+      return BLOSC2_ERROR_READ_BUFFER;
+    }
+    srcsize -= bstarts_end;
   }
-  srcsize -= bstarts_end;
 
   /* Read optional dictionary if flag set */
   if (context->blosc2_flags & BLOSC2_USEDICT) {
@@ -2315,85 +2395,6 @@ int blosc_compress(int clevel, int doshuffle, size_t typesize, size_t nbytes,
 }
 
 
-int set_nans(blosc_header* header, uint8_t* src, uint8_t* dest, int32_t destsize) {
-  int32_t nitems = header->nbytes / header->typesize;
-  if (nitems > destsize / header->typesize) {
-    nitems = destsize / header->typesize;
-  }
-
-  if (header->typesize > destsize) {
-    BLOSC_TRACE_ERROR("Not enough space in dest");
-    return BLOSC2_ERROR_WRITE_BUFFER;
-  }
-
-  if (header->typesize == 4) {
-    float* dest_ = (float*)dest;
-    for (int i = 0; i < nitems; i++) {
-      dest_[i] = nanf("");
-    }
-    return header->nbytes;
-  }
-  else if (header->typesize == 8) {
-    double* dest_ = (double*)dest;
-    for (int i = 0; i < nitems; i++) {
-      dest_[i] = nan("");
-    }
-    return header->nbytes;
-  }
-
-  BLOSC_TRACE_ERROR("Unsupported typesize for NaN");
-  return BLOSC2_ERROR_DATA;
-}
-
-
-int set_values(blosc_header* header, uint8_t* src, uint8_t* dest, int32_t destsize) {
-  int32_t nitems = header->nbytes / header->typesize;
-  if (nitems > destsize / header->typesize) {
-    nitems = destsize / header->typesize;
-  }
-
-  if (header->typesize > destsize) {
-    BLOSC_TRACE_ERROR("Not enough space in dest");
-    return BLOSC2_ERROR_WRITE_BUFFER;
-  }
-  // Get the value at the end of the header
-  void* value = malloc(header->typesize);
-  BLOSC_ERROR_NULL(value, BLOSC2_ERROR_MEMORY_ALLOC);
-  memcpy(value, src + BLOSC_EXTENDED_HEADER_LENGTH, header->typesize);
-  // And copy it to dest
-  for (int i = 0; i < nitems; i++) {
-    memcpy(dest + i * header->typesize, value, header->typesize);
-  }
-  free(value);
-
-  return header->nbytes;
-}
-
-
-// Return > 0 if runlen.  0 if not a runlen.
-int handle_runlen(blosc_header *header, uint8_t* src, uint8_t* dest, int32_t destsize) {
-  bool doshuffle_flag = header->flags & BLOSC_DOSHUFFLE;
-  bool dobitshuffle_flag = header->flags & BLOSC_DOBITSHUFFLE;
-  int rc = 0;
-
-  if (doshuffle_flag & dobitshuffle_flag) {
-    int32_t runlen_type = (header->blosc2_flags >> 4) & BLOSC2_RUNLEN_MASK;
-    if (runlen_type == BLOSC2_VALUE_RUNLEN) {
-      // All repeated values
-      rc = set_values(header, src, dest, destsize);
-    }
-    else if (runlen_type == BLOSC2_NAN_RUNLEN) {
-      rc = set_nans(header, src, dest, destsize);
-    }
-    else if (runlen_type == BLOSC2_ZERO_RUNLEN) {
-      memset(dest, 0, destsize);
-      rc = header->nbytes;
-    }
-  }
-
-  return rc;
-}
-
 
 int blosc_run_decompression_with_context(blosc2_context* context, const void* src, int32_t srcsize,
                                          void* dest, int32_t destsize) {
@@ -2410,16 +2411,6 @@ int blosc_run_decompression_with_context(blosc2_context* context, const void* sr
   if (header.nbytes > destsize) {
     // Not enough space for writing into the destination
     return BLOSC2_ERROR_WRITE_BUFFER;
-  }
-
-  // Is that a chunk with a special value (runlen)?
-  rc = handle_runlen(&header, _src, dest, destsize);
-  if (rc < 0) {
-    return rc;
-  }
-  if (rc > 0) {
-    // This means that we have found a special value and we are done.
-    return rc;
   }
 
   rc = initialize_context_decompression(context, &header, src, srcsize, dest, destsize);
@@ -2533,16 +2524,6 @@ int _blosc_getitem(blosc2_context* context, blosc_header* header, const void* sr
     return BLOSC2_ERROR_WRITE_BUFFER;
   }
 
-  // Is that a chunk with a special value (runlen)?
-  rc = handle_runlen(header, _src, dest, nitems * header->typesize);
-  if (rc < 0) {
-    return rc;
-  }
-  if (rc > 0) {
-    // This means that we have found a special value and we are done.
-    return rc;
-  }
-
   context->bstarts = (int32_t*)(_src + context->header_overhead);
 
   /* Check region boundaries */
@@ -2609,11 +2590,16 @@ int _blosc_getitem(blosc2_context* context, blosc_header* header, const void* sr
     bool get_single_block = ((startb == 0) && (bsize == nitems * header->typesize));
     uint8_t* tmp2 = get_single_block ? dest : scontext->tmp2;
     bool memcpyed = header->flags & (uint8_t)BLOSC_MEMCPYED;
+    if (context->runlen_type) {
+      // Fake a runlen as if its a memcpyed chunk
+      memcpyed = true;
+    }
+
     // If memcpyed we don't have a bstarts section (because it is not needed)
     int32_t src_offset = memcpyed ?
       context->header_overhead + j * bsize : sw32_(context->bstarts + j);
 
-    cbytes = blosc_d(context->serial_context, bsize, leftoverblock,
+    cbytes = blosc_d(context->serial_context, bsize, leftoverblock, memcpyed,
                      src, srcsize, src_offset, j,
                      tmp2, 0, scontext->tmp, scontext->tmp3);
     if (cbytes < 0) {
@@ -2744,6 +2730,11 @@ static void t_blosc_do_job(void *ctxt)
 
   // Determine whether we can do a static distribution of workload among different threads
   bool memcpyed = context->header_flags & (uint8_t)BLOSC_MEMCPYED;
+  if (!context->do_compress && context->runlen_type) {
+    // Fake a runlen as if its a memcpyed chunk
+    memcpyed = true;
+  }
+
   bool static_schedule = (!compress || memcpyed) && context->block_maskout == NULL;
   if (static_schedule) {
       /* Blocks per thread */
@@ -2807,7 +2798,7 @@ static void t_blosc_do_job(void *ctxt)
         // If memcpyed we don't have a bstarts section (because it is not needed)
         int32_t src_offset = memcpyed ?
             context->header_overhead + nblock_ * blocksize : sw32_(bstarts + nblock_);
-        cbytes = blosc_d(thcontext, bsize, leftoverblock,
+        cbytes = blosc_d(thcontext, bsize, leftoverblock, memcpyed,
                           src, srcsize, src_offset, nblock_,
                           dest, nblock_ * blocksize, tmp, tmp2);
       }
@@ -3479,7 +3470,7 @@ int blosc2_chunk_zeros(const size_t nbytes, const size_t typesize, void* dest, s
   header.flags = BLOSC_DOSHUFFLE | BLOSC_DOBITSHUFFLE;  // extended header
   header.typesize = (uint8_t)typesize;
   header.nbytes = (int32_t)nbytes;
-  header.blocksize = (int32_t)nbytes;
+  header.blocksize = 4 * 4096;
   header.cbytes = BLOSC_EXTENDED_HEADER_LENGTH;
   header.blosc2_flags = BLOSC2_ZERO_RUNLEN << 4;  // mark chunk as all zeros
 
@@ -3514,7 +3505,7 @@ int blosc2_chunk_nans(const size_t nbytes, const size_t typesize, void* dest, si
   header.flags = BLOSC_DOSHUFFLE | BLOSC_DOBITSHUFFLE;  // extended header
   header.typesize = (uint8_t)typesize;
   header.nbytes = (int32_t)nbytes;
-  header.blocksize = (int32_t)nbytes;
+  header.blocksize = 4096;
   header.cbytes = BLOSC_EXTENDED_HEADER_LENGTH;
   header.blosc2_flags = BLOSC2_NAN_RUNLEN << 4;  // mark chunk as all NaNs
 
@@ -3550,7 +3541,7 @@ int blosc2_chunk_repeatval(const size_t nbytes, const size_t typesize, void* des
   header.flags = BLOSC_DOSHUFFLE | BLOSC_DOBITSHUFFLE;  // extended header
   header.typesize = (uint8_t)typesize;
   header.nbytes = (int32_t)nbytes;
-  header.blocksize = (int32_t)nbytes;
+  header.blocksize = 4096;
   header.cbytes = BLOSC_EXTENDED_HEADER_LENGTH + (int32_t)typesize;
   header.blosc2_flags = BLOSC2_VALUE_RUNLEN << 4;  // mark chunk as all repeated value
 

--- a/blosc/blosc2.c
+++ b/blosc/blosc2.c
@@ -1225,6 +1225,7 @@ int pipeline_d(struct thread_context* thread_context, const int32_t bsize, uint8
 
 
 int32_t set_nans(int32_t typesize, uint8_t* dest, int32_t destsize) {
+  // destsize can only be a multiple of typesize
   if (destsize % typesize != 0) {
     return -1;
   }
@@ -1256,6 +1257,16 @@ int32_t set_nans(int32_t typesize, uint8_t* dest, int32_t destsize) {
 
 
 int32_t set_values(int32_t typesize, const uint8_t* src, uint8_t* dest, int32_t destsize) {
+  // destsize can only be a multiple of typesize
+  int64_t val8;
+  int64_t* dest8;
+  int32_t val4;
+  int32_t* dest4;
+  int16_t val2;
+  int16_t* dest2;
+  int8_t val1;
+  int8_t* dest1;
+
   if (destsize % typesize != 0) {
     return -1;
   }
@@ -1264,32 +1275,31 @@ int32_t set_values(int32_t typesize, const uint8_t* src, uint8_t* dest, int32_t 
     return 0;
   }
 
-  // Copy the value of the repeated value to dest
-  int64_t val8 = ((int64_t*)(src + BLOSC_EXTENDED_HEADER_LENGTH))[0];
-  int64_t* dest8 = (int64_t*)dest;
-  int32_t val4 = ((int32_t*)(src + BLOSC_EXTENDED_HEADER_LENGTH))[0];
-  int32_t* dest4 = (int32_t*)dest;
-  int16_t val2 = ((int16_t*)(src + BLOSC_EXTENDED_HEADER_LENGTH))[0];
-  int16_t* dest2 = (int16_t*)dest;
-  int8_t val1 = ((int8_t*)(src + BLOSC_EXTENDED_HEADER_LENGTH))[0];
-  int8_t* dest1 = (int8_t*)dest;
   switch (typesize) {
     case 8:
+      val8 = ((int64_t*)(src + BLOSC_EXTENDED_HEADER_LENGTH))[0];
+      dest8 = (int64_t*)dest;
       for (int i = 0; i < nitems; i++) {
         dest8[i] = val8;
       }
       break;
     case 4:
+      val4 = ((int32_t*)(src + BLOSC_EXTENDED_HEADER_LENGTH))[0];
+      dest4 = (int32_t*)dest;
       for (int i = 0; i < nitems; i++) {
         dest4[i] = val4;
       }
       break;
     case 2:
+      val2 = ((int16_t*)(src + BLOSC_EXTENDED_HEADER_LENGTH))[0];
+      dest2 = (int16_t*)dest;
       for (int i = 0; i < nitems; i++) {
         dest2[i] = val2;
       }
       break;
     case 1:
+      val1 = ((int8_t*)(src + BLOSC_EXTENDED_HEADER_LENGTH))[0];
+      dest1 = (int8_t*)dest;
       for (int i = 0; i < nitems; i++) {
         dest1[i] = val1;
       }

--- a/blosc/blosc2.c
+++ b/blosc/blosc2.c
@@ -1225,9 +1225,10 @@ int pipeline_d(struct thread_context* thread_context, const int32_t bsize, uint8
 
 
 int32_t set_nans(int32_t typesize, uint8_t* dest, int32_t destsize) {
+  // destsize can only be a multiple of typesize (by construction)
   int32_t nitems = destsize / typesize;
-  if (nitems > destsize / typesize) {
-    nitems = destsize / typesize;
+  if (nitems == 0) {
+    return 0;
   }
 
   if (typesize == 4) {
@@ -1253,9 +1254,10 @@ int32_t set_nans(int32_t typesize, uint8_t* dest, int32_t destsize) {
 
 
 int32_t set_values(int32_t typesize, const uint8_t* src, uint8_t* dest, int32_t destsize) {
+  // destsize can only be a multiple of typesize (by construction)
   int32_t nitems = destsize / typesize;
-  if (nitems > destsize / typesize) {
-    nitems = destsize / typesize;
+  if (nitems == 0) {
+    return 0;
   }
 
   // Copy the value of the repeated value to dest

--- a/blosc/context.h
+++ b/blosc/context.h
@@ -61,6 +61,8 @@ struct blosc2_context_s {
   /* Type size */
   int32_t* bstarts;
   /* Starts for every block inside the compressed buffer */
+  int32_t runlen_type;
+  /* Run-length type for chunk.  0 if not run-length */
   int compcode;
   /* Compressor code to use */
   int clevel;

--- a/tests/test_postfilter.c
+++ b/tests/test_postfilter.c
@@ -40,7 +40,7 @@ int init_data(void) {
 
   /* Initialize inputs */
   for (int i = 0; i < SIZE; i++) {
-    data[i] = data_cnt ? 1 : i;
+    data[i] = data_cnt ? 0 : i;  // important to have a zero here for testing special chunks!
     data2[i] = data_cnt ? 2 : i * 2;
   }
 
@@ -242,10 +242,13 @@ static char *all_tests(void) {
   cparams.nthreads = NTHREADS;
   dparams.nthreads = 1;
   mu_run_test(test_postfilter2);
+
+  // Activate special chunks from now on
+  data_cnt = true;
+
   cparams.clevel = 5;
   cparams.nthreads = 1;
-  data_cnt = true;
-  mu_run_test(test_postfilter2);
+  mu_run_test(test_postfilter0);
   cparams.clevel = 9;
   cparams.nthreads = NTHREADS;
   mu_run_test(test_postfilter2);
@@ -254,7 +257,6 @@ static char *all_tests(void) {
   cparams.clevel = 9;
   cparams.nthreads = 1;
   dparams.nthreads = 1;
-  data_cnt = true;
   cparams.filters[BLOSC2_MAX_FILTERS - 1] = BLOSC_NOSHUFFLE;
   mu_run_test(test_postfilter0);
 

--- a/tests/test_sframe_lazychunk.c
+++ b/tests/test_sframe_lazychunk.c
@@ -44,7 +44,12 @@ static char* test_lazy_chunk(void) {
   cparams.blocksize = BLOCKSIZE * cparams.typesize;
   dparams.nthreads = nthreads;
   blosc2_storage storage = {.contiguous=false, .urlpath=directory, .cparams=&cparams, .dparams=&dparams};
+  blosc2_remove_dir(storage.urlpath);
   schunk = blosc2_schunk_new(&storage);
+  if (schunk == NULL) {
+    printf("ERROR: cannot create sframe: %s\n", directory);
+    return "";
+  }
 
   // Feed it with data
   for (int nchunk = 0; nchunk < nchunks; nchunk++) {

--- a/tests/test_zero_runlen.c
+++ b/tests/test_zero_runlen.c
@@ -195,9 +195,7 @@ CUTEST_TEST_TEST(zero_runlen) {
   /* Free resources */
   free(data_buffer);
   free(rec_buffer);
-  /* Destroy the super-chunk */
   blosc2_schunk_free(schunk);
-  /* Destroy the Blosc environment */
 
   /* Free resources */
   if (backend.urlpath != NULL && backend.contiguous == false) {


### PR DESCRIPTION
This fixes the execution of postfilters even when special chunks (zeros, constants, NaNs) are present.