### PR TITLE
Special chunks

### DIFF
--- a/README_CHUNK_FORMAT.rst
+++ b/README_CHUNK_FORMAT.rst
@@ -142,17 +142,25 @@ for encoding blocks with a filter pipeline::
         or it is in the global `flags` for chunk.
     :bit 3 (``0x08``):
         Whether the chunk is 'lazy' or not.
-    :bits 4 and 5:
-        Indicate run-lengths for the entire chunk.
+    :bits 4, 5 and 6:
+        Indicate special values for the entire chunk.
 
             :``0``:
-                No run.
+                No special values.
             :``1``:
                 A run of zeros.
             :``2``:
                 A run of NaN (Not-a-Number) floats (whether f32 or f64 depends on typesize).
             :``3``:
                 Run-length of a value that follows the header (i.e. no blocks section).
+            :``4``:
+                Values that are not initialized.
+            :``5``:
+                Reserved.
+            :``6``:
+                Reserved.
+            :``7``:
+                Reserved.
 
 
 Blocks

--- a/bench/create_frame.c
+++ b/bench/create_frame.c
@@ -69,7 +69,7 @@ int create_cframe(const char* compname) {
   blosc2_cparams cparams = BLOSC2_CPARAMS_DEFAULTS;
   cparams.typesize = sizeof(int32_t);
   cparams.compcode = compcode;
-  cparams.clevel = 5;
+  cparams.clevel = 9;
   cparams.nthreads = NTHREADS;
   //cparams.blocksize = 1024;
   blosc2_dparams dparams = BLOSC2_DPARAMS_DEFAULTS;
@@ -82,7 +82,7 @@ int create_cframe(const char* compname) {
 
 #ifdef CREATE_ZEROS
   // Precompute chunk of zeros
-  int ret = blosc2_chunk_zeros(isize, sizeof(int32_t), data_dest, isize);
+  int ret = blosc2_chunk_zeros(cparams, isize, data_dest, isize);
   if (ret < 0) {
     printf("Compression error in chunk_zeros.  Error code: %d\n", ret);
     return ret;

--- a/bench/zero_runlen.c
+++ b/bench/zero_runlen.c
@@ -21,7 +21,7 @@
 
 #define NCHUNKS (2000)
 #define CHUNKSIZE (500 * 1000)  // > NCHUNKS for the bench purposes
-#define NTHREADS 4
+#define NTHREADS 8
 
 enum {
   ZERO_DETECTION = 0,
@@ -70,13 +70,13 @@ int check_special_values(int svalue) {
         csize = blosc2_compress(5, 1, sizeof(int32_t), data_buffer, isize, chunk, osize);
         break;
       case CHECK_ZEROS:
-        csize = blosc2_chunk_zeros(isize, sizeof(int32_t), chunk, BLOSC_EXTENDED_HEADER_LENGTH);
+        csize = blosc2_chunk_zeros(cparams, isize, chunk, BLOSC_EXTENDED_HEADER_LENGTH);
         break;
       case CHECK_NANS:
-        csize = blosc2_chunk_nans(isize, sizeof(float), chunk, BLOSC_EXTENDED_HEADER_LENGTH);
+        csize = blosc2_chunk_nans(cparams, isize, chunk, BLOSC_EXTENDED_HEADER_LENGTH);
         break;
       case CHECK_VALUES:
-        csize = blosc2_chunk_repeatval(isize, sizeof(int32_t), chunk,
+        csize = blosc2_chunk_repeatval(cparams, isize, chunk,
                                        BLOSC_EXTENDED_HEADER_LENGTH + sizeof(int32_t), &value);
         break;
       default:
@@ -235,12 +235,12 @@ int main(void) {
   if (rc < 0) {
     return rc;
   }
-  printf("*** Testing special NaNs...");
+  printf("*** Testing NaNs...");
   rc = check_special_values(CHECK_NANS);
   if (rc < 0) {
     return rc;
   }
-  printf("*** Testing special values...");
+  printf("*** Testing repeated values...");
   rc = check_special_values(CHECK_VALUES);
   if (rc < 0) {
     return rc;

--- a/blosc/blosc2.c
+++ b/blosc/blosc2.c
@@ -3540,6 +3540,8 @@ int blosc2_chunk_zeros(blosc2_cparams cparams, const size_t nbytes, void* dest, 
 
   memcpy((uint8_t *)dest, &header, sizeof(header));
 
+  blosc2_free_ctx(context);
+
   return BLOSC_EXTENDED_HEADER_LENGTH;
 }
 
@@ -3571,6 +3573,8 @@ int blosc2_chunk_uninit(blosc2_cparams cparams, const size_t nbytes, void* dest,
 
   memcpy((uint8_t *)dest, &header, sizeof(header));
 
+  blosc2_free_ctx(context);
+
   return BLOSC_EXTENDED_HEADER_LENGTH;
 }
 
@@ -3601,6 +3605,8 @@ int blosc2_chunk_nans(blosc2_cparams cparams, const size_t nbytes, void* dest, s
   header.blosc2_flags = BLOSC2_NAN_RUNLEN << 4;  // mark chunk as all NaNs
 
   memcpy((uint8_t *)dest, &header, sizeof(header));
+
+  blosc2_free_ctx(context);
 
   return BLOSC_EXTENDED_HEADER_LENGTH;
 }
@@ -3640,6 +3646,8 @@ int blosc2_chunk_repeatval(blosc2_cparams cparams, const size_t nbytes,
 
   memcpy((uint8_t *)dest, &header, sizeof(header));
   memcpy((uint8_t *)dest + sizeof(header), repeatval, typesize);
+
+  blosc2_free_ctx(context);
 
   return BLOSC_EXTENDED_HEADER_LENGTH + (uint8_t)typesize;
 }

--- a/blosc/blosc2.c
+++ b/blosc/blosc2.c
@@ -1979,7 +1979,8 @@ static int initialize_context_decompression(blosc2_context* context, blosc_heade
     return BLOSC2_ERROR_DATA;
   }
 
-  if ((srcsize == context->header_overhead) && !context->special_type) {
+  if ((header->nbytes == 0) && (header->cbytes == context->header_overhead) &&
+      !context->special_type) {
     // A compressed buffer with only a header can only contain a zero-length buffer
     return 0;
   }

--- a/blosc/blosc2.c
+++ b/blosc/blosc2.c
@@ -665,7 +665,7 @@ typedef struct blosc_header_s {
 } blosc_header;
 
 
-int blosc_read_header(const uint8_t* src, int32_t srcsize, bool extended_header, blosc_header* header)
+int read_chunk_header(const uint8_t* src, int32_t srcsize, bool extended_header, blosc_header* header)
 {
   memset(header, 0, sizeof(blosc_header));
 
@@ -2470,7 +2470,7 @@ int blosc_run_decompression_with_context(blosc2_context* context, const void* sr
   uint8_t* _src = (uint8_t*)src;
   int rc;
 
-  rc = blosc_read_header(src, srcsize, true, &header);
+  rc = read_chunk_header(src, srcsize, true, &header);
   if (rc < 0) {
     return rc;
   }
@@ -2716,7 +2716,7 @@ int blosc2_getitem_ctx(blosc2_context* context, const void* src, int32_t srcsize
   int result;
 
   /* Minimally populate the context */
-  result = blosc_read_header((uint8_t *)src, srcsize, true, &header);
+  result = read_chunk_header((uint8_t *) src, srcsize, true, &header);
   if (result < 0) {
     return result;
   }
@@ -3184,7 +3184,7 @@ void blosc_cbuffer_sizes(const void* cbuffer, size_t* nbytes, size_t* cbytes, si
 
 int blosc2_cbuffer_sizes(const void* cbuffer, int32_t* nbytes, int32_t* cbytes, int32_t* blocksize) {
   blosc_header header;
-  int rc = blosc_read_header((uint8_t*)cbuffer, BLOSC_MIN_HEADER_LENGTH, false, &header);
+  int rc = read_chunk_header((uint8_t *) cbuffer, BLOSC_MIN_HEADER_LENGTH, false, &header);
   if (rc < 0) {
     /* Return zeros if error reading header */
     memset(&header, 0, sizeof(header));
@@ -3230,7 +3230,7 @@ int blosc_cbuffer_validate(const void* cbuffer, size_t cbytes, size_t* nbytes) {
 /* Return `typesize` and `flags` from a compressed buffer. */
 void blosc_cbuffer_metainfo(const void* cbuffer, size_t* typesize, int* flags) {
   blosc_header header;
-  int rc = blosc_read_header((uint8_t*)cbuffer, BLOSC_MIN_HEADER_LENGTH, false, &header);
+  int rc = read_chunk_header((uint8_t *) cbuffer, BLOSC_MIN_HEADER_LENGTH, false, &header);
   if (rc < 0) {
     *typesize = *flags = 0;
     return;
@@ -3245,7 +3245,7 @@ void blosc_cbuffer_metainfo(const void* cbuffer, size_t* typesize, int* flags) {
 /* Return version information from a compressed buffer. */
 void blosc_cbuffer_versions(const void* cbuffer, int* version, int* versionlz) {
   blosc_header header;
-  int rc = blosc_read_header((uint8_t*)cbuffer, BLOSC_MIN_HEADER_LENGTH, false, &header);
+  int rc = read_chunk_header((uint8_t *) cbuffer, BLOSC_MIN_HEADER_LENGTH, false, &header);
   if (rc < 0) {
     *version = *versionlz = 0;
     return;
@@ -3262,7 +3262,7 @@ const char* blosc_cbuffer_complib(const void* cbuffer) {
   blosc_header header;
   int clibcode;
   const char* complib;
-  int rc = blosc_read_header((uint8_t*)cbuffer, BLOSC_MIN_HEADER_LENGTH, false, &header);
+  int rc = read_chunk_header((uint8_t *) cbuffer, BLOSC_MIN_HEADER_LENGTH, false, &header);
   if (rc < 0) {
     return NULL;
   }

--- a/blosc/blosc2.c
+++ b/blosc/blosc2.c
@@ -1973,8 +1973,8 @@ static int initialize_context_decompression(blosc2_context* context, blosc_heade
     return BLOSC2_ERROR_DATA;
   }
 
-  int memcpy = (context->header_flags & (uint8_t) BLOSC_MEMCPYED);
-  if (memcpy && (header->cbytes != header->nbytes + context->header_overhead)) {
+  int memcpyed = (context->header_flags & (uint8_t) BLOSC_MEMCPYED);
+  if (memcpyed && (header->cbytes != header->nbytes + context->header_overhead)) {
     BLOSC_TRACE_ERROR("Wrong header info for this memcpyed chunk");
     return BLOSC2_ERROR_DATA;
   }
@@ -1987,8 +1987,8 @@ static int initialize_context_decompression(blosc2_context* context, blosc_heade
 
   context->bstarts = (int32_t *) (context->src + context->header_overhead);
   bstarts_end = context->header_overhead;
-  if (!context->special_type && !memcpy) {
-    /* If chunk is not special or a memcpy, we do have a bstarts section */
+  if (!context->special_type && !memcpyed) {
+    /* If chunk is not special or a memcpyed, we do have a bstarts section */
     bstarts_end = context->header_overhead + (context->nblocks * sizeof(int32_t));
   }
 

--- a/blosc/blosc2.h
+++ b/blosc/blosc2.h
@@ -376,58 +376,6 @@ BLOSC_EXPORT int blosc_decompress(const void* src, void* dest, size_t destsize);
 
 
 /**
- * @brief Create a chunk made of zeros.
- *
- * @param nbytes The size (in bytes) of the chunk.
- * @param typesize The size (in bytes) of the type.
- * @param dest The buffer where the data chunk will be put.
- * @param destsize The size (in bytes) of the @p dest buffer;
- * must be BLOSC_EXTENDED_HEADER_LENGTH at least.
- *
- * @return The number of bytes compressed (BLOSC_EXTENDED_HEADER_LENGTH).
- * If negative, there has been an error and @dest is unusable.
- * */
-BLOSC_EXPORT int blosc2_chunk_zeros(size_t nbytes, size_t typesize,
-                                    void* dest, size_t destsize);
-
-
-/**
- * @brief Create a chunk made of nans.
- *
- * @param nbytes The size (in bytes) of the chunk.
- * @param typesize The size (in bytes) of the type;
- * only 4 bytes (float) and 8 bytes (double) are supported.
- * @param dest The buffer where the data chunk will be put.
- * @param destsize The size (in bytes) of the @p dest buffer;
- * must be BLOSC_EXTENDED_HEADER_LENGTH at least.
- *
- * @note Whether the NaNs are floats or doubles will be given by the typesize.
- *
- * @return The number of bytes compressed (BLOSC_EXTENDED_HEADER_LENGTH).
- * If negative, there has been an error and @dest is unusable.
- * */
-BLOSC_EXPORT int blosc2_chunk_nans(size_t nbytes, size_t typesize,
-                                   void* dest, size_t destsize);
-
-
-/**
- * @brief Create a chunk made of repeated values.
- *
- * @param nbytes The size (in bytes) of the chunk.
- * @param typesize The size (in bytes) of the type.
- * @param dest The buffer where the data chunk will be put.
- * @param destsize The size (in bytes) of the @p dest buffer.
- * @param repeatval A pointer to the repeated value (little endian).
- * The size of the value is given by @p typesize param.
- *
- * @return The number of bytes compressed (BLOSC_EXTENDED_HEADER_LENGTH + typesize).
- * If negative, there has been an error and @dest is unusable.
- * */
-BLOSC_EXPORT int blosc2_chunk_repeatval(size_t nbytes, size_t typesize,
-                                        void* dest, size_t destsize, void* repeatval);
-
-
-/**
  * @brief Get @p nitems (of @p typesize size) in @p src buffer starting in @p start.
  * The items are returned in @p dest buffer, which has to have enough
  * space for storing all items.
@@ -1079,6 +1027,58 @@ BLOSC_EXPORT int blosc2_compress_ctx(
  */
 BLOSC_EXPORT int blosc2_decompress_ctx(blosc2_context* context, const void* src,
                                        int32_t srcsize, void* dest, int32_t destsize);
+
+/**
+ * @brief Create a chunk made of zeros.
+ *
+ * @param nbytes The size (in bytes) of the chunk.
+ * @param typesize The size (in bytes) of the type.
+ * @param dest The buffer where the data chunk will be put.
+ * @param destsize The size (in bytes) of the @p dest buffer;
+ * must be BLOSC_EXTENDED_HEADER_LENGTH at least.
+ *
+ * @return The number of bytes compressed (BLOSC_EXTENDED_HEADER_LENGTH).
+ * If negative, there has been an error and @dest is unusable.
+ * */
+BLOSC_EXPORT int blosc2_chunk_zeros(blosc2_cparams cparams, size_t nbytes,
+                                    void* dest, size_t destsize);
+
+
+/**
+ * @brief Create a chunk made of nans.
+ *
+ * @param nbytes The size (in bytes) of the chunk.
+ * @param typesize The size (in bytes) of the type;
+ * only 4 bytes (float) and 8 bytes (double) are supported.
+ * @param dest The buffer where the data chunk will be put.
+ * @param destsize The size (in bytes) of the @p dest buffer;
+ * must be BLOSC_EXTENDED_HEADER_LENGTH at least.
+ *
+ * @note Whether the NaNs are floats or doubles will be given by the typesize.
+ *
+ * @return The number of bytes compressed (BLOSC_EXTENDED_HEADER_LENGTH).
+ * If negative, there has been an error and @dest is unusable.
+ * */
+BLOSC_EXPORT int blosc2_chunk_nans(blosc2_cparams cparams, size_t nbytes,
+                                   void* dest, size_t destsize);
+
+
+/**
+ * @brief Create a chunk made of repeated values.
+ *
+ * @param nbytes The size (in bytes) of the chunk.
+ * @param typesize The size (in bytes) of the type.
+ * @param dest The buffer where the data chunk will be put.
+ * @param destsize The size (in bytes) of the @p dest buffer.
+ * @param repeatval A pointer to the repeated value (little endian).
+ * The size of the value is given by @p typesize param.
+ *
+ * @return The number of bytes compressed (BLOSC_EXTENDED_HEADER_LENGTH + typesize).
+ * If negative, there has been an error and @dest is unusable.
+ * */
+BLOSC_EXPORT int blosc2_chunk_repeatval(blosc2_cparams cparams, size_t nbytes,
+                                        void* dest, size_t destsize, void* repeatval);
+
 
 /**
  * @brief Context interface counterpart for #blosc_getitem.

--- a/blosc/blosc2.h
+++ b/blosc/blosc2.h
@@ -244,6 +244,7 @@ enum {
   BLOSC2_NAN_RUNLEN = 0x2,      //!< NaN run-length
   BLOSC2_VALUE_RUNLEN = 0x3,    //!< generic value run-length
   BLOSC2_UNINIT_VALUE = 0x4,    //!< non initialized values
+  BLOSC2_SPECIAL_LASTID = 0x4,  //!<last valid ID for special value (update this adequately)
   BLOSC2_SPECIAL_MASK = 0x7     //!< special value mask (prev IDs cannot be larger than this)
 };
 

--- a/blosc/blosc2.h
+++ b/blosc/blosc2.h
@@ -239,11 +239,12 @@ enum {
  * @brief Run lengths for special values for chunks/frames
  */
 enum {
-  BLOSC2_NO_RUNLEN = 0x0,       //!< no run-length
+  BLOSC2_NO_SPECIAL = 0x0,      //!< no run-length
   BLOSC2_ZERO_RUNLEN = 0x1,     //!< zero run-length
   BLOSC2_NAN_RUNLEN = 0x2,      //!< NaN run-length
   BLOSC2_VALUE_RUNLEN = 0x3,    //!< generic value run-length
-  BLOSC2_RUNLEN_MASK = 0x3      //!< run-length value mask
+  BLOSC2_UNINIT_VALUE = 0x4,    //!< non initialized values
+  BLOSC2_SPECIAL_MASK = 0x7     //!< special value mask (prev IDs cannot be larger than this)
 };
 
 /**
@@ -1078,6 +1079,22 @@ BLOSC_EXPORT int blosc2_chunk_nans(blosc2_cparams cparams, size_t nbytes,
  * */
 BLOSC_EXPORT int blosc2_chunk_repeatval(blosc2_cparams cparams, size_t nbytes,
                                         void* dest, size_t destsize, void* repeatval);
+
+
+/**
+ * @brief Create a chunk made of uninitialized values.
+ *
+ * @param cparams The compression parameters.
+ * @param nbytes The size (in bytes) of the chunk.
+ * @param dest The buffer where the data chunk will be put.
+ * @param destsize The size (in bytes) of the @p dest buffer;
+ * must be BLOSC_EXTENDED_HEADER_LENGTH at least.
+ *
+ * @return The number of bytes compressed (BLOSC_EXTENDED_HEADER_LENGTH).
+ * If negative, there has been an error and @dest is unusable.
+ * */
+BLOSC_EXPORT int blosc2_chunk_uninit(blosc2_cparams cparams, size_t nbytes,
+                                     void* dest, size_t destsize);
 
 
 /**

--- a/blosc/blosc2.h
+++ b/blosc/blosc2.h
@@ -1031,8 +1031,8 @@ BLOSC_EXPORT int blosc2_decompress_ctx(blosc2_context* context, const void* src,
 /**
  * @brief Create a chunk made of zeros.
  *
+ * @param cparams The compression parameters.
  * @param nbytes The size (in bytes) of the chunk.
- * @param typesize The size (in bytes) of the type.
  * @param dest The buffer where the data chunk will be put.
  * @param destsize The size (in bytes) of the @p dest buffer;
  * must be BLOSC_EXTENDED_HEADER_LENGTH at least.
@@ -1047,9 +1047,9 @@ BLOSC_EXPORT int blosc2_chunk_zeros(blosc2_cparams cparams, size_t nbytes,
 /**
  * @brief Create a chunk made of nans.
  *
- * @param nbytes The size (in bytes) of the chunk.
- * @param typesize The size (in bytes) of the type;
+ * @param cparams The compression parameters;
  * only 4 bytes (float) and 8 bytes (double) are supported.
+ * @param nbytes The size (in bytes) of the chunk.
  * @param dest The buffer where the data chunk will be put.
  * @param destsize The size (in bytes) of the @p dest buffer;
  * must be BLOSC_EXTENDED_HEADER_LENGTH at least.
@@ -1066,8 +1066,8 @@ BLOSC_EXPORT int blosc2_chunk_nans(blosc2_cparams cparams, size_t nbytes,
 /**
  * @brief Create a chunk made of repeated values.
  *
+ * @param cparams The compression parameters.
  * @param nbytes The size (in bytes) of the chunk.
- * @param typesize The size (in bytes) of the type.
  * @param dest The buffer where the data chunk will be put.
  * @param destsize The size (in bytes) of the @p dest buffer.
  * @param repeatval A pointer to the repeated value (little endian).

--- a/blosc/context.h
+++ b/blosc/context.h
@@ -61,8 +61,8 @@ struct blosc2_context_s {
   /* Type size */
   int32_t* bstarts;
   /* Starts for every block inside the compressed buffer */
-  int32_t runlen_type;
-  /* Run-length type for chunk.  0 if not run-length */
+  int32_t special_type;
+  /* Special type for chunk.  0 if not special. */
   int compcode;
   /* Compressor code to use */
   int clevel;

--- a/blosc/schunk.c
+++ b/blosc/schunk.c
@@ -494,10 +494,11 @@ int blosc2_schunk_append_chunk(blosc2_schunk *schunk, uint8_t *chunk, bool copy)
     schunk->cbytes += chunk_cbytes;
   } else {
     // A frame
-    int special_value = (chunk[BLOSC2_CHUNK_BLOSC2_FLAGS] & 0x30) >> 4;
+    int special_value = (chunk[BLOSC2_CHUNK_BLOSC2_FLAGS] >> 4) & BLOSC2_SPECIAL_MASK;
     switch (special_value) {
       case BLOSC2_ZERO_RUNLEN:
       case BLOSC2_NAN_RUNLEN:
+      case BLOSC2_UNINIT_VALUE:
         schunk->cbytes += 0;
         break;
       default:
@@ -582,10 +583,11 @@ int blosc2_schunk_insert_chunk(blosc2_schunk *schunk, int nchunk, uint8_t *chunk
     schunk->cbytes += chunk_cbytes;
   } else {
     // A frame
-    int special_value = (chunk[BLOSC2_CHUNK_BLOSC2_FLAGS] & 0x30) >> 4;
+    int special_value = (chunk[BLOSC2_CHUNK_BLOSC2_FLAGS] >> 4) & BLOSC2_SPECIAL_MASK;
     switch (special_value) {
       case BLOSC2_ZERO_RUNLEN:
       case BLOSC2_NAN_RUNLEN:
+      case BLOSC2_UNINIT_VALUE:
         schunk->cbytes += 0;
         break;
       default:
@@ -707,10 +709,11 @@ int blosc2_schunk_update_chunk(blosc2_schunk *schunk, int nchunk, uint8_t *chunk
     schunk->cbytes -= chunk_cbytes_old;
   } else {
     // A frame
-    int special_value = (chunk[BLOSC2_CHUNK_BLOSC2_FLAGS] & 0x30) >> 4;
+    int special_value = (chunk[BLOSC2_CHUNK_BLOSC2_FLAGS] >> 4) & BLOSC2_SPECIAL_MASK;
     switch (special_value) {
       case BLOSC2_ZERO_RUNLEN:
       case BLOSC2_NAN_RUNLEN:
+      case BLOSC2_UNINIT_VALUE:
         schunk->nbytes += chunk_nbytes;
         schunk->nbytes -= chunk_nbytes_old;
         if (frame->sframe) {

--- a/tests/test_zero_runlen.c
+++ b/tests/test_zero_runlen.c
@@ -108,13 +108,13 @@ CUTEST_TEST_TEST(zero_runlen) {
         csize = blosc2_compress(5, 1, sizeof(int32_t), data_buffer, isize, chunk, osize);
         break;
       case CHECK_ZEROS:
-        csize = blosc2_chunk_zeros(isize, sizeof(int32_t), chunk, BLOSC_EXTENDED_HEADER_LENGTH);
+        csize = blosc2_chunk_zeros(cparams, isize, chunk, BLOSC_EXTENDED_HEADER_LENGTH);
         break;
       case CHECK_NANS:
-        csize = blosc2_chunk_nans(isize, sizeof(float), chunk, BLOSC_EXTENDED_HEADER_LENGTH);
+        csize = blosc2_chunk_nans(cparams, isize, chunk, BLOSC_EXTENDED_HEADER_LENGTH);
         break;
       case CHECK_VALUES:
-        csize = blosc2_chunk_repeatval(isize, sizeof(int32_t), chunk,
+        csize = blosc2_chunk_repeatval(cparams, isize, chunk,
                                        BLOSC_EXTENDED_HEADER_LENGTH + sizeof(int32_t), &value);
         break;
       default:


### PR DESCRIPTION
This introduces a new special chunk for uninitizalized values.  This does not take time to decompress because the data is not copied anyware, and it is meant for quickly creating large super-chunks with uninitialized values.

As bonus, this PR reserves space for 3 additional special values to be used in the future.