### PR TITLE
Update pkg-config file to support blosc2. Fixes #236.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -410,10 +410,10 @@ endif()
 # uninstall target
 if(BLOSC_INSTALL)
     configure_file(
-         "${CMAKE_CURRENT_SOURCE_DIR}/blosc.pc.in"
-         "${CMAKE_CURRENT_BINARY_DIR}/blosc.pc"
+         "${CMAKE_CURRENT_SOURCE_DIR}/blosc2.pc.in"
+         "${CMAKE_CURRENT_BINARY_DIR}/blosc2.pc"
          @ONLY)
-    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/blosc.pc"
+    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/blosc2.pc"
             DESTINATION lib/pkgconfig COMPONENT DEV)
      configure_file(
         "${CMAKE_CURRENT_SOURCE_DIR}/cmake_uninstall.cmake.in"

--- a/blosc2.pc.in
+++ b/blosc2.pc.in
@@ -4,11 +4,11 @@ libdir=${exec_prefix}/lib
 sharedlibdir=${libdir}
 includedir=${prefix}/include
 
-Name: blosc
+Name: blosc2
 Description: A blocking, shuffling and lossless compression library
-URL: http://blosc.org/
+URL: https://blosc.org/
 Version: @BLOSC_VERSION_STRING@
 
 Requires:
-Libs: -L${libdir} -L${sharedlibdir} -lblosc
+Libs: -L${libdir} -L${sharedlibdir} -lblosc2
 Cflags: -I${includedir}


### PR DESCRIPTION
Rename and update the pkg-config file.

For testing with one of the example files, one could use
```
cc simple.c `pkg-config --cflags --libs blosc2`
```

I only tested this on Debian 11, but regarding the small changes, I don't think that it should be a problem.