### PR TITLE
Build system: Change from hard coded 'lib' to CMAKE_INSTALL_LIBDIR. Fixes #341

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -409,12 +409,14 @@ endif()
 
 # uninstall target
 if(BLOSC_INSTALL)
+    include(GNUInstallDirs)
+    set(CMAKE_INSTALL_LIBDIR ${CMAKE_INSTALL_LIBDIR})
     configure_file(
          "${CMAKE_CURRENT_SOURCE_DIR}/blosc2.pc.in"
          "${CMAKE_CURRENT_BINARY_DIR}/blosc2.pc"
          @ONLY)
     install(FILES "${CMAKE_CURRENT_BINARY_DIR}/blosc2.pc"
-            DESTINATION lib/pkgconfig COMPONENT DEV)
+            DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig" COMPONENT DEV)
      configure_file(
         "${CMAKE_CURRENT_SOURCE_DIR}/cmake_uninstall.cmake.in"
         "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"

--- a/blosc/CMakeLists.txt
+++ b/blosc/CMakeLists.txt
@@ -62,8 +62,6 @@ if(COMPILER_SUPPORT_ALTIVEC)
 endif()
 set(SOURCES ${SOURCES} shuffle.c)
 
-# library install directory
-set(lib_dir lib${LIB_SUFFIX})
 set(version_string ${BLOSC_VERSION_MAJOR}.${BLOSC_VERSION_MINOR}.${BLOSC_VERSION_PATCH})
 
 set(CMAKE_THREAD_PREFER_PTHREAD TRUE) # pre 3.1
@@ -291,14 +289,14 @@ if(BLOSC_INSTALL)
 
     if(BUILD_SHARED)
         install(TARGETS blosc2_shared
-                LIBRARY DESTINATION ${lib_dir}
-                ARCHIVE DESTINATION ${lib_dir}
+                LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+                ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
                 RUNTIME DESTINATION bin COMPONENT LIB)
     endif()
     if(BUILD_STATIC)
         install(TARGETS blosc2_static
-                LIBRARY DESTINATION ${lib_dir}
-                ARCHIVE DESTINATION ${lib_dir}
+                LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+                ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
                 RUNTIME DESTINATION bin COMPONENT LIB)
     endif()
 endif()

--- a/blosc2.pc.in
+++ b/blosc2.pc.in
@@ -1,6 +1,6 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
-libdir=${exec_prefix}/lib
+libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
 sharedlibdir=${libdir}
 includedir=${prefix}/include
 

--- a/plugins/codecs/ndlz/ndlz.c
+++ b/plugins/codecs/ndlz/ndlz.c
@@ -37,7 +37,7 @@ int ndlz_compress(const uint8_t *input, int32_t input_len, uint8_t *output, int3
             return ndlz8_compress(input, input_len, output, output_len, meta, cparams);
             break;
         default:
-            printf("\n NDLZ is not avaiable for this cellsize \n");
+            printf("\n NDLZ is not available for this cellsize \n");
             return 0;
     }
 }
@@ -56,7 +56,7 @@ int ndlz_decompress(const uint8_t *input, int32_t input_len, uint8_t *output, in
             return ndlz8_decompress(input, input_len, output, output_len, meta, dparams);
             break;
         default:
-            printf("\n NDLZ is not avaiable for this cellsize \n");
+            printf("\n NDLZ is not available for this cellsize \n");
             return 0;
     }
 }

--- a/plugins/codecs/ndlz/ndlz4x4.c
+++ b/plugins/codecs/ndlz/ndlz4x4.c
@@ -682,7 +682,7 @@ int ndlz4_decompress(const uint8_t *input, int32_t input_len, uint8_t *output, i
   ind += padding[1];
 
   if (ind != (blockshape[0] * blockshape[1])) {
-    printf("Output size is not compatible with embeded blockshape \n");
+    printf("Output size is not compatible with embedded blockshape \n");
     return 0;
   }
   if (ind > (uint32_t) output_len) {

--- a/plugins/codecs/ndlz/ndlz8x8.c
+++ b/plugins/codecs/ndlz/ndlz8x8.c
@@ -563,7 +563,7 @@ int ndlz8_decompress(const uint8_t *input, int32_t input_len, uint8_t *output, i
   free(local_buffer);
 
   if (ind != (blockshape[0] * blockshape[1])) {
-    printf("Output size is not compatible with embeded blockshape \n");
+    printf("Output size is not compatible with embedded blockshape \n");
     return 0;
   }
   if (ind > (uint32_t) output_len) {

--- a/plugins/filters/ndcell/ndcell.c
+++ b/plugins/filters/ndcell/ndcell.c
@@ -343,7 +343,7 @@ int ndcell_decoder(const uint8_t* input, uint8_t* output, int32_t length, int8_t
         free(shape);
         free(chunkshape);
         free(blockshape);
-        printf("Output size is not compatible with embeded blockshape ind %d %d \n", ind, (blocksize / typesize));
+        printf("Output size is not compatible with embedded blockshape ind %d %d \n", ind, (blocksize / typesize));
         return 0;
     }
 

--- a/plugins/filters/ndmean/ndmean.c
+++ b/plugins/filters/ndmean/ndmean.c
@@ -414,7 +414,7 @@ int ndmean_decoder(const uint8_t* input, uint8_t* output, int32_t length, int8_t
     free(blockshape);
 
     if (ind != (int32_t) (blocksize / typesize)) {
-        printf("Output size is not compatible with embeded blockshape ind %d %d \n", ind, (blocksize / typesize));
+        printf("Output size is not compatible with embedded blockshape ind %d %d \n", ind, (blocksize / typesize));
         return 0;
     }
 


### PR DESCRIPTION
Removes the hard coded library path `lib`. Replaces it with `CMAKE_INSTALL_LIBDIR`. This also sets the same path in the pkg-config file.

Depending on how you configure with CMake, the path will default to `lib` or the distribution specific library path. It can be overridden if specifying `-DCMAKE_INSTALL_LIBDIR=your_libdir_path` during CMake configuration. The variable is also avaliable for manual change when configuring with `ccmake`.

The `CMAKE_INSTALL_LIBDIR` is included with `GNUInstallDirs`. There is several other `CMAKE_INSTALL_*` variables like this.


The pr also includes a commit regarding some typos found by lintian.