### PR TITLE
Add error message when appending a chunk which is not multiple of typesize

### DIFF
--- a/blosc/blosc2.c
+++ b/blosc/blosc2.c
@@ -1915,9 +1915,8 @@ static int initialize_context_compression(
   int32_t blocksize, int16_t new_nthreads, int16_t nthreads,
   blosc2_btune *udbtune, void *btune_config,
   blosc2_schunk* schunk) {
-
   if (srcsize % typesize != 0) {
-    BLOSC_TRACE_ERROR("The srcsize must be a multiple of the typesize.");
+    BLOSC_TRACE_ERROR("srcsize must be a multiple of typesize.");
     return BLOSC2_ERROR_INVALID_PARAM;
   }
   /* Set parameters */

--- a/blosc/blosc2.c
+++ b/blosc/blosc2.c
@@ -1916,6 +1916,10 @@ static int initialize_context_compression(
   blosc2_btune *udbtune, void *btune_config,
   blosc2_schunk* schunk) {
 
+  if (srcsize % typesize != 0) {
+    BLOSC_TRACE_ERROR("The srcsize must be a multiple of the typesize.");
+    return BLOSC2_ERROR_INVALID_PARAM;
+  }
   /* Set parameters */
   context->do_compress = 1;
   context->src = (const uint8_t*)src;

--- a/blosc/schunk.c
+++ b/blosc/schunk.c
@@ -291,7 +291,9 @@ blosc2_schunk* blosc2_schunk_copy(blosc2_schunk *schunk, blosc2_storage *storage
     if (blosc2_vlmeta_get(schunk, name, &content, &content_len) < 0) {
       BLOSC_TRACE_ERROR("Can not get %s `vlmetalayer`.", name);
     }
-    if (blosc2_vlmeta_add(new_schunk, name, content, content_len, NULL) < 0) {
+    blosc2_cparams cparams2 = BLOSC2_CPARAMS_DEFAULTS;
+    cparams2.typesize = sizeof(uint8_t);
+    if (blosc2_vlmeta_add(new_schunk, name, content, content_len, &cparams2) < 0) {
       BLOSC_TRACE_ERROR("Can not add %s `vlmetalayer`.", name);
       return NULL;
     }

--- a/examples/frame_simple.c
+++ b/examples/frame_simple.c
@@ -83,7 +83,9 @@ int main(void) {
   for (uint32_t j = 0; j < content_len; ++j) {
     content[j] = (uint8_t) j;
   }
-  int umlen = blosc2_vlmeta_add(schunk, "vlmetalayer", content, content_len, NULL);
+  blosc2_cparams cparams2 = BLOSC2_CPARAMS_DEFAULTS;
+  cparams2.typesize = sizeof (uint8_t);
+  int umlen = blosc2_vlmeta_add(schunk, "vlmetalayer", content, content_len, &cparams2);
   free(content);
   if (umlen < 0) {
     printf("Cannot write vlmetalayers chunk");

--- a/examples/frame_vlmetalayers.c
+++ b/examples/frame_vlmetalayers.c
@@ -58,14 +58,16 @@ int main(void) {
   }
 
   // Add some vlmetalayers data
-  vlmetalater_len = blosc2_vlmeta_add(schunk, "vlmetalayer", (uint8_t *) "This is a vlmetalayers content...", 32, NULL);
+  blosc2_cparams cparams2 = BLOSC2_CPARAMS_DEFAULTS;
+  cparams2.typesize = sizeof(uint8_t);
+  vlmetalater_len = blosc2_vlmeta_add(schunk, "vlmetalayer", (uint8_t *) "This is a vlmetalayers content...", 32, &cparams2);
   if (vlmetalater_len < 0) {
     printf("Cannot write vlmetalayers chunk");
     return vlmetalater_len;
   }
 
   // Add some vlmetalayers data
-  vlmetalater_len = blosc2_vlmeta_add(schunk, "vlmetalayer2", (uint8_t *) "This is a content...", 10, NULL);
+  vlmetalater_len = blosc2_vlmeta_add(schunk, "vlmetalayer2", (uint8_t *) "This is a content...", 10, &cparams2);
   if (vlmetalater_len < 0) {
     printf("Cannot write vlmetalayers chunk");
     return vlmetalater_len;
@@ -73,7 +75,7 @@ int main(void) {
 
   vlmetalater_len = blosc2_vlmeta_update(schunk, "vlmetalayer", (uint8_t *) "This is a another vlmetalayer content...",
                                          20,
-                                         NULL);
+                                         &cparams2);
   if (vlmetalater_len < 0) {
     printf("Cannot write vlmetalayers chunk");
     return vlmetalater_len;

--- a/tests/fuzz/generate_inputs_corpus.c
+++ b/tests/fuzz/generate_inputs_corpus.c
@@ -97,7 +97,9 @@ int create_cframe(const char* compname) {
   for (uint32_t j = 0; j < content_len; ++j) {
     content[j] = (uint8_t) j;
   }
-  int umlen = blosc2_vlmeta_add(schunk, "vlmetalayer", content, content_len, NULL);
+  blosc2_cparams cparams2 = BLOSC2_CPARAMS_DEFAULTS;
+  cparams2.typesize = sizeof(uint8_t);
+  int umlen = blosc2_vlmeta_add(schunk, "vlmetalayer", content, content_len, &cparams2);
   free(content);
   if (umlen < 0) {
     printf("Cannot write vlmetalayers chunk");

--- a/tests/test_bitshuffle_leftovers.c
+++ b/tests/test_bitshuffle_leftovers.c
@@ -20,13 +20,10 @@ static int test_roundtrip_bitshuffle8(int size, void *data, void *data_out, void
   int isize = size;
   int osize = size + BLOSC_MIN_HEADER_LENGTH;
   int csize = blosc_compress(9, BLOSC_BITSHUFFLE, 8, isize, data, data_out, osize);
+  mu_assert("ERROR: undetected chunksize not being a multiple of typesize", csize < 0);
   if (csize == 0) {
     printf("Buffer is uncompressible.  Giving up.\n");
     return 1;
-  }
-  else if (csize < 0) {
-    printf("Compression error.  Error code: %d\n", csize);
-    return csize;
   }
   printf("Compression: %d -> %d (%.1fx)\n", isize, csize, (1.*isize) / csize);
 

--- a/tests/test_bitshuffle_leftovers.c
+++ b/tests/test_bitshuffle_leftovers.c
@@ -27,7 +27,7 @@ static int test_roundtrip_bitshuffle8(int size, void *data, void *data_out, void
   }
   printf("Compression: %d -> %d (%.1fx)\n", isize, csize, (1.*isize) / csize);
 
-  FILE *fout = fopen("test-bitshuffle8-nomemcpy.cdata", "w");
+  FILE *fout = fopen("test-bitshuffle8-nomemcpy.cdata", "wb");
   fwrite(data_out, csize, 1, fout);
   fclose(fout);
 
@@ -65,7 +65,7 @@ static int test_roundtrip_bitshuffle4(int size, void *data, void *data_out, void
   }
   printf("Compression: %d -> %d (%.1fx)\n", isize, csize, (1.*isize) / csize);
 
-  FILE *fout = fopen("test-bitshuffle4-memcpy.cdata", "w");
+  FILE *fout = fopen("test-bitshuffle4-memcpy.cdata", "wb");
   fwrite(data_out, csize, 1, fout);
   fclose(fout);
 

--- a/tests/test_compressor.c
+++ b/tests/test_compressor.c
@@ -210,7 +210,7 @@ static char *test_typesize(void) {
   setenv("BLOSC_TYPESIZE", "9", 0);
   cbytes2 = blosc_compress(clevel, doshuffle, typesize, size, src,
                            dest, size + BLOSC_MAX_OVERHEAD);
-  mu_assert("ERROR: BLOSC_TYPESIZE does not work correctly", cbytes2 > cbytes);
+  mu_assert("ERROR: undetected chunksize not being a multiple of typesize", cbytes2 < 0);
 
   /* Reset envvar */
   unsetenv("BLOSC_TYPESIZE");

--- a/tests/test_copy.c
+++ b/tests/test_copy.c
@@ -126,8 +126,10 @@ CUTEST_TEST_TEST(copy) {
   if (metalayers) {
     blosc2_meta_add(schunk, meta_name, (uint8_t *) &meta_content, meta_content_len);
   }
+  blosc2_cparams cparams2 = BLOSC2_CPARAMS_DEFAULTS;
+  cparams2.typesize = sizeof(uint8_t);
   if (vlmetalayers) {
-    blosc2_vlmeta_add(schunk, "vlmetalayer", (uint8_t *) &meta_content, meta_content_len, NULL);
+    blosc2_vlmeta_add(schunk, "vlmetalayer", (uint8_t *) &meta_content, meta_content_len, &cparams2);
   }
 
   /* Append the chunks */

--- a/tests/test_frame.c
+++ b/tests/test_frame.c
@@ -96,8 +96,10 @@ static char* test_frame(void) {
     blosc2_meta_add(schunk, "metalayer2", (uint8_t *) "my metalayer1", sizeof("my metalayer1"));
   }
 
+  blosc2_cparams cparams2 = BLOSC2_CPARAMS_DEFAULTS;
+  cparams2.typesize = sizeof(char);
   if (vlmetalayers) {
-    blosc2_vlmeta_add(schunk, "vlmetalayer", (uint8_t *) content, (int32_t) content_len, NULL);
+    blosc2_vlmeta_add(schunk, "vlmetalayer", (uint8_t *) content, (int32_t) content_len, &cparams2);
   }
 
   if (!sparse_schunk) {
@@ -151,7 +153,7 @@ static char* test_frame(void) {
     mu_assert("ERROR: bad vlmetalayers length in frame", (size_t) content_len_ == content_len);
     mu_assert("ERROR: bad vlmetalayers data in frame", strncmp((char*)content_, content, content_len) == 0);
     free(content_);
-    blosc2_vlmeta_update(schunk, "vlmetalayer", (uint8_t *) content2, (int32_t) content_len2, NULL);
+    blosc2_vlmeta_update(schunk, "vlmetalayer", (uint8_t *) content2, (int32_t) content_len2, &cparams2);
   }
 
   // Feed it with data
@@ -193,7 +195,7 @@ static char* test_frame(void) {
     mu_assert("ERROR: bad vlmetalayers length in frame", (size_t) content_len_ == content_len2);
     mu_assert("ERROR: bad vlmetalayers data in frame", strncmp((char*)content_, content2, content_len2) == 0);
     free(content_);
-    blosc2_vlmeta_update(schunk, "vlmetalayer", (uint8_t *) content3, (int32_t) content_len3, NULL);
+    blosc2_vlmeta_update(schunk, "vlmetalayer", (uint8_t *) content3, (int32_t) content_len3, &cparams2);
   }
 
   if (!sparse_schunk) {

--- a/tests/test_schunk.c
+++ b/tests/test_schunk.c
@@ -54,8 +54,10 @@ static char* test_schunk(void) {
   blosc2_meta_update(schunk, "metalayer2", (uint8_t *) "my metalayer2", sizeof("my metalayer2"));
 
   // Attach some user metadata into it
-  blosc2_vlmeta_add(schunk, "vlmetalayer1", (uint8_t *) "testing the vlmetalayers", 23, NULL);
-  blosc2_vlmeta_add(schunk, "vlmetalayer2", (uint8_t *) "vlmetalayers", 11, NULL);
+  blosc2_cparams cparams2 = BLOSC2_CPARAMS_DEFAULTS;
+  cparams2.typesize = sizeof(char);
+  blosc2_vlmeta_add(schunk, "vlmetalayer1", (uint8_t *) "testing the vlmetalayers", 23, &cparams2);
+  blosc2_vlmeta_add(schunk, "vlmetalayer2", (uint8_t *) "vlmetalayers", 11, &cparams2);
 
   /* Gather some info */
   nbytes = schunk->nbytes;
@@ -92,7 +94,7 @@ static char* test_schunk(void) {
     }
   }
   // update metalayer
-  blosc2_vlmeta_update(schunk, "vlmetalayer1", (uint8_t *) "testing the  vlmetalayers", 24, NULL);
+  blosc2_vlmeta_update(schunk, "vlmetalayer1", (uint8_t *) "testing the  vlmetalayers", 24, &cparams2);
 
   // metalayers
   uint8_t* content;

--- a/tests/test_sframe.c
+++ b/tests/test_sframe.c
@@ -79,10 +79,11 @@ static char* test_sframe(void) {
     blosc2_meta_add(schunk, "metalayer1", (uint8_t *) "my metalayer1", sizeof("my metalayer1"));
     blosc2_meta_add(schunk, "metalayer2", (uint8_t *) "my metalayer1", sizeof("my metalayer1"));
   }
-
+  blosc2_cparams cparams2 = BLOSC2_CPARAMS_DEFAULTS;
+  cparams2.typesize = sizeof(char);
   if (vlmetalayers) {
-    blosc2_vlmeta_add(schunk, "vlmetalayer", (uint8_t *) content, (int32_t) content_len, NULL);
-    blosc2_vlmeta_add(schunk, "vlmetalayer2", (uint8_t *) content2, (int32_t) content_len2, NULL);
+    blosc2_vlmeta_add(schunk, "vlmetalayer", (uint8_t *) content, (int32_t) content_len, &cparams2);
+    blosc2_vlmeta_add(schunk, "vlmetalayer2", (uint8_t *) content2, (int32_t) content_len2, &cparams2);
   }
 
   if (free_new) {
@@ -112,7 +113,7 @@ static char* test_sframe(void) {
     mu_assert("ERROR: bad vlmetalayers length in frame", (size_t) content_len_ == content_len);
     mu_assert("ERROR: bad vlmetalayers data in frame", strncmp((char*)content_, content, content_len) == 0);
     free(content_);
-    blosc2_vlmeta_update(schunk, "vlmetalayer", (uint8_t *) content2, (int32_t) content_len2, NULL);
+    blosc2_vlmeta_update(schunk, "vlmetalayer", (uint8_t *) content2, (int32_t) content_len2, &cparams2);
   }
 
   // Feed it with data
@@ -148,7 +149,7 @@ static char* test_sframe(void) {
     mu_assert("ERROR: bad vlmetalayers length in frame", (size_t) content_len_ == content_len2);
     mu_assert("ERROR: bad vlmetalayers data in frame", strncmp((char*)content_, content2, content_len2) == 0);
     free(content_);
-    blosc2_vlmeta_update(schunk, "vlmetalayer", (uint8_t *) content3, (int32_t) content_len3, NULL);
+    blosc2_vlmeta_update(schunk, "vlmetalayer", (uint8_t *) content3, (int32_t) content_len3, &cparams2);
   }
 
   if (free_new) {

--- a/tests/test_urcodecs.c
+++ b/tests/test_urcodecs.c
@@ -199,6 +199,7 @@ CUTEST_TEST_TEST(urcodecs) {
   schunk = blosc2_schunk_new(&storage);
   uint8_t codec_params = 222;
   blosc2_cparams cparams2 = BLOSC2_CPARAMS_DEFAULTS;
+  cparams2.typesize = sizeof(uint8_t);
   blosc2_vlmeta_add(schunk, "codec_arange", &codec_params, 1, &cparams2);
 
   for (nchunk = 0; nchunk < NCHUNKS; nchunk++) {


### PR DESCRIPTION
If `chunksize` is not multiple of `typesize` that means `typesize` has not been set correctly.