### PR TITLE
Fixed integer overflow checking for valid header and trailer read lengths.

### DIFF
--- a/blosc/frame.c
+++ b/blosc/frame.c
@@ -1291,7 +1291,7 @@ static int get_meta_from_header(blosc2_frame_s* frame, blosc2_schunk* schunk, ui
     }
     // Go to offset and see if we have the correct marker
     uint8_t* content_marker = header + offset;
-    if (header_len < offset + 1 + 4) {
+    if (header_len < (size_t)offset + 1 + 4) {
       return BLOSC2_ERROR_READ_BUFFER;
     }
     if (*content_marker != 0xc6) {
@@ -1307,7 +1307,7 @@ static int get_meta_from_header(blosc2_frame_s* frame, blosc2_schunk* schunk, ui
     metalayer->content_len = content_len;
 
     // Finally, read the content
-    if (header_len < offset + 1 + 4 + content_len) {
+    if (header_len < (size_t)offset + 1 + 4 + content_len) {
       return BLOSC2_ERROR_READ_BUFFER;
     }
     char* content = malloc((size_t)content_len);
@@ -1461,7 +1461,7 @@ static int get_vlmeta_from_trailer(blosc2_frame_s* frame, blosc2_schunk* schunk,
     }
     // Go to offset and see if we have the correct marker
     uint8_t* content_marker = trailer + offset;
-    if (trailer_len < offset + 1 + 4) {
+    if (trailer_len < (size_t)offset + 1 + 4) {
       return BLOSC2_ERROR_READ_BUFFER;
     }
     if (*content_marker != 0xc6) {
@@ -1477,7 +1477,7 @@ static int get_vlmeta_from_trailer(blosc2_frame_s* frame, blosc2_schunk* schunk,
     metalayer->content_len = content_len;
 
     // Finally, read the content
-    if (trailer_len < offset + 1 + 4 + content_len) {
+    if (trailer_len < (size_t)offset + 1 + 4 + content_len) {
       return BLOSC2_ERROR_READ_BUFFER;
     }
     char* content = malloc((size_t)content_len);


### PR DESCRIPTION
https://oss-fuzz.com/testcase-detail/5957284579639296

We first cast to larger value then add. Otherwise `content_len` might be `INT32_MAX` and overflow.