### PR TITLE
Let decompress an empty array

### DIFF
--- a/blosc/blosc2.c
+++ b/blosc/blosc2.c
@@ -692,7 +692,7 @@ int read_chunk_header(const uint8_t* src, int32_t srcsize, bool extended_header,
     BLOSC_TRACE_ERROR("`cbytes` is too small to read min header.");
     return BLOSC2_ERROR_INVALID_HEADER;
   }
-  if (header->blocksize <= 0 || header->blocksize > header->nbytes) {
+  if (header->blocksize <= 0 || (header->nbytes > 0 && (header->blocksize > header->nbytes))) {
     BLOSC_TRACE_ERROR("`blocksize` is zero or greater than uncompressed size");
     return BLOSC2_ERROR_INVALID_HEADER;
   }

--- a/blosc/blosc2.h
+++ b/blosc/blosc2.h
@@ -368,7 +368,7 @@ BLOSC_EXPORT int blosc_compress(int clevel, int doshuffle, size_t typesize,
  *
  * @return The number of bytes decompressed.
  * If an error occurs, e.g. the compressed data is corrupted or the
- * output buffer is not large enough, then 0 (zero) or a negative value
+ * output buffer is not large enough, then a negative value
  * will be returned instead.
  *
  * This function supports all the configuration based environment variables
@@ -947,7 +947,7 @@ BLOSC_EXPORT int blosc2_compress(int clevel, int doshuffle, int32_t typesize,
  *
  * @return The number of bytes decompressed.
  * If an error occurs, e.g. the compressed data is corrupted or the
- * output buffer is not large enough, then 0 (zero) or a negative value
+ * output buffer is not large enough, then a negative value
  * will be returned instead.
 */
 /*
@@ -1025,7 +1025,7 @@ BLOSC_EXPORT int blosc2_compress_ctx(
  * @return The number of bytes decompressed (i.e. the maskout blocks are not
  * counted). If an error occurs, e.g. the compressed data is corrupted,
  * @p destsize is not large enough or context is not meant for decompression,
- * then 0 (zero) or a negative value will be returned instead.
+ * then a negative value will be returned instead.
  */
 BLOSC_EXPORT int blosc2_decompress_ctx(blosc2_context* context, const void* src,
                                        int32_t srcsize, void* dest, int32_t destsize);

--- a/tests/test_empty_buffer.c
+++ b/tests/test_empty_buffer.c
@@ -1,0 +1,49 @@
+/*********************************************************************
+  Blosc - Blocked Shuffling and Compression Library
+
+  Unit tests for the blosc_decompress() function.
+
+  Creation date: 2010-06-07
+  Author: The Blosc Developers <blosc@blosc.org>
+
+  See LICENSE.txt for details about copyright and rights to use.
+**********************************************************************/
+
+#include <stdio.h>
+#include "test_common.h"
+
+/** Test the blosc_decompress function. */
+static char* test_empty_buffer(int clevel, int do_shuffle, int32_t typesize) {
+  void* buf = NULL;
+  int buf_size = 0;
+  int csize, dsize;
+  void* dest = malloc(0 + BLOSC_MAX_OVERHEAD);
+
+  csize = blosc2_compress(clevel, do_shuffle, typesize, buf, buf_size, dest, 0+BLOSC_MAX_OVERHEAD);
+  mu_assert("ERROR: Compression error.", csize > 0);
+
+  void* decomp = NULL;
+  dsize = blosc_decompress(dest, decomp, 0);
+  free(dest);
+  mu_assert("ERROR: in blosc_decompress.", dsize >= 0);
+
+  return EXIT_SUCCESS;
+}
+
+
+int main(void) {
+  /* Initialize blosc before running tests. */
+  blosc_init();
+  char* result = test_empty_buffer(3, BLOSC_NOSHUFFLE, 1);
+  if (result != EXIT_SUCCESS) {
+    printf(" (%s)\n", result);
+  }
+  else {
+    printf(" ALL TESTS PASSED");
+  }
+
+  /* Cleanup blosc resources. */
+  blosc_destroy();
+  return result != EXIT_SUCCESS;
+
+}

--- a/tests/test_postfilter.c
+++ b/tests/test_postfilter.c
@@ -107,7 +107,7 @@ static char *test_postfilter0(void) {
 
   /* Decompress  */
   dsize = blosc2_decompress_ctx(dctx, data_out, csize, data_dest, (size_t)dsize);
-  mu_assert("Decompression error", dsize > 0);
+  mu_assert("Decompression error", dsize >= 0);
 
   for (int i = 0; i < SIZE; i++) {
     mu_assert("Decompressed data differs from original!", data[i] * 2 == data_dest[i]);
@@ -146,7 +146,7 @@ static char *test_postfilter1(void) {
 
   /* Decompress  */
   dsize = blosc2_decompress_ctx(dctx, data_out, csize, data_dest, (size_t)dsize);
-  mu_assert("Decompression error", dsize > 0);
+  mu_assert("Decompression error", dsize >= 0);
 
   for (int i = 0; i < SIZE; i++) {
     mu_assert("Decompressed data differs from original!", data[i] * 3 == data_dest[i]);
@@ -188,7 +188,7 @@ static char *test_postfilter2(void) {
 
   /* Decompress  */
   dsize = blosc2_decompress_ctx(dctx, data_out, csize, data_dest, (size_t)dsize);
-  mu_assert("Decompression error", dsize > 0);
+  mu_assert("Decompression error", dsize >= 0);
 
   for (int i = 0; i < SIZE; i++) {
     if ((data[i] + data2[i]) != data_dest[i]) {

--- a/tests/test_prefilter.c
+++ b/tests/test_prefilter.c
@@ -79,7 +79,7 @@ static char *test_prefilter0(void) {
 
   /* Decompress  */
   dsize = blosc2_decompress_ctx(dctx, data_out, csize, data_dest, (size_t)dsize);
-  mu_assert("Decompression error", dsize > 0);
+  mu_assert("Decompression error", dsize >= 0);
 
   for (int i = 0; i < SIZE; i++) {
     mu_assert("Decompressed data differs from original!", data[i] * 2 == data_dest[i]);
@@ -114,7 +114,7 @@ static char *test_prefilter1(void) {
 
   /* Decompress  */
   dsize = blosc2_decompress_ctx(dctx, data_out, csize, data_dest, (size_t)dsize);
-  mu_assert("Decompression error", dsize > 0);
+  mu_assert("Decompression error", dsize >= 0);
 
   for (int i = 0; i < SIZE; i++) {
     mu_assert("Decompressed data differs from original!", data[i] * 3 == data_dest[i]);
@@ -152,7 +152,7 @@ static char *test_prefilter2(void) {
 
   /* Decompress  */
   dsize = blosc2_decompress_ctx(dctx, data_out, csize, data_dest, (size_t)dsize);
-  mu_assert("Decompression error", dsize > 0);
+  mu_assert("Decompression error", dsize >= 0);
 
   for (int i = 0; i < SIZE; i++) {
     if ((data[i] + data2[i]) != data_dest[i]) {


### PR DESCRIPTION
For python-blosc2 we may want to compress an empty array.
The problem is that `blosc_decompress` returns zero or a negative value if an errors occurs, otherwise it returns the number of bytes decompressed. Which in the case of an empty array would be 0.

If in the python-blosc2 ` decompress `function the 0 return value is ignored when decompressing, empty arrays could be compressed and decompressed... The other solution is to change the function from `blosc2` to only return a negative value when an error occurs.