### PR TITLE
Fast path for filling with special values

### DIFF
--- a/bench/create_frame.c
+++ b/bench/create_frame.c
@@ -51,6 +51,7 @@ Process finished with exit code 0
 
 // For exercising the optimized zero chunk creators uncomment the line below
 #define CREATE_ZEROS
+#define CREATE_ZEROS_SPECIAL
 
 
 int create_cframe(const char* compname) {
@@ -91,6 +92,14 @@ int create_cframe(const char* compname) {
 
   // Add some data
   blosc_set_timestamp(&last);
+
+#ifdef CREATE_ZEROS_SPECIAL
+  int rc = blosc2_schunk_fill_special(schunk, NCHUNKS * CHUNKSIZE,BLOSC2_ZERO_RUNLEN);
+  if (rc < 0) {
+    printf("Error in fill special.  Error code: %d\n", rc);
+    return rc;
+  }
+#else
   for (nchunk = 0; nchunk < NCHUNKS; nchunk++) {
 #ifdef CREATE_ZEROS
     int nchunks = blosc2_schunk_append_chunk(schunk, (uint8_t *) data_dest, true);
@@ -112,6 +121,7 @@ int create_cframe(const char* compname) {
     }
 #endif
   }
+#endif
   blosc_set_timestamp(&current);
 
   /* Gather some info */

--- a/bench/create_frame.c
+++ b/bench/create_frame.c
@@ -94,8 +94,9 @@ int create_cframe(const char* compname) {
   // Add some data
   blosc_set_timestamp(&last);
 
+  int64_t nitems = (int64_t)NCHUNKS * CHUNKSIZE;
 #ifdef CREATE_ZEROS_SPECIAL
-  int rc = blosc2_schunk_fill_special(schunk, NCHUNKS * CHUNKSIZE,
+  int rc = blosc2_schunk_fill_special(schunk, nitems,
                                       BLOSC2_ZERO_RUNLEN, isize);
   if (rc < 0) {
     printf("Error in fill special.  Error code: %d\n", rc);
@@ -142,6 +143,13 @@ int create_cframe(const char* compname) {
     if (dsize < 0) {
       printf("Decompression error in schunk.  Error code: %d\n", dsize);
       return dsize;
+    }
+    if (nchunk == NCHUNKS - 1) {
+      int32_t leftover_bytes = nitems / CHUNKSIZE;
+      if (leftover_bytes > 0 && dsize != isize) {
+        printf("Wrong size for last chunk.  It is %d and should be: %ld\n", dsize, isize);
+        return dsize;
+      }
     }
   }
   blosc_set_timestamp(&current);

--- a/bench/create_frame.c
+++ b/bench/create_frame.c
@@ -53,7 +53,7 @@ Process finished with exit code 0
 //#define CREATE_ZEROS
 #define CREATE_FILL
 //#define CREATE_LOOP
-#define CONTIGUOUS_FRAME false
+#define CONTIGUOUS_FRAME true
 
 int create_cframe(const char* compname) {
   size_t isize = CHUNKSHAPE * sizeof(int32_t);

--- a/bench/create_frame.c
+++ b/bench/create_frame.c
@@ -46,7 +46,8 @@ Process finished with exit code 0
 #define GB  (1024*MB)
 
 #define CHUNKSIZE (500 * 1000)
-#define NCHUNKS 1000
+//#define CHUNKSIZE (500)
+#define NCHUNKS 10000
 #define NTHREADS 8
 
 // For exercising the optimized zero chunk creators uncomment the line below

--- a/bench/create_frame.c
+++ b/bench/create_frame.c
@@ -46,13 +46,11 @@ Process finished with exit code 0
 #define GB  (1024*MB)
 
 #define CHUNKSHAPE (500 * 1000)
-//#define CHUNKSHAPE (500)
 #define NCHUNKS 100000
-//#define NCHUNKS 1
 #define NTHREADS 1  // curiously, using 1 single thread is better for the uninitialized values
 
 // For exercising the optimized chunk creators (un)comment the lines below as you please
-#define CREATE_ZEROS
+//#define CREATE_ZEROS
 #define CREATE_FILL
 //#define CREATE_LOOP
 #define CONTIGUOUS_FRAME false

--- a/bench/create_frame.c
+++ b/bench/create_frame.c
@@ -102,9 +102,9 @@ int create_cframe(const char* compname) {
   nitems = (int64_t)NCHUNKS * CHUNKSHAPE + 1;
 #ifdef CREATE_ZEROS
   // Precompute chunk of zeros
-  int special_value = BLOSC2_ZERO_RUNLEN;
+  int special_value = BLOSC2_SPECIAL_ZERO;
 #else
-  int special_value = BLOSC2_UNINIT_VALUE;
+  int special_value = BLOSC2_SPECIAL_UNINIT;
 #endif
   int rc = blosc2_schunk_fill_special(schunk, nitems, special_value, isize);
   if (rc < 0) {

--- a/bench/create_frame.c
+++ b/bench/create_frame.c
@@ -78,7 +78,7 @@ int create_cframe(const char* compname) {
   char filename[64];
   sprintf(filename, "frame_simple-%s.b2frame", compname);
   blosc2_storage storage = {.cparams=&cparams, .dparams=&dparams,
-                            .urlpath=NULL, .contiguous=false};
+                            .urlpath=NULL, .contiguous=true};
   blosc2_schunk* schunk = blosc2_schunk_new(&storage);
 
 #ifdef CREATE_ZEROS
@@ -94,7 +94,8 @@ int create_cframe(const char* compname) {
   blosc_set_timestamp(&last);
 
 #ifdef CREATE_ZEROS_SPECIAL
-  int rc = blosc2_schunk_fill_special(schunk, NCHUNKS * CHUNKSIZE,BLOSC2_ZERO_RUNLEN);
+  int rc = blosc2_schunk_fill_special(schunk, NCHUNKS * CHUNKSIZE,
+                                      BLOSC2_ZERO_RUNLEN, isize);
   if (rc < 0) {
     printf("Error in fill special.  Error code: %d\n", rc);
     return rc;

--- a/blosc/blosc2.c
+++ b/blosc/blosc2.c
@@ -1228,7 +1228,7 @@ int pipeline_d(struct thread_context* thread_context, const int32_t bsize, uint8
 }
 
 
-int32_t set_nans(int32_t typesize, uint8_t* dest, int32_t destsize) {
+static int32_t set_nans(int32_t typesize, uint8_t* dest, int32_t destsize) {
   // destsize can only be a multiple of typesize
   if (destsize % typesize != 0) {
     return -1;
@@ -1260,7 +1260,7 @@ int32_t set_nans(int32_t typesize, uint8_t* dest, int32_t destsize) {
 }
 
 
-int32_t set_values(int32_t typesize, const uint8_t* src, uint8_t* dest, int32_t destsize) {
+static int32_t set_values(int32_t typesize, const uint8_t* src, uint8_t* dest, int32_t destsize) {
   // destsize can only be a multiple of typesize
   int64_t val8;
   int64_t* dest8;

--- a/blosc/blosc2.c
+++ b/blosc/blosc2.c
@@ -3520,6 +3520,11 @@ int blosc2_chunk_zeros(blosc2_cparams cparams, const size_t nbytes, void* dest, 
     return BLOSC2_ERROR_DATA;
   }
 
+  if (nbytes % cparams.typesize) {
+    BLOSC_TRACE_ERROR("nbytes must be a multiple of typesize");
+    return BLOSC2_ERROR_DATA;
+  }
+
   blosc_header header;
   blosc2_context* context = blosc2_create_cctx(cparams);
 
@@ -3555,6 +3560,11 @@ int blosc2_chunk_zeros(blosc2_cparams cparams, const size_t nbytes, void* dest, 
 int blosc2_chunk_uninit(blosc2_cparams cparams, const size_t nbytes, void* dest, size_t destsize) {
   if (destsize < BLOSC_EXTENDED_HEADER_LENGTH) {
     BLOSC_TRACE_ERROR("dest buffer is not long enough");
+    return BLOSC2_ERROR_DATA;
+  }
+
+  if (nbytes % cparams.typesize) {
+    BLOSC_TRACE_ERROR("nbytes must be a multiple of typesize");
     return BLOSC2_ERROR_DATA;
   }
 
@@ -3595,6 +3605,11 @@ int blosc2_chunk_nans(blosc2_cparams cparams, const size_t nbytes, void* dest, s
     return BLOSC2_ERROR_DATA;
   }
 
+  if (nbytes % cparams.typesize) {
+    BLOSC_TRACE_ERROR("nbytes must be a multiple of typesize");
+    return BLOSC2_ERROR_DATA;
+  }
+
   blosc_header header;
   blosc2_context* context = blosc2_create_cctx(cparams);
 
@@ -3632,6 +3647,11 @@ int blosc2_chunk_repeatval(blosc2_cparams cparams, const size_t nbytes,
   uint8_t typesize = cparams.typesize;
   if (destsize < BLOSC_EXTENDED_HEADER_LENGTH + typesize) {
     BLOSC_TRACE_ERROR("dest buffer is not long enough");
+    return BLOSC2_ERROR_DATA;
+  }
+
+  if (nbytes % cparams.typesize) {
+    BLOSC_TRACE_ERROR("nbytes must be a multiple of typesize");
     return BLOSC2_ERROR_DATA;
   }
 

--- a/blosc/blosc2.c
+++ b/blosc/blosc2.c
@@ -2575,6 +2575,7 @@ int blosc_decompress(const void* src, void* dest, size_t destsize) {
 int _blosc_getitem(blosc2_context* context, blosc_header* header, const void* src, int32_t srcsize,
                    int start, int nitems, void* dest, int32_t destsize) {
   uint8_t* _src = (uint8_t*)(src);  /* current pos for source buffer */
+  uint8_t* _dest = (uint8_t*)(dest);
   int32_t ntbytes = 0;              /* the number of uncompressed bytes */
   int32_t bsize, bsize2, ebsize, leftoverblock;
   int32_t cbytes;
@@ -2614,6 +2615,44 @@ int _blosc_getitem(blosc2_context* context, blosc_header* header, const void* sr
   if (context->special_type) {
     // Fake a runlen as if its a memcpyed chunk
     memcpyed = true;
+  }
+
+  bool is_lazy = ((context->header_overhead == BLOSC_EXTENDED_HEADER_LENGTH) &&
+                  (context->blosc2_flags & 0x08u) && !context->special_type);
+  if (memcpyed && !is_lazy && !context->postfilter) {
+    // Short-circuit for (non-lazy) memcpyed or special values
+    ntbytes = nitems * header->typesize;
+    switch (context->special_type) {
+      case BLOSC2_SPECIAL_VALUE:
+        // All repeated values
+        rc = set_values(context->typesize, _src, _dest, ntbytes);
+        if (rc < 0) {
+          BLOSC_TRACE_ERROR("set_values failed");
+          return BLOSC2_ERROR_DATA;
+        }
+        break;
+      case BLOSC2_SPECIAL_NAN:
+        rc = set_nans(context->typesize, _dest, ntbytes);
+        if (rc < 0) {
+          BLOSC_TRACE_ERROR("set_nans failed");
+          return BLOSC2_ERROR_DATA;
+        }
+        break;
+      case BLOSC2_SPECIAL_ZERO:
+        memset(_dest, 0, ntbytes);
+        break;
+      case BLOSC2_SPECIAL_UNINIT:
+        // We do nothing here
+        break;
+      case BLOSC2_NO_SPECIAL:
+        _src += context->header_overhead + start * context->typesize;
+        memcpy(_dest, _src, ntbytes);
+        break;
+      default:
+        BLOSC_TRACE_ERROR("Unhandled special value case");
+        return -1;
+    }
+    return ntbytes;
   }
 
   ebsize = header->blocksize + header->typesize * (signed)sizeof(int32_t);

--- a/blosc/blosc2.h
+++ b/blosc/blosc2.h
@@ -281,6 +281,7 @@ enum {
   BLOSC2_ERROR_THREAD_CREATE = -26,   //!< Thread or thread context creation failure
   BLOSC2_ERROR_POSTFILTER = -27,      //!< Postfilter failure
   BLOSC2_ERROR_FRAME_SPECIAL = -28,   //!< Special frame failure
+  BLOSC2_ERROR_SCHUNK_SPECIAL = -29,  //!< Special super-chunk failure
 };
 
 /**
@@ -1489,7 +1490,8 @@ BLOSC_EXPORT int blosc2_schunk_reorder_offsets(blosc2_schunk *schunk, int *offse
 BLOSC_EXPORT int64_t blosc2_schunk_frame_len(blosc2_schunk* schunk);
 
 /* Fill an empty frame with special values (fast path). */
-int blosc2_schunk_fill_special(blosc2_schunk* schunk, int64_t nitems, int special_value);
+int blosc2_schunk_fill_special(blosc2_schunk* schunk, int64_t nitems, int special_value,
+                               int32_t chunksize);
 
 
 /*********************************************************************

--- a/blosc/blosc2.h
+++ b/blosc/blosc2.h
@@ -280,6 +280,7 @@ enum {
   BLOSC2_ERROR_FILE_TRUNCATE = -25,   //!< File truncate failure
   BLOSC2_ERROR_THREAD_CREATE = -26,   //!< Thread or thread context creation failure
   BLOSC2_ERROR_POSTFILTER = -27,      //!< Postfilter failure
+  BLOSC2_ERROR_FRAME_SPECIAL = -28,   //!< Special frame failure
 };
 
 /**
@@ -1073,7 +1074,7 @@ BLOSC_EXPORT int blosc2_chunk_nans(blosc2_cparams cparams, size_t nbytes,
  * @param dest The buffer where the data chunk will be put.
  * @param destsize The size (in bytes) of the @p dest buffer.
  * @param repeatval A pointer to the repeated value (little endian).
- * The size of the value is given by @p typesize param.
+ * The size of the value is given by @p cparams.typesize param.
  *
  * @return The number of bytes compressed (BLOSC_EXTENDED_HEADER_LENGTH + typesize).
  * If negative, there has been an error and @dest is unusable.
@@ -1486,6 +1487,9 @@ BLOSC_EXPORT int blosc2_schunk_reorder_offsets(blosc2_schunk *schunk, int *offse
  * If there is not an internal frame, an estimate of the length is provided.
  */
 BLOSC_EXPORT int64_t blosc2_schunk_frame_len(blosc2_schunk* schunk);
+
+/* Fill an empty frame with special values (fast path). */
+int blosc2_schunk_fill_special(blosc2_schunk* schunk, int64_t nitems, int special_value);
 
 
 /*********************************************************************

--- a/blosc/blosc2.h
+++ b/blosc/blosc2.h
@@ -239,13 +239,13 @@ enum {
  * @brief Run lengths for special values for chunks/frames
  */
 enum {
-  BLOSC2_NO_SPECIAL = 0x0,      //!< no special value
-  BLOSC2_ZERO_RUNLEN = 0x1,     //!< zero run-length
-  BLOSC2_NAN_RUNLEN = 0x2,      //!< NaN run-length
-  BLOSC2_VALUE_RUNLEN = 0x3,    //!< generic value run-length
-  BLOSC2_UNINIT_VALUE = 0x4,    //!< non initialized values
-  BLOSC2_SPECIAL_LASTID = 0x4,  //!<last valid ID for special value (update this adequately)
-  BLOSC2_SPECIAL_MASK = 0x7     //!< special value mask (prev IDs cannot be larger than this)
+  BLOSC2_NO_SPECIAL = 0x0,       //!< no special value
+  BLOSC2_SPECIAL_ZERO = 0x1,     //!< zero special value
+  BLOSC2_SPECIAL_NAN = 0x2,      //!< NaN special value
+  BLOSC2_SPECIAL_VALUE = 0x3,    //!< generic special value
+  BLOSC2_SPECIAL_UNINIT = 0x4,   //!< non initialized values
+  BLOSC2_SPECIAL_LASTID = 0x4,   //!< last valid ID for special value (update this adequately)
+  BLOSC2_SPECIAL_MASK = 0x7      //!< special value mask (prev IDs cannot be larger than this)
 };
 
 /**
@@ -1495,7 +1495,7 @@ BLOSC_EXPORT int64_t blosc2_schunk_frame_len(blosc2_schunk* schunk);
  * @param schunk The super-chunk to be filled.  This must be empty initially.
  * @param nitems The number of items to fill.
  * @param special_value The special value to use for filling.  The only values
- * supported for now are BLOSC2_ZERO_RUNLEN, BLOSC2_NAN_RUNLEN and BLOSC2_UNINIT_VALUE.
+ * supported for now are BLOSC2_SPECIAL_ZERO, BLOSC2_SPECIAL_NAN and BLOSC2_SPECIAL_UNINIT.
  * @param chunksize The chunksize for the chunks that are to be added to the super-chunk.
  *
  * @return The total number of chunks that have been added to the super-chunk.

--- a/blosc/blosc2.h
+++ b/blosc/blosc2.h
@@ -239,7 +239,7 @@ enum {
  * @brief Run lengths for special values for chunks/frames
  */
 enum {
-  BLOSC2_NO_SPECIAL = 0x0,      //!< no run-length
+  BLOSC2_NO_SPECIAL = 0x0,      //!< no special value
   BLOSC2_ZERO_RUNLEN = 0x1,     //!< zero run-length
   BLOSC2_NAN_RUNLEN = 0x2,      //!< NaN run-length
   BLOSC2_VALUE_RUNLEN = 0x3,    //!< generic value run-length
@@ -1489,7 +1489,18 @@ BLOSC_EXPORT int blosc2_schunk_reorder_offsets(blosc2_schunk *schunk, int *offse
  */
 BLOSC_EXPORT int64_t blosc2_schunk_frame_len(blosc2_schunk* schunk);
 
-/* Fill an empty frame with special values (fast path). */
+/**
+ * @brief Quickly fill an empty frame with special values (zeros, NaNs, uninit).
+ *
+ * @param schunk The super-chunk to be filled.  This must be empty initially.
+ * @param nitems The number of items to fill.
+ * @param special_value The special value to use for filling.  The only values
+ * supported for now are BLOSC2_ZERO_RUNLEN, BLOSC2_NAN_RUNLEN and BLOSC2_UNINIT_VALUE.
+ * @param chunksize The chunksize for the chunks that are to be added to the super-chunk.
+ *
+ * @return The total number of chunks that have been added to the super-chunk.
+ * If there is an error, a negative value is returned.
+ */
 int blosc2_schunk_fill_special(blosc2_schunk* schunk, int64_t nitems, int special_value,
                                int32_t chunksize);
 

--- a/blosc/frame.c
+++ b/blosc/frame.c
@@ -2130,8 +2130,9 @@ int frame_fill_special(blosc2_frame_s* frame, int64_t nitems, int special_value,
   }
 
   // Compute the number of chunks and the length of the offsets chunk
-  nchunks = nitems * typesize / chunksize;
-  int32_t leftover_items = nitems % chunksize;
+  int32_t chunkitems = chunksize / typesize;
+  nchunks = (int32_t)(nitems / chunkitems);
+  int32_t leftover_items = (int32_t)(nitems % chunkitems);
   if (leftover_items) {
     nchunks += 1;
   }

--- a/blosc/frame.h
+++ b/blosc/frame.h
@@ -145,6 +145,6 @@ int frame_update_header(blosc2_frame_s* frame, blosc2_schunk* schunk, bool new);
 int frame_update_trailer(blosc2_frame_s* frame, blosc2_schunk* schunk);
 
 int frame_fill_special(blosc2_frame_s* frame, int64_t nitems, int special_value,
-                       blosc2_schunk* schunk);
+                       int32_t chunksize, blosc2_schunk* schunk);
 
 #endif //BLOSC_FRAME_H

--- a/blosc/frame.h
+++ b/blosc/frame.h
@@ -144,4 +144,7 @@ int frame_decompress_chunk(blosc2_context* dctx, blosc2_frame_s* frame, int nchu
 int frame_update_header(blosc2_frame_s* frame, blosc2_schunk* schunk, bool new);
 int frame_update_trailer(blosc2_frame_s* frame, blosc2_schunk* schunk);
 
+int frame_fill_special(blosc2_frame_s* frame, int64_t nitems, int special_value,
+                       blosc2_schunk* schunk);
+
 #endif //BLOSC_FRAME_H

--- a/blosc/schunk.c
+++ b/blosc/schunk.c
@@ -475,7 +475,9 @@ int blosc2_schunk_fill_special(blosc2_schunk* schunk, int64_t nitems, int specia
     return 0;
   }
 
-  if ((nitems / chunksize) > INT_MAX) {
+  int32_t typesize = schunk->typesize;
+
+  if ((nitems * typesize / chunksize) > INT_MAX) {
     BLOSC_TRACE_ERROR("nitems is too large.  Try increasing the chunksize.");
     return BLOSC2_ERROR_SCHUNK_SPECIAL;
   }
@@ -486,14 +488,14 @@ int blosc2_schunk_fill_special(blosc2_schunk* schunk, int64_t nitems, int specia
   }
 
   // Compute the number of chunks and the length of the offsets chunk
-  int32_t nchunks = nitems / chunksize;
+  int32_t nchunks = nitems * typesize / chunksize;
   int32_t leftover_items = nitems % chunksize;
-  int32_t leftover_size = leftover_items * schunk->typesize;
+  int32_t leftover_size = leftover_items * typesize;
 
   /* Update counters */
   schunk->chunksize = chunksize;
   schunk->nchunks = nchunks;
-  schunk->nbytes = nitems * schunk->typesize;
+  schunk->nbytes = nitems * typesize;
 
   if (schunk->frame == NULL) {
     // Build the special chunks

--- a/blosc/schunk.c
+++ b/blosc/schunk.c
@@ -469,6 +469,17 @@ blosc2_schunk* blosc2_schunk_from_buffer(uint8_t *cframe, int64_t len, bool copy
   return schunk;
 }
 
+/* Fill an empty frame with special values (fast path). */
+int blosc2_schunk_fill_special(blosc2_schunk* schunk, int64_t nitems, int special_value) {
+  if (schunk->frame == NULL) {
+    BLOSC_TRACE_ERROR("This only works for frames.");
+    return BLOSC2_ERROR_FRAME_SPECIAL;
+  }
+  /* Fill an empty frame with special values (fast path). */
+  blosc2_frame_s* frame = (blosc2_frame_s*)schunk->frame;
+  return frame_fill_special(frame, nitems, special_value, schunk);
+
+  }
 
 /* Append an existing chunk into a super-chunk. */
 int blosc2_schunk_append_chunk(blosc2_schunk *schunk, uint8_t *chunk, bool copy) {

--- a/blosc/schunk.c
+++ b/blosc/schunk.c
@@ -554,11 +554,11 @@ int blosc2_schunk_fill_special(blosc2_schunk* schunk, int64_t nitems, int specia
     int64_t frame_len = frame_fill_special(frame, nitems, special_value, chunksize, schunk);
     if (frame_len < 0) {
       BLOSC_TRACE_ERROR("Error creating special frame.");
-      return nchunks;
+      return frame_len;
     }
   }
 
-  return nchunks;
+  return schunk->nchunks;
 }
 
 /* Append an existing chunk into a super-chunk. */

--- a/blosc/schunk.c
+++ b/blosc/schunk.c
@@ -501,15 +501,15 @@ int blosc2_schunk_fill_special(blosc2_schunk* schunk, int64_t nitems, int specia
     blosc2_schunk_get_cparams(schunk, &cparams);
     int csize, csize2;
     switch (special_value) {
-      case BLOSC2_ZERO_RUNLEN:
+      case BLOSC2_SPECIAL_ZERO:
         csize = blosc2_chunk_zeros(*cparams, chunksize, chunk, BLOSC_EXTENDED_HEADER_LENGTH);
         csize2 = blosc2_chunk_zeros(*cparams, leftover_size, chunk2, BLOSC_EXTENDED_HEADER_LENGTH);
         break;
-      case BLOSC2_UNINIT_VALUE:
+      case BLOSC2_SPECIAL_UNINIT:
         csize = blosc2_chunk_uninit(*cparams, chunksize, chunk, BLOSC_EXTENDED_HEADER_LENGTH);
         csize2 = blosc2_chunk_uninit(*cparams, leftover_size, chunk2, BLOSC_EXTENDED_HEADER_LENGTH);
         break;
-      case BLOSC2_NAN_RUNLEN:
+      case BLOSC2_SPECIAL_NAN:
         csize = blosc2_chunk_nans(*cparams, chunksize, chunk, BLOSC_EXTENDED_HEADER_LENGTH);
         csize2 = blosc2_chunk_nans(*cparams, leftover_size, chunk2, BLOSC_EXTENDED_HEADER_LENGTH);
         break;
@@ -590,9 +590,9 @@ int blosc2_schunk_append_chunk(blosc2_schunk *schunk, uint8_t *chunk, bool copy)
     // A frame
     int special_value = (chunk[BLOSC2_CHUNK_BLOSC2_FLAGS] >> 4) & BLOSC2_SPECIAL_MASK;
     switch (special_value) {
-      case BLOSC2_ZERO_RUNLEN:
-      case BLOSC2_NAN_RUNLEN:
-      case BLOSC2_UNINIT_VALUE:
+      case BLOSC2_SPECIAL_ZERO:
+      case BLOSC2_SPECIAL_NAN:
+      case BLOSC2_SPECIAL_UNINIT:
         schunk->cbytes += 0;
         break;
       default:
@@ -679,9 +679,9 @@ int blosc2_schunk_insert_chunk(blosc2_schunk *schunk, int nchunk, uint8_t *chunk
     // A frame
     int special_value = (chunk[BLOSC2_CHUNK_BLOSC2_FLAGS] >> 4) & BLOSC2_SPECIAL_MASK;
     switch (special_value) {
-      case BLOSC2_ZERO_RUNLEN:
-      case BLOSC2_NAN_RUNLEN:
-      case BLOSC2_UNINIT_VALUE:
+      case BLOSC2_SPECIAL_ZERO:
+      case BLOSC2_SPECIAL_NAN:
+      case BLOSC2_SPECIAL_UNINIT:
         schunk->cbytes += 0;
         break;
       default:
@@ -804,9 +804,9 @@ int blosc2_schunk_update_chunk(blosc2_schunk *schunk, int nchunk, uint8_t *chunk
     // A frame
     int special_value = (chunk[BLOSC2_CHUNK_BLOSC2_FLAGS] >> 4) & BLOSC2_SPECIAL_MASK;
     switch (special_value) {
-      case BLOSC2_ZERO_RUNLEN:
-      case BLOSC2_NAN_RUNLEN:
-      case BLOSC2_UNINIT_VALUE:
+      case BLOSC2_SPECIAL_ZERO:
+      case BLOSC2_SPECIAL_NAN:
+      case BLOSC2_SPECIAL_UNINIT:
         schunk->nbytes += chunk_nbytes;
         schunk->nbytes -= chunk_nbytes_old;
         if (frame->sframe) {

--- a/tests/cutest.h
+++ b/tests/cutest.h
@@ -161,7 +161,8 @@ int _cutest_run(int (*test)(void *), void *test_data, char *name) {
     params_strides[i] = params_strides[i - 1] * _cutest_params[i - 1].params_len;
   }
 
-  char test_name[1024];
+  int max_test_name = 1024;
+  char test_name[max_test_name];
   int count = 0;
   int num = niters;
   do { count++; num /= 10;} while(num != 0);
@@ -169,7 +170,7 @@ int _cutest_run(int (*test)(void *), void *test_data, char *name) {
     sprintf(test_name, "[%0*d/%d] %s(", count, niter + 1, niters, name);
     for (int i = 0; i < nparams; ++i) {
       _cutest_params_ind[i] = niter / params_strides[i] % _cutest_params[i].params_len;
-      sprintf(test_name, "%s%s[%d], ", test_name, _cutest_params[i].name,
+      snprintf(test_name, max_test_name, "%s%s[%d], ", test_name, _cutest_params[i].name,
               _cutest_params_ind[i]);
     }
     test_name[strlen(test_name) - 1] = 0;

--- a/tests/test_copy.c
+++ b/tests/test_copy.c
@@ -75,10 +75,10 @@ CUTEST_TEST_SETUP(copy) {
       {false, "test_copy_s.b2frame"}, // disk - sframe
   ));
   CUTEST_PARAMETRIZE(backend2, test_copy_backend, CUTEST_DATA(
-      {false, NULL},  // memory - schunk
-      {true, NULL},  // memory - cframe
-      {true, "test_copy2.b2frame"}, // disk - cframe
-      {false, "test_copy2_s.b2frame"}, // disk - sframe
+          {false, NULL},  // memory - schunk
+          {true, NULL},  // memory - cframe
+          {true, "test_copy2.b2frame"}, // disk - cframe
+          {false, "test_copy2_s.b2frame"}, // disk - sframe
   ));
 }
 

--- a/tests/test_fill_special.c
+++ b/tests/test_fill_special.c
@@ -1,0 +1,174 @@
+/*
+  Copyright (C) 2021  The Blosc Developers
+  http://blosc.org
+  License: BSD (see LICENSE.txt)
+
+  Benchmark showing Blosc zero detection capabilities via run-length.
+
+*/
+
+#include <stdio.h>
+#include <stdint.h>
+#include <math.h>
+
+#include "blosc2.h"
+#include "cutest.h"
+
+
+#define NCHUNKS (10)
+#define CHUNKSHAPE (5 * 1000)
+#define NTHREADS 4
+
+enum {
+  CHECK_ZEROS = 1,
+  CHECK_NANS = 2,
+  CHECK_UNINIT = 3,
+};
+
+typedef struct {
+  bool contiguous;
+  char *urlpath;
+}test_fill_special_backend;
+
+CUTEST_TEST_DATA(fill_special) {
+  blosc2_cparams cparams;
+  blosc2_dparams dparams;
+};
+
+CUTEST_TEST_SETUP(fill_special) {
+  blosc_init();
+  data->cparams = BLOSC2_CPARAMS_DEFAULTS;
+  blosc2_cparams* cparams = &data->cparams;
+  cparams->typesize = sizeof(float);
+  cparams->clevel = 9;
+  cparams->nthreads = NTHREADS;
+  data->dparams = BLOSC2_DPARAMS_DEFAULTS;
+  blosc2_dparams* dparams = &data->dparams;
+  dparams->nthreads = NTHREADS;
+
+  CUTEST_PARAMETRIZE(svalue, int, CUTEST_DATA(
+          CHECK_ZEROS,
+          CHECK_NANS,
+          CHECK_UNINIT,
+  ));
+  CUTEST_PARAMETRIZE(leftover_items, int, CUTEST_DATA(
+          0,
+          1,
+          10,
+  ));
+  CUTEST_PARAMETRIZE(backend, test_fill_special_backend, CUTEST_DATA(
+      {false, NULL},  // memory - schunk
+      {true, NULL},  // memory - cframe
+      {true, "test_fill_special.b2frame"}, // disk - cframe
+      {false, "test_fill_special_s.b2frame"}, // disk - sframe
+  ));
+}
+
+
+CUTEST_TEST_TEST(fill_special) {
+  blosc2_cparams* cparams = &data->cparams;
+  blosc2_dparams* dparams = &data->dparams;
+  int32_t isize = CHUNKSHAPE * cparams->typesize;
+  int32_t* data_dest = malloc(isize);
+  int nchunk;
+
+  CUTEST_GET_PARAMETER(svalue, int);
+  CUTEST_GET_PARAMETER(leftover_items, int);
+  CUTEST_GET_PARAMETER(backend, test_fill_special_backend);
+
+  // Remove a possible stale sparse frame
+  if (!backend.contiguous && backend.urlpath != NULL) {
+    blosc2_remove_dir(backend.urlpath);
+  }
+
+  /* Create a super-chunk container */
+  blosc2_storage storage = {
+          .cparams=cparams, .dparams=dparams,
+          .urlpath=backend.urlpath, .contiguous=backend.contiguous};
+  blosc2_schunk* schunk = blosc2_schunk_new(&storage);
+  CUTEST_ASSERT("Error creating schunk", schunk != NULL);
+
+  int ret;
+  int special_value;
+  switch (svalue) {
+    case CHECK_ZEROS:
+      special_value = BLOSC2_ZERO_RUNLEN;
+      ret = blosc2_chunk_zeros(*cparams, isize, data_dest, isize);
+      break;
+    case CHECK_NANS:
+      special_value = BLOSC2_NAN_RUNLEN;
+      ret = blosc2_chunk_nans(*cparams, isize, data_dest, isize);
+      break;
+    case CHECK_UNINIT:
+      special_value = BLOSC2_UNINIT_VALUE;
+      ret = blosc2_chunk_uninit(*cparams, isize, data_dest, isize);
+      break;
+    default:
+      CUTEST_ASSERT("Unrecognized case", false);
+  }
+  CUTEST_ASSERT("Creation error in special chunk", ret == BLOSC_EXTENDED_HEADER_LENGTH);
+
+  // Add some items into the super-chunk
+  int64_t nitems;
+  // Make nitems a non-divisible number of CHUNKSHAPE
+  nitems = (int64_t)NCHUNKS * CHUNKSHAPE + leftover_items;
+  int32_t leftover_bytes = (int32_t)(nitems % CHUNKSHAPE) * cparams->typesize;
+  int nchunks = blosc2_schunk_fill_special(schunk, nitems, special_value, isize);
+  if (leftover_items != 0) {
+    CUTEST_ASSERT("Error in fill special", nchunks == NCHUNKS + 1);
+  }
+  else {
+    CUTEST_ASSERT("Error in fill special", nchunks == NCHUNKS);
+  }
+
+  /* Retrieve and decompress the chunks from the super-chunks and compare values */
+  for (nchunk = 0; nchunk < nchunks; nchunk++) {
+    int32_t dsize = blosc2_schunk_decompress_chunk(schunk, nchunk, data_dest, isize);
+    if ((nchunk == nchunks - 1) && (leftover_items > 0)) {
+      CUTEST_ASSERT("Wrong size for last chunk.", dsize == leftover_bytes);
+    }
+    else {
+      CUTEST_ASSERT("Wrong size for last chunk.", dsize == isize);
+    }
+
+    // Check values
+    int32_t cbytes;
+    uint8_t* chunk;
+    bool needs_free;
+    float fvalue;
+    cbytes = blosc2_schunk_get_chunk(schunk, nchunk, &chunk, &needs_free);
+    CUTEST_ASSERT("Wrong chunk size!", cbytes == BLOSC_EXTENDED_HEADER_LENGTH);
+    dsize = blosc2_getitem_ctx(schunk->dctx, chunk, cbytes, 0, 1, &fvalue, sizeof(float));
+    CUTEST_ASSERT("Wrong decompressed item size!", dsize == sizeof(float));
+    switch (special_value) {
+      case CHECK_ZEROS:
+        CUTEST_ASSERT("Wrong value!", fvalue == 0.);
+        break;
+      case CHECK_NANS:
+        CUTEST_ASSERT("Wrong value!", isnan(fvalue));
+        break;
+      default:
+        // We cannot check non initialized values
+        break;
+    }
+
+    if (needs_free) {
+      free(chunk);
+    }
+  }
+
+  /* Free resources */
+  blosc2_schunk_free(schunk);
+  free(data_dest);
+
+  return 0;
+}
+
+CUTEST_TEST_TEARDOWN(fill_special) {
+  blosc_destroy();
+}
+
+
+int main() {
+  CUTEST_TEST_RUN(fill_special)
+}

--- a/tests/test_fill_special.c
+++ b/tests/test_fill_special.c
@@ -92,15 +92,15 @@ CUTEST_TEST_TEST(fill_special) {
   int special_value;
   switch (svalue) {
     case CHECK_ZEROS:
-      special_value = BLOSC2_ZERO_RUNLEN;
+      special_value = BLOSC2_SPECIAL_ZERO;
       ret = blosc2_chunk_zeros(*cparams, isize, data_dest, isize);
       break;
     case CHECK_NANS:
-      special_value = BLOSC2_NAN_RUNLEN;
+      special_value = BLOSC2_SPECIAL_NAN;
       ret = blosc2_chunk_nans(*cparams, isize, data_dest, isize);
       break;
     case CHECK_UNINIT:
-      special_value = BLOSC2_UNINIT_VALUE;
+      special_value = BLOSC2_SPECIAL_UNINIT;
       ret = blosc2_chunk_uninit(*cparams, isize, data_dest, isize);
       break;
     default:

--- a/tests/test_lazychunk.c
+++ b/tests/test_lazychunk.c
@@ -85,7 +85,11 @@ static char* test_lazy_chunk(void) {
   for (int nchunk = 0; nchunk < nchunks; nchunk++) {
     memset(data_dest, 0, isize);
     cbytes = blosc2_schunk_get_lazychunk(schunk, nchunk, &lazy_chunk, &needs_free);
+    mu_assert("ERROR: cannot get lazy chunk.", cbytes > 0);
     dsize = blosc2_decompress_ctx(schunk->dctx, lazy_chunk, cbytes, data_dest, isize);
+    if (needs_free) {
+      free(lazy_chunk);
+    }
     mu_assert("ERROR: chunk cannot be decompressed correctly.", dsize >= 0);
     for (int i = 0; i < NBLOCKS; i++) {
       for (int j = 0; j < BLOCKSIZE; j++) {

--- a/tests/test_sframe_lazychunk.c
+++ b/tests/test_sframe_lazychunk.c
@@ -19,7 +19,7 @@
 int tests_run = 0;
 int nchunks;
 int clevel;
-int nthreads;
+int16_t nthreads;
 char* directory;
 
 
@@ -27,7 +27,7 @@ char* directory;
 static char* test_lazy_chunk(void) {
   static int32_t data[CHUNKSIZE];
   static int32_t data_dest[CHUNKSIZE];
-  size_t isize = CHUNKSIZE * sizeof(int32_t);
+  int32_t isize = CHUNKSIZE * sizeof(int32_t);
   int dsize;
   int cbytes;
   blosc2_cparams cparams = BLOSC2_CPARAMS_DEFAULTS;
@@ -90,8 +90,12 @@ static char* test_lazy_chunk(void) {
   for (int nchunk = 0; nchunk < nchunks; nchunk++) {
     memset(data_dest, 0, isize);
     cbytes = blosc2_schunk_get_lazychunk(schunk, nchunk, &lazy_chunk, &needs_free);
+    mu_assert("ERROR: cannot get lazy chunk.", cbytes > 0);
     dsize = blosc2_decompress_ctx(schunk->dctx, lazy_chunk, cbytes, data_dest, isize);
     mu_assert("ERROR: chunk cannot be decompressed correctly.", dsize >= 0);
+    if (needs_free) {
+      free(lazy_chunk);
+    }
     for (int i = 0; i < NBLOCKS; i++) {
       for (int j = 0; j < BLOCKSIZE; j++) {
         mu_assert("ERROR: bad roundtrip (blosc2_decompress_ctx)",


### PR DESCRIPTION
This implements a function for filling a super-chunk only with special values (zeros, NaNs or uninitizalized).

The API for the new function is:

```
int blosc2_schunk_fill_special(blosc2_schunk* schunk, int64_t nitems, int special_value,
                               int32_t chunksize);
```

And here is a taste of how fast it can go.  For zeros:

```
$ create_frame

   ***  Creating zeros   ***
   ***  Using fill method!   ***

*** Creating simple frame for blosclz
Compression ratio: 186.26 GB -> 0.00 GB (49999.5x)
Compression time: 0.00311 s, 59842.7 GB/s
Decompression time: 2.62 s, 71.1 GB/s

*** Creating simple frame for lz4
Compression ratio: 186.26 GB -> 0.00 GB (49999.5x)
Compression time: 0.00307 s, 60618.5 GB/s
Decompression time: 2.56 s, 72.8 GB/s
```

And here for uninitizalized values:

```
$ create_frame

   ***  Creating unitialized   ***
   ***  Using fill method!   ***

*** Creating simple frame for blosclz
Compression ratio: 186.26 GB -> 0.00 GB (49999.5x)
Compression time: 0.00373 s, 49880.5 GB/s
Decompression time: 0.00534 s, 34857.1 GB/s

*** Creating simple frame for lz4
Compression ratio: 186.26 GB -> 0.00 GB (49999.5x)
Compression time: 0.00577 s, 32262.8 GB/s
Decompression time: 0.0173 s, 10758.6 GB/s

Process finished with exit code 0

```

This fixes #280.