### PR TITLE
Fix some issues with plugins

### DIFF
--- a/plugins/codecs/ndlz/CMakeLists.txt
+++ b/plugins/codecs/ndlz/CMakeLists.txt
@@ -1,24 +1,24 @@
 # sources
-set(SOURCES ${SOURCES} ndlz.c ndlz.h ndlz4x4.c ndlz4x4.h ndlz8x8.c ndlz8x8.h xxhash.c xxhash.h)
+set(SOURCES ${SOURCES} ndlz.c ndlz.h ndlz-private.h ndlz4x4.c ndlz4x4.h ndlz8x8.c ndlz8x8.h xxhash.c xxhash.h)
 
 # targets
-add_executable(test_ndlz test_ndlz.c ${SOURCES})
-# Define the BLOSC_TESTING symbol so normally-hidden functions
-# aren't hidden from the view of the test programs.
-set_property(
-        TARGET test_ndlz
-        APPEND PROPERTY COMPILE_DEFINITIONS BLOSC_TESTING)
-
-target_link_libraries(test_ndlz blosc_testing)
-
-# tests
 if(BUILD_TESTS)
-    add_test(test_plugin_test_ndlz test_ndlz)
-endif()
+    add_executable(test_ndlz test_ndlz.c ${SOURCES})
+    # Define the BLOSC_TESTING symbol so normally-hidden functions
+    # aren't hidden from the view of the test programs.
+    set_property(
+            TARGET test_ndlz
+            APPEND PROPERTY COMPILE_DEFINITIONS BLOSC_TESTING)
 
-# Copy test files
-file(GLOB TESTS_DATA ../../test_data/example_s*.caterva)
-foreach (data ${TESTS_DATA})
-    file(COPY ${data}
-            DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/)
-endforeach(data)
+    target_link_libraries(test_ndlz blosc_testing)
+
+    # tests
+        add_test(test_plugin_test_ndlz test_ndlz)
+
+    # Copy test files
+    file(GLOB TESTS_DATA ../../test_data/example_s*.caterva)
+    foreach (data ${TESTS_DATA})
+        file(COPY ${data}
+                DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/)
+    endforeach(data)
+endif()

