### PR TITLE
Added typesize check when reading frame header info.

### DIFF
--- a/blosc/frame.c
+++ b/blosc/frame.c
@@ -409,7 +409,15 @@ int get_header_info(blosc2_frame_s *frame, int32_t *header_len, int64_t *frame_l
 
   // Fetch some internal lengths
   from_big(header_len, framep + FRAME_HEADER_LEN, sizeof(*header_len));
+  if (*header_len < FRAME_HEADER_MINLEN) {
+    BLOSC_TRACE_ERROR("Header length is zero or smaller than min allowed.");
+    return BLOSC2_ERROR_INVALID_HEADER;
+  }
   from_big(frame_len, framep + FRAME_LEN, sizeof(*frame_len));
+  if (*header_len > *frame_len) {
+    BLOSC_TRACE_ERROR("Header length exceeds length of the frame.");
+    return BLOSC2_ERROR_INVALID_HEADER;
+  }
   from_big(nbytes, framep + FRAME_NBYTES, sizeof(*nbytes));
   from_big(cbytes, framep + FRAME_CBYTES, sizeof(*cbytes));
   from_big(blocksize, framep + FRAME_BLOCKSIZE, sizeof(*blocksize));
@@ -418,11 +426,10 @@ int get_header_info(blosc2_frame_s *frame, int32_t *header_len, int64_t *frame_l
   }
   if (typesize != NULL) {
     from_big(typesize, framep + FRAME_TYPESIZE, sizeof(*typesize));
-  }
-
-  if (*header_len < FRAME_HEADER_MINLEN || *header_len > *frame_len) {
-    BLOSC_TRACE_ERROR("Header length is invalid or exceeds length of the frame.");
-    return BLOSC2_ERROR_INVALID_HEADER;
+    if (*typesize <= 0 || *typesize > BLOSC_MAX_TYPESIZE) {
+      BLOSC_TRACE_ERROR("`typesize` is zero or greater than max allowed.");
+      return BLOSC2_ERROR_INVALID_HEADER;
+    }
   }
 
   // Codecs

--- a/blosc/frame.c
+++ b/blosc/frame.c
@@ -1687,6 +1687,7 @@ blosc2_schunk* frame_to_schunk(blosc2_frame_s* frame, bool copy, const blosc2_io
   uint8_t* data_chunk = NULL;
   const blosc2_io_cb *io_cb = blosc2_get_io_cb(udio->id);
   if (io_cb == NULL) {
+    blosc2_schunk_free(schunk);
     BLOSC_TRACE_ERROR("Error getting the input/output API");
     return NULL;
   }
@@ -1711,6 +1712,7 @@ blosc2_schunk* frame_to_schunk(blosc2_frame_s* frame, bool copy, const blosc2_io
       data_chunk = frame->cframe + header_len + offsets[i];
       rc = blosc2_cbuffer_sizes(data_chunk, NULL, &chunk_cbytes, NULL);
       if (rc < 0) {
+        blosc2_schunk_free(schunk);
         return NULL;
       }
     }
@@ -1725,6 +1727,7 @@ blosc2_schunk* frame_to_schunk(blosc2_frame_s* frame, bool copy, const blosc2_io
         rbytes = io_cb->read(data_chunk, 1, BLOSC_EXTENDED_HEADER_LENGTH, fp);
         if (rbytes != BLOSC_EXTENDED_HEADER_LENGTH) {
           io_cb->close(fp);
+          blosc2_schunk_free(schunk);
           return NULL;
         }
       }
@@ -1741,6 +1744,7 @@ blosc2_schunk* frame_to_schunk(blosc2_frame_s* frame, bool copy, const blosc2_io
       }
       rc = blosc2_cbuffer_sizes(data_chunk, NULL, &chunk_cbytes, NULL);
       if (rc < 0) {
+        blosc2_schunk_free(schunk);
         return NULL;
       }
       if (chunk_cbytes > prev_alloc) {

--- a/blosc/schunk.c
+++ b/blosc/schunk.c
@@ -469,8 +469,8 @@ blosc2_schunk* blosc2_schunk_from_buffer(uint8_t *cframe, int64_t len, bool copy
     return NULL;
   }
   blosc2_schunk* schunk = frame_to_schunk(frame, copy, &BLOSC2_IO_DEFAULTS);
-  if (copy) {
-    // We don't need the frame anymore
+  if (schunk && copy) {
+    // Super-chunk has its own copy of frame
     frame_free(frame);
   }
   return schunk;


### PR DESCRIPTION
https://oss-fuzz.com/testcase-detail/6103287616110592

Also I have moved some length checks closer to where the values are read. This should prevent it from reading fields if header length is too small.