### PR TITLE
Patch armv7l shuffle/bitshuffle support include header, lax-vector-conv

### DIFF
--- a/blosc/CMakeLists.txt
+++ b/blosc/CMakeLists.txt
@@ -194,7 +194,7 @@ if(COMPILER_SUPPORT_NEON)
         # Only armv7l needs special -mfpu=neon flag; aarch64 doesn't.
       set_source_files_properties(
             shuffle-neon.c bitshuffle-neon.c
-            PROPERTIES COMPILE_FLAGS "-mfpu=neon")
+            PROPERTIES COMPILE_FLAGS "-mfpu=neon -flax-vector-conversions")
     endif()
     # Define a symbol for the shuffle-dispatch implementation
     # so it knows NEON is supported even though that file is

--- a/blosc/shuffle.c
+++ b/blosc/shuffle.c
@@ -36,6 +36,7 @@
 #endif  /* defined(SHUFFLE_SSE2_ENABLED) */
 
 #if defined(SHUFFLE_NEON_ENABLED)
+  #include <sys/auxv.h>
   #include "shuffle-neon.h"
   #include "bitshuffle-neon.h"
 #endif  /* defined(SHUFFLE_NEON_ENABLED) */
@@ -251,7 +252,7 @@ static blosc_cpu_features blosc_get_cpu_features(void) {
   /* aarch64 always has NEON */
   cpu_features |= BLOSC_HAVE_NEON;
 #else
-  if (getauxval(AT_HWCAP) & HWCAP_NEON) {
+  if (getauxval(AT_HWCAP) & HWCAP_ARM_NEON) {
     cpu_features |= BLOSC_HAVE_NEON;
   }
 #endif

--- a/blosc/shuffle.c
+++ b/blosc/shuffle.c
@@ -36,7 +36,10 @@
 #endif  /* defined(SHUFFLE_SSE2_ENABLED) */
 
 #if defined(SHUFFLE_NEON_ENABLED)
-  #include <sys/auxv.h>
+  #ifndef __aarch64__
+    /* Avoid including Linux header on macOS */
+    #include <sys/auxv.h>
+  #endif
   #include "shuffle-neon.h"
   #include "bitshuffle-neon.h"
 #endif  /* defined(SHUFFLE_NEON_ENABLED) */


### PR DESCRIPTION
This patch resolves the armv7l build issues identified in #306 