### PR TITLE
Export blosc2_schunk_fill_special, fixes #321

### DIFF
--- a/include/blosc2.h
+++ b/include/blosc2.h
@@ -1744,7 +1744,7 @@ BLOSC_EXPORT int64_t blosc2_schunk_frame_len(blosc2_schunk* schunk);
  * @return The total number of chunks that have been added to the super-chunk.
  * If there is an error, a negative value is returned.
  */
-int blosc2_schunk_fill_special(blosc2_schunk* schunk, int64_t nitems, int special_value,
+BLOSC_EXPORT int blosc2_schunk_fill_special(blosc2_schunk* schunk, int64_t nitems, int special_value,
                                int32_t chunksize);
 
 


### PR DESCRIPTION
Despite being in blosc2.h, `blosc2_schunk_fill_special` is not exported like the other functions specified in the header with a similar name. This pull request exports `blosc2_schunk_fill_special`.

Additionally, an exported `blosc2_schunk_fill_special` is required to build the Caterva examples when building Blosc2 as a shared library.