### PR TITLE
Fix bug when updating a chunk of a cframe

### DIFF
--- a/blosc/frame.c
+++ b/blosc/frame.c
@@ -3020,6 +3020,7 @@ void* frame_update_chunk(blosc2_frame_s* frame, int nchunk, void* chunk, blosc2_
         io_cb->close(fp);
         return NULL;
       }
+      io_cb->seek(fp, header_len + new_cbytes, SEEK_SET);
     }
     wbytes = io_cb->write(off_chunk, 1, new_off_cbytes, fp);  // the new offsets
     io_cb->close(fp);

--- a/tests/test_update_chunk.c
+++ b/tests/test_update_chunk.c
@@ -118,6 +118,12 @@ static char* test_update_chunk(void) {
       mu_assert("ERROR: bad roundtrip", a == i);
     }
   }
+
+  // Check that the chunks can be decompressed
+  for (int nchunk = 0; nchunk < tdata.nchunks; nchunk++) {
+    dsize = blosc2_schunk_decompress_chunk(schunk, nchunk, (void *) data_dest, isize);
+    mu_assert("ERROR: chunk cannot be decompressed correctly", dsize >= 0);
+  }
   /* Free resources */
   if (!storage.contiguous && storage.urlpath != NULL) {
     blosc2_remove_dir(storage.urlpath);


### PR DESCRIPTION
When updating a chunk from a cframe, the index chunk was written immediately after the updated chunk. Thus, some data was overwritten by the index chunk.