### PR TITLE
Added max blocksize with check for 32-bit context allocation

### DIFF
--- a/blosc/blosc2.c
+++ b/blosc/blosc2.c
@@ -696,6 +696,10 @@ int blosc_read_header(const uint8_t* src, int32_t srcsize, bool extended_header,
     BLOSC_TRACE_ERROR("`blocksize` is zero or greater than uncompressed size");
     return BLOSC2_ERROR_INVALID_HEADER;
   }
+  if (header->blocksize > BLOSC2_MAXBLOCKSIZE) {
+    BLOSC_TRACE_ERROR("`blocksize` greater than maximum allowed");
+    return BLOSC2_ERROR_INVALID_HEADER;
+  }
   if (header->typesize <= 0 || header->typesize > BLOSC_MAX_TYPESIZE) {
     BLOSC_TRACE_ERROR("`typesize` is zero or greater than max allowed.");
     return BLOSC2_ERROR_INVALID_HEADER;

--- a/blosc/blosc2.h
+++ b/blosc/blosc2.h
@@ -110,7 +110,7 @@ enum {
   BLOSC_BITSHUFFLE = 2,  //!< bit-wise shuffle
   BLOSC_DELTA = 3,       //!< delta filter
   BLOSC_TRUNC_PREC = 4,  //!< truncate precision filter
-  BLOSC_LAST_FILTER= 5,  //!< sentinel
+  BLOSC_LAST_FILTER = 5,  //!< sentinel
 };
 
 enum {
@@ -223,27 +223,27 @@ enum {
  * @brief Offsets for fields in Blosc2 chunk header
  */
 enum {
-    BLOSC2_CHUNK_VERSION = 0x0,       //!< the version for the chunk format
-    BLOSC2_CHUNK_VERSIONLZ = 0x1,     //!< the version for the format of internal codec
-    BLOSC2_CHUNK_FLAGS = 0x2,         //!< flags and codec info
-    BLOSC2_CHUNK_TYPESIZE = 0x3,      //!< (uint8) the number of bytes of the atomic type
-    BLOSC2_CHUNK_NBYTES = 0x4,        //!< (int32) uncompressed size of the buffer (this header is not included)
-    BLOSC2_CHUNK_BLOCKSIZE = 0x8,     //!< (int32) size of internal blocks
-    BLOSC2_CHUNK_CBYTES = 0xc,        //!< (int32) compressed size of the buffer (including this header)
-    BLOSC2_CHUNK_FILTER_CODES = 0x10, //!< the codecs for the filter pipeline (1 byte per code)
-    BLOSC2_CHUNK_FILTER_META = 0x18,  //!< meta info for the filter pipeline (1 byte per code)
-    BLOSC2_CHUNK_BLOSC2_FLAGS = 0x1F, //!< flags specific for Blosc2 functionality
+  BLOSC2_CHUNK_VERSION = 0x0,       //!< the version for the chunk format
+  BLOSC2_CHUNK_VERSIONLZ = 0x1,     //!< the version for the format of internal codec
+  BLOSC2_CHUNK_FLAGS = 0x2,         //!< flags and codec info
+  BLOSC2_CHUNK_TYPESIZE = 0x3,      //!< (uint8) the number of bytes of the atomic type
+  BLOSC2_CHUNK_NBYTES = 0x4,        //!< (int32) uncompressed size of the buffer (this header is not included)
+  BLOSC2_CHUNK_BLOCKSIZE = 0x8,     //!< (int32) size of internal blocks
+  BLOSC2_CHUNK_CBYTES = 0xc,        //!< (int32) compressed size of the buffer (including this header)
+  BLOSC2_CHUNK_FILTER_CODES = 0x10, //!< the codecs for the filter pipeline (1 byte per code)
+  BLOSC2_CHUNK_FILTER_META = 0x18,  //!< meta info for the filter pipeline (1 byte per code)
+  BLOSC2_CHUNK_BLOSC2_FLAGS = 0x1F, //!< flags specific for Blosc2 functionality
 };
 
 /**
  * @brief Run lengths for special values for chunks/frames
  */
 enum {
-    BLOSC2_NO_RUNLEN = 0x0,       //!< no run-length
-    BLOSC2_ZERO_RUNLEN = 0x1,     //!< zero run-length
-    BLOSC2_NAN_RUNLEN = 0x2,      //!< NaN run-length
-    BLOSC2_VALUE_RUNLEN = 0x3,    //!< generic value run-length
-    BLOSC2_RUNLEN_MASK = 0x3      //!< run-length value mask
+  BLOSC2_NO_RUNLEN = 0x0,       //!< no run-length
+  BLOSC2_ZERO_RUNLEN = 0x1,     //!< zero run-length
+  BLOSC2_NAN_RUNLEN = 0x2,      //!< NaN run-length
+  BLOSC2_VALUE_RUNLEN = 0x3,    //!< generic value run-length
+  BLOSC2_RUNLEN_MASK = 0x3      //!< run-length value mask
 };
 
 /**
@@ -278,7 +278,6 @@ enum {
   BLOSC2_ERROR_FILE_TRUNCATE = -25,   //!< File truncate failure
   BLOSC2_ERROR_THREAD_CREATE = -26,   //!< Thread or thread context creation failure
   BLOSC2_ERROR_POSTFILTER = -27,      //!< Postfilter failure
-
 };
 
 /**

--- a/blosc/blosc2.h
+++ b/blosc/blosc2.h
@@ -141,6 +141,7 @@ enum {
  */
 enum {
   BLOSC2_MAXDICTSIZE = 128 * 1024, //!< maximum size for compression dicts
+  BLOSC2_MAXBLOCKSIZE = 536866816  //!< maximum size for blocks
 };
 
 /**


### PR DESCRIPTION
> Added maximum block size to prevent context tmp buffer from overflowing in 4 * ebsize calculation. Maximum size is 512mb - 4k which is closest in value to (INT32_MAX / 4) - (BLOSC_MAX_TYPESIZE * sizeof(int32_t)). This allows 32-bit apps to allocate enough memory without tmp_nbytes overflowing during context creation.

Should solve `clusterfuzz-testcase-decompress_frame_fuzzer-4516447050137600` and probably some others.