### PR TITLE
Fix schunk_delete_chunk for an sframe

### DIFF
--- a/blosc/frame.c
+++ b/blosc/frame.c
@@ -3147,10 +3147,13 @@ void* frame_delete_chunk(blosc2_frame_s* frame, int nchunk, blosc2_schunk* schun
         BLOSC_TRACE_ERROR("Unable to get offset to chunk %d.", nchunk);
         return NULL;
       }
-      int err = sframe_delete_chunk(frame->urlpath, offset);
-      if (err != 0) {
-        BLOSC_TRACE_ERROR("Unable to delete chunk!");
-        return NULL;
+      if (offset >= 0){
+        // There is no need to delete any file if it is a special chunk
+        int err = sframe_delete_chunk(frame->urlpath, offset);
+        if (err != 0) {
+          BLOSC_TRACE_ERROR("Unable to delete chunk!");
+          return NULL;
+        }
       }
       // Update the offsets chunk in the chunks frame
       fp = sframe_open_index(frame->urlpath, "rb+", frame->schunk->storage->io);

--- a/blosc/frame.c
+++ b/blosc/frame.c
@@ -3148,7 +3148,7 @@ void* frame_delete_chunk(blosc2_frame_s* frame, int nchunk, blosc2_schunk* schun
         return NULL;
       }
       if (offset >= 0){
-        // There is no need to delete any file if it is a special chunk
+        // Remove the chunk file only if it is not a special value chunk
         int err = sframe_delete_chunk(frame->urlpath, offset);
         if (err != 0) {
           BLOSC_TRACE_ERROR("Unable to delete chunk!");

--- a/tests/test_delete_chunk.c
+++ b/tests/test_delete_chunk.c
@@ -94,7 +94,15 @@ static char* test_delete_chunk(void) {
     mu_assert("ERROR: bad append", nchunks_ > 0);
   }
 
-  for (int i = 0; i < tdata.ndeletes; ++i) {
+  if (tdata.nchunks >= 2) {
+    // Check that no file is removed if a special value chunk is deleted in a sframe
+    int _nchunks = blosc2_schunk_delete_chunk(schunk, 1);
+    mu_assert("ERROR: chunk 1 cannot be deleted correctly", _nchunks >= 0);
+    _nchunks = blosc2_schunk_delete_chunk(schunk, 0);
+    mu_assert("ERROR: chunk 0 cannot be deleted correctly", _nchunks >= 0);
+  }
+
+  for (int i = 0; i < tdata.ndeletes - 2; ++i) {
     // Delete in a random position
     int pos = rand() % (schunk->nchunks);
     int32_t nchunks_old = schunk->nchunks;


### PR DESCRIPTION
Do not delete the chunk file when it is a special value chunk.