### PR TITLE
New splitmode field for cparams

### DIFF
--- a/blosc/blosc2.c
+++ b/blosc/blosc2.c
@@ -3411,6 +3411,7 @@ blosc2_context* blosc2_create_cctx(blosc2_cparams cparams) {
   context->nthreads = cparams.nthreads;
   context->new_nthreads = context->nthreads;
   context->blocksize = cparams.blocksize;
+  context->splitmode = cparams.splitmode;
   context->threads_started = 0;
   context->schunk = cparams.schunk;
 

--- a/blosc/blosc2.h
+++ b/blosc/blosc2.h
@@ -218,9 +218,21 @@ enum {
   BLOSC_ZSTD_VERSION_FORMAT = 1,
 };
 
+/**
+ * @brief Split mode for blocks.
+ * NEVER and ALWAYS are for experimenting with compression ratio.
+ * AUTO for nearly optimal behaviour (based on heuristics).
+ * FORWARD_COMPAT provides best forward compatibility (default).
+ */
+enum {
+  BLOSC_ALWAYS_SPLIT = 1,
+  BLOSC_NEVER_SPLIT = 2,
+  BLOSC_AUTO_SPLIT = 3,
+  BLOSC_FORWARD_COMPAT_SPLIT = 4,
+};
 
 /**
- * @brief Offsets for fields in Blosc2 chunk header
+ * @brief Offsets for fields in Blosc2 chunk header.
  */
 enum {
   BLOSC2_CHUNK_VERSION = 0x0,       //!< the version for the chunk format
@@ -750,6 +762,8 @@ typedef struct {
   //!< The number of threads to use internally (1).
   int32_t blocksize;
   //!< The requested size of the compressed blocks (0; meaning automatic).
+  int32_t splitmode;
+  //!< Whether the blocks should be split or not.
   void* schunk;
   //!< The associated schunk, if any (NULL).
   uint8_t filters[BLOSC2_MAX_FILTERS];
@@ -768,8 +782,10 @@ typedef struct {
  * @brief Default struct for compression params meant for user initialization.
  */
 static const blosc2_cparams BLOSC2_CPARAMS_DEFAULTS = {
-        BLOSC_BLOSCLZ, 5, 0, 8, 1, 0, NULL,
-        {0, 0, 0, 0, 0, BLOSC_SHUFFLE}, {0, 0, 0, 0, 0, 0},
+        BLOSC_BLOSCLZ, 5, 0, 8, 1, 0,
+        BLOSC_FORWARD_COMPAT_SPLIT, NULL,
+        {0, 0, 0, 0, 0, BLOSC_SHUFFLE},
+        {0, 0, 0, 0, 0, 0},
         NULL, NULL, NULL};
 
 /**

--- a/blosc/context.h
+++ b/blosc/context.h
@@ -51,6 +51,8 @@ struct blosc2_context_s {
   /* Extra bytes at end of buffer */
   int32_t blocksize;
   /* Length of the block in bytes */
+  int32_t splitmode;
+  /* Whether the blocks should be split or not */
   int32_t output_bytes;
   /* Counter for the number of input bytes */
   int32_t srcsize;

--- a/blosc/stune.h
+++ b/blosc/stune.h
@@ -44,7 +44,20 @@ static blosc2_btune BTUNE_DEFAULTS = {
 /* Conditions for splitting a block before compressing with a codec. */
 static int split_block(blosc2_context* context, int32_t typesize,
                        int32_t blocksize, bool extended_header) {
-  // Normally all the compressors designed for speed benefit from a split.
+  switch (context->splitmode) {
+    case BLOSC_ALWAYS_SPLIT:
+      return 1;
+    case BLOSC_NEVER_SPLIT:
+      return 0;
+    case BLOSC_FORWARD_COMPAT_SPLIT:
+    case BLOSC_AUTO_SPLIT:
+      // These cases will be handled later
+      break;
+    default:
+      BLOSC_TRACE_WARNING("Unrecongnized split mode.  Default to BLOSC_FORWARD_COMPAT_SPLIT");
+  }
+
+  // For now, BLOSC_FORWARD_COMPAT_SPLIT and BLOSC_AUTO_SPLIT will be treated the same
   int compcode = context->compcode;
   bool shuffle = context->filter_flags & BLOSC_DOSHUFFLE;
   return (

--- a/tests/test_contexts.c
+++ b/tests/test_contexts.c
@@ -41,6 +41,7 @@ int main(void) {
   cparams.filters[BLOSC2_MAX_FILTERS - 1] = BLOSC_SHUFFLE;
   cparams.clevel = 5;
   cparams.nthreads = NTHREADS;
+  cparams.splitmode = BLOSC_AUTO_SPLIT;
   cctx = blosc2_create_cctx(cparams);
 
   /* Compress with clevel=5 and shuffle active  */

--- a/tests/test_copy.c
+++ b/tests/test_copy.c
@@ -49,12 +49,14 @@ CUTEST_TEST_SETUP(copy) {
   data->cparams.typesize = sizeof(int32_t);
   data->cparams.clevel = 9;
   data->cparams.nthreads = NTHREADS;
+  data->cparams.splitmode = BLOSC_NEVER_SPLIT;
 
   data->cparams2 = BLOSC2_CPARAMS_DEFAULTS;
   data->cparams2.typesize = sizeof(int32_t);
   data->cparams2.clevel = 2;
   data->cparams2.nthreads = NTHREADS;
   data->cparams2.blocksize = 10000;
+  data->cparams2.splitmode = BLOSC_ALWAYS_SPLIT;
 
   CUTEST_PARAMETRIZE(nchunks, int32_t, CUTEST_DATA(
       0, 1, 10, 20


### PR DESCRIPTION
Will allow to control when and how to make a split of the block during compression.  Fixes #286.