--- a/plugins/codecs/ndlz/ndlz-private.h
+++ b/plugins/codecs/ndlz/ndlz-private.h
@@ -1,0 +1,124 @@
+/*********************************************************************
+  Blosc - Blocked Shuffling and Compression Library
+
+  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  https://blosc.org
+  License: BSD 3-Clause (see LICENSE.txt)
+
+  See LICENSE.txt for details about copyright and rights to use.
+**********************************************************************/
+
+
+
+#ifndef NDLZ_PRIVATE_H
+#define NDLZ_PRIVATE_H
+#include "context.h"
+
+#if defined (__cplusplus)
+extern "C" {
+#endif
+#define XXH_INLINE_ALL
+
+#define NDLZ_VERSION_STRING "1.0.0"
+
+#define NDLZ_ERROR_NULL(pointer)         \
+    do {                                 \
+        if ((pointer) == NULL) {         \
+            return 0;                    \
+        }                                \
+    } while (0)
+
+
+static void swap_store(void *dest, const void *pa, int size) {
+    uint8_t *pa_ = (uint8_t *) pa;
+    uint8_t pa2_[8];
+    int i = 1; /* for big/little endian detection */
+    char *p = (char *) &i;
+
+    if (p[0] == 1) {
+        /* little endian */
+        switch (size) {
+            case 8:
+                pa2_[0] = pa_[7];
+                pa2_[1] = pa_[6];
+                pa2_[2] = pa_[5];
+                pa2_[3] = pa_[4];
+                pa2_[4] = pa_[3];
+                pa2_[5] = pa_[2];
+                pa2_[6] = pa_[1];
+                pa2_[7] = pa_[0];
+                break;
+            case 4:
+                pa2_[0] = pa_[3];
+                pa2_[1] = pa_[2];
+                pa2_[2] = pa_[1];
+                pa2_[3] = pa_[0];
+                break;
+            case 2:
+                pa2_[0] = pa_[1];
+                pa2_[1] = pa_[0];
+                break;
+            case 1:
+                pa2_[0] = pa_[0];
+                break;
+            default:
+                fprintf(stderr, "Unhandled nitems: %d\n", size);
+        }
+    }
+    memcpy(dest, pa2_, size);
+}
+
+static int32_t deserialize_meta(uint8_t *smeta, uint32_t smeta_len, int8_t *ndim, int64_t *shape,
+                         int32_t *chunkshape, int32_t *blockshape) {
+    uint8_t *pmeta = smeta;
+
+    // Check that we have an array with 5 entries (version, ndim, shape, chunkshape, blockshape)
+    pmeta += 1;
+
+    // version entry
+    int8_t version = pmeta[0];  // positive fixnum (7-bit positive integer)
+    pmeta += 1;
+
+    // ndim entry
+    *ndim = pmeta[0];
+    int8_t ndim_aux = *ndim;  // positive fixnum (7-bit positive integer)
+    pmeta += 1;
+
+    // shape entry
+    // Initialize to ones, as required by Caterva
+    for (int i = 0; i < 8; i++) shape[i] = 1;
+    pmeta += 1;
+    for (int8_t i = 0; i < ndim_aux; i++) {
+        pmeta += 1;
+        swap_store(shape + i, pmeta, sizeof(int64_t));
+        pmeta += sizeof(int64_t);
+    }
+
+    // chunkshape entry
+    // Initialize to ones, as required by Caterva
+    for (int i = 0; i < 8; i++) chunkshape[i] = 1;
+    pmeta += 1;
+    for (int8_t i = 0; i < ndim_aux; i++) {
+        pmeta += 1;
+        swap_store(chunkshape + i, pmeta, sizeof(int32_t));
+        pmeta += sizeof(int32_t);
+    }
+
+    // blockshape entry
+    // Initialize to ones, as required by Caterva
+    for (int i = 0; i < 8; i++) blockshape[i] = 1;
+    pmeta += 1;
+    for (int8_t i = 0; i < ndim_aux; i++) {
+        pmeta += 1;
+        swap_store(blockshape + i, pmeta, sizeof(int32_t));
+        pmeta += sizeof(int32_t);
+    }
+    uint32_t slen = (uint32_t)(pmeta - smeta);
+    return 0;
+}
+
+#if defined (__cplusplus)
+}
+#endif
+
+#endif /* NDLZ_PRIVATE_H */

--- a/plugins/codecs/ndlz/ndlz.c
+++ b/plugins/codecs/ndlz/ndlz.c
@@ -18,99 +18,10 @@
 
 
 #include <stdio.h>
-#include "ndlz4x4.h"
 #include "ndlz.h"
+#include "ndlz-private.h"
+#include "ndlz4x4.h"
 #include "ndlz8x8.h"
