### PR TITLE
Fix mkdir bug for MinGW-w64 gcc

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -74,13 +74,15 @@ jobs:
             compiler: cl
             cmake-args: -A x64
 
-            # Windows GCC started to fail with commit 39e4c3c which was just a printf removal.
-            # Looks like this is a problem with this platform in upstream CI.
-            # Commenting this out for now.
-            # - name: Windows GCC
-            # os: windows-latest
-            # compiler: gcc
-            # cmake-args: -G Ninja
+          - name: Windows GCC Ninja
+            os: windows-latest
+            compiler: gcc
+            cmake-args: -G Ninja
+
+          - name: Windows GCC MinGW
+            os: windows-latest
+            compiler: gcc
+            cmake-args:  -G "MinGW Makefiles"
 
           - name: macOS Clang
             os: macOS-latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,6 +117,13 @@ option(PREFER_EXTERNAL_ZSTD
 
 set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 
+if(MINGW)
+    # This gets us DLL resource information when compiling on MinGW.
+    if(NOT CMAKE_RC_COMPILER)
+        set(CMAKE_RC_COMPILER windres.exe)
+    endif()
+endif(MINGW)
+
 if (ENABLE_ASAN)
     message(STATUS "Enabling ASAN")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -Os -fno-omit-frame-pointer -fsanitize=address")

--- a/blosc/frame.c
+++ b/blosc/frame.c
@@ -19,7 +19,7 @@
 #include "frame.h"
 #include "sframe.h"
 
-#if defined(_WIN32) && !defined(__MINGW32__)
+#if defined(_WIN32)
 #include <windows.h>
   #include <malloc.h>
 

--- a/blosc/schunk.c
+++ b/blosc/schunk.c
@@ -18,9 +18,12 @@
 #include "frame.h"
 #include "stune.h"
 
-#if defined(_WIN32) && !defined(__MINGW32__)
+#if defined(_WIN32)
   #include <windows.h>
+  #include <direct.h>
   #include <malloc.h>
+
+  #define mkdir(D, M) _mkdir(D)
 
 /* stdint.h only available in VS2010 (VC++ 16.0) and newer */
   #if defined(_MSC_VER) && _MSC_VER < 1600
@@ -31,11 +34,6 @@
 
 #endif  /* _WIN32 */
 
-#if defined(_WIN32)
-#include <direct.h>
-
-#define mkdir(D, M) _mkdir(D)
-#endif
 
 /* If C11 is supported, use it's built-in aligned allocation. */
 #if __STDC_VERSION__ >= 201112L

--- a/blosc/schunk.c
+++ b/blosc/schunk.c
@@ -21,9 +21,6 @@
 #if defined(_WIN32) && !defined(__MINGW32__)
   #include <windows.h>
   #include <malloc.h>
-  #include <direct.h>
-
-  #define mkdir _mkdir
 
 /* stdint.h only available in VS2010 (VC++ 16.0) and newer */
   #if defined(_MSC_VER) && _MSC_VER < 1600
@@ -33,6 +30,12 @@
   #endif
 
 #endif  /* _WIN32 */
+
+#if defined(_WIN32)
+#include <direct.h>
+
+#define mkdir(D, M) _mkdir(D)
+#endif
 
 /* If C11 is supported, use it's built-in aligned allocation. */
 #if __STDC_VERSION__ >= 201112L


### PR DESCRIPTION
With the MinGW-w64 gcc compiler there is an incompatibility due to the mkdir function.

Probably, it will be needed to add `-DCMAKE_RC_COMPILER=windres` as CMake Options in the settings to build the project.