### PR TITLE
Fixed ASAN heap-buffer-overflow when reading frame metalayers.

### DIFF
--- a/blosc/frame.c
+++ b/blosc/frame.c
@@ -1284,16 +1284,15 @@ static int get_meta_from_header(blosc2_frame_s* frame, blosc2_schunk* schunk, ui
     }
     // Go to offset and see if we have the correct marker
     uint8_t* content_marker = header + offset;
+    if (header_len < offset + 1 + 4) {
+      return BLOSC2_ERROR_READ_BUFFER;
+    }
     if (*content_marker != 0xc6) {
       return BLOSC2_ERROR_DATA;
     }
 
     // Read the size of the content
     int32_t content_len;
-    header_pos += sizeof(content_len);
-    if (header_len < header_pos) {
-      return BLOSC2_ERROR_READ_BUFFER;
-    }
     from_big(&content_len, content_marker + 1, sizeof(content_len));
     if (content_len < 0) {
       return BLOSC2_ERROR_DATA;
@@ -1301,8 +1300,7 @@ static int get_meta_from_header(blosc2_frame_s* frame, blosc2_schunk* schunk, ui
     metalayer->content_len = content_len;
 
     // Finally, read the content
-    header_pos += content_len;
-    if (header_len < header_pos) {
+    if (header_len < offset + 1 + 4 + content_len) {
       return BLOSC2_ERROR_READ_BUFFER;
     }
     char* content = malloc((size_t)content_len);


### PR DESCRIPTION
Similar to #279. Variable `header_pos` is used for checking boundaries when reading name/offsets. Don't need to increase `header_pos` when seeking to another offset in the header to read metadata.

https://oss-fuzz.com/testcase-detail/5361858753200128