-
-
-
-static void swap_store(void *dest, const void *pa, int size) {
-    uint8_t *pa_ = (uint8_t *) pa;
-    uint8_t pa2_[8];
-    int i = 1; /* for big/little endian detection */
-    char *p = (char *) &i;
-
-    if (p[0] == 1) {
-        /* little endian */
-        switch (size) {
-            case 8:
-                pa2_[0] = pa_[7];
-                pa2_[1] = pa_[6];
-                pa2_[2] = pa_[5];
-                pa2_[3] = pa_[4];
-                pa2_[4] = pa_[3];
-                pa2_[5] = pa_[2];
-                pa2_[6] = pa_[1];
-                pa2_[7] = pa_[0];
-                break;
-            case 4:
-                pa2_[0] = pa_[3];
-                pa2_[1] = pa_[2];
-                pa2_[2] = pa_[1];
-                pa2_[3] = pa_[0];
-                break;
-            case 2:
-                pa2_[0] = pa_[1];
-                pa2_[1] = pa_[0];
-                break;
-            case 1:
-                pa2_[0] = pa_[0];
-                break;
-            default:
-                fprintf(stderr, "Unhandled nitems: %d\n", size);
-        }
-    }
-    memcpy(dest, pa2_, size);
-}
-
-int32_t deserialize_meta(uint8_t *smeta, uint32_t smeta_len, int8_t *ndim, int64_t *shape,
-                         int32_t *chunkshape, int32_t *blockshape) {
-    uint8_t *pmeta = smeta;
-
-    // Check that we have an array with 5 entries (version, ndim, shape, chunkshape, blockshape)
-    pmeta += 1;
-
-    // version entry
-    int8_t version = pmeta[0];  // positive fixnum (7-bit positive integer)
-    pmeta += 1;
-
-    // ndim entry
-    *ndim = pmeta[0];
-    int8_t ndim_aux = *ndim;  // positive fixnum (7-bit positive integer)
-    pmeta += 1;
-
-    // shape entry
-    // Initialize to ones, as required by Caterva
-    for (int i = 0; i < 8; i++) shape[i] = 1;
-    pmeta += 1;
-    for (int8_t i = 0; i < ndim_aux; i++) {
-        pmeta += 1;
-        swap_store(shape + i, pmeta, sizeof(int64_t));
-        pmeta += sizeof(int64_t);
-    }
-
-    // chunkshape entry
-    // Initialize to ones, as required by Caterva
-    for (int i = 0; i < 8; i++) chunkshape[i] = 1;
-    pmeta += 1;
-    for (int8_t i = 0; i < ndim_aux; i++) {
-        pmeta += 1;
-        swap_store(chunkshape + i, pmeta, sizeof(int32_t));
-        pmeta += sizeof(int32_t);
-    }
-
-    // blockshape entry
-    // Initialize to ones, as required by Caterva
-    for (int i = 0; i < 8; i++) blockshape[i] = 1;
-    pmeta += 1;
-    for (int8_t i = 0; i < ndim_aux; i++) {
-        pmeta += 1;
-        swap_store(blockshape + i, pmeta, sizeof(int32_t));
-        pmeta += sizeof(int32_t);
-    }
-    uint32_t slen = (uint32_t)(pmeta - smeta);
-    return 0;
-}
 
 int ndlz_compress(const uint8_t *input, int32_t input_len, uint8_t *output, int32_t output_len,
                   uint8_t meta, blosc2_cparams *cparams) {

--- a/plugins/codecs/ndlz/ndlz.h
+++ b/plugins/codecs/ndlz/ndlz.h
@@ -17,32 +17,12 @@
 #if defined (__cplusplus)
 extern "C" {
 #endif
-#define XXH_INLINE_ALL
-
-#define NDLZ_VERSION_STRING "1.0.0"
-
-#define NDLZ_ERROR_NULL(pointer)         \
-    do {                                 \
-        if ((pointer) == NULL) {         \
-            return 0;                    \
-        }                                \
-    } while (0)
-
-
-
-
-static void swap_store(void *dest, const void *pa, int size);
-
-int32_t deserialize_meta(uint8_t *smeta, uint32_t smeta_len, int8_t *ndim, int64_t *shape,
-                         int32_t *chunkshape, int32_t *blockshape);
-
 
 int ndlz_compress(const uint8_t *input, int32_t input_len, uint8_t *output, int32_t output_len,
                    uint8_t meta, blosc2_cparams *cparams);
 
 int ndlz_decompress(const uint8_t *input, int32_t input_len, uint8_t *output, int32_t output_len,
                      uint8_t meta, blosc2_dparams *dparams);
-
 
 #if defined (__cplusplus)
 }

--- a/plugins/codecs/ndlz/ndlz4x4.h
+++ b/plugins/codecs/ndlz/ndlz4x4.h
@@ -18,6 +18,7 @@
 extern "C" {
 #endif
 #include "ndlz.h"
+#include "ndlz-private.h"
 /*
 #include <stdio.h>
 #include "blosc2-common.h"

--- a/plugins/codecs/ndlz/ndlz8x8.h
+++ b/plugins/codecs/ndlz/ndlz8x8.h
@@ -18,7 +18,7 @@
 extern "C" {
 #endif
 #include "ndlz.h"
-
+#include "ndlz-private.h"
 
 /**
   Compress a block of data in the input buffer and returns the size of

--- a/plugins/filters/ndcell/CMakeLists.txt
+++ b/plugins/filters/ndcell/CMakeLists.txt
@@ -1,24 +1,25 @@
 # sources
 set(SOURCES ndcell.c ndcell.h)
 
-# targets
-add_executable(test_ndcell test_ndcell.c ${SOURCES})
-# Define the BLOSC_TESTING symbol so normally-hidden functions
-# aren't hidden from the view of the test programs.
-set_property(
-        TARGET test_ndcell
-        APPEND PROPERTY COMPILE_DEFINITIONS BLOSC_TESTING)
-
-target_link_libraries(test_ndcell blosc_testing)
-
-# tests
 if(BUILD_TESTS)
-    add_test(test_plugin_test_ndcell test_ndcell)
-endif()
 
-# Copy test files
-file(GLOB TESTS_DATA ../../test_data/*.caterva)
-foreach (data ${TESTS_DATA})
-    file(COPY ${data}
-            DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/)
-endforeach(data)
+    # targets
+    add_executable(test_ndcell test_ndcell.c ${SOURCES})
+    # Define the BLOSC_TESTING symbol so normally-hidden functions
+    # aren't hidden from the view of the test programs.
+    set_property(
+            TARGET test_ndcell
+            APPEND PROPERTY COMPILE_DEFINITIONS BLOSC_TESTING)
+
+    target_link_libraries(test_ndcell blosc_testing)
+
+    # tests
+    add_test(test_plugin_test_ndcell test_ndcell)
+
+    # Copy test files
+    file(GLOB TESTS_DATA ../../test_data/*.caterva)
+    foreach (data ${TESTS_DATA})
+        file(COPY ${data}
+                DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/)
+    endforeach(data)
+endif()

--- a/plugins/filters/ndmean/CMakeLists.txt
+++ b/plugins/filters/ndmean/CMakeLists.txt
@@ -1,30 +1,30 @@
 # sources
 set(SOURCES ndmean.c ndmean.h)
 
-# targets
-add_executable(test_ndmean_repart test_ndmean_repart.c ${SOURCES})
-add_executable(test_ndmean_mean test_ndmean_mean.c ${SOURCES})
-# Define the BLOSC_TESTING symbol so normally-hidden functions
-# aren't hidden from the view of the test programs.
-set_property(
-        TARGET test_ndmean_mean
-        APPEND PROPERTY COMPILE_DEFINITIONS BLOSC_TESTING)
-set_property(
-        TARGET test_ndmean_repart
-        APPEND PROPERTY COMPILE_DEFINITIONS BLOSC_TESTING)
-
-target_link_libraries(test_ndmean_repart blosc_testing)
-target_link_libraries(test_ndmean_mean blosc_testing)
-
-# tests
 if(BUILD_TESTS)
+    # targets
+    add_executable(test_ndmean_repart test_ndmean_repart.c ${SOURCES})
+    add_executable(test_ndmean_mean test_ndmean_mean.c ${SOURCES})
+    # Define the BLOSC_TESTING symbol so normally-hidden functions
+    # aren't hidden from the view of the test programs.
+    set_property(
+            TARGET test_ndmean_mean
+            APPEND PROPERTY COMPILE_DEFINITIONS BLOSC_TESTING)
+    set_property(
+            TARGET test_ndmean_repart
+            APPEND PROPERTY COMPILE_DEFINITIONS BLOSC_TESTING)
+
+    target_link_libraries(test_ndmean_repart blosc_testing)
+    target_link_libraries(test_ndmean_mean blosc_testing)
+
+    # tests
     add_test(test_plugin_ndmean_repart test_ndmean_repart)
     add_test(test_plugin_ndmean_mean test_ndmean_mean)
-endif()
 
-# Copy test files
-file(GLOB TESTS_DATA *.caterva)
-foreach (data ${TESTS_DATA})
-    file(COPY ${data}
-            DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/)
-endforeach(data)
+    # Copy test files
+    file(GLOB TESTS_DATA *.caterva)
+    foreach (data ${TESTS_DATA})
+        file(COPY ${data}
+                DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/)
+    endforeach(data)
+endif()


### PR DESCRIPTION
- Not create test targets when the variable `BUILD_TESTS` is `OFF`.
- Only include the functions `ndlz_compress` and `ndlz_decompress` in `ndlz.h`. So, a `ndlz-private.h` is created.