### PR TITLE
Fix build on FreeBSD/powerpc64le

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -303,7 +303,7 @@ elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL armv7l OR
         # Unrecognized compiler. Emit a warning message to let the user know hardware-acceleration won't be available.
         message(WARNING "Unable to determine which ${CMAKE_SYSTEM_PROCESSOR} hardware features are supported by the C compiler (${CMAKE_C_COMPILER_ID} ${CMAKE_C_COMPILER_VERSION}).")
     endif()
-elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL ppc64le)
+elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "^(ppc64le|powerpc64le)")
     if(CMAKE_C_COMPILER_ID STREQUAL GNU AND CMAKE_C_COMPILER_VERSION VERSION_GREATER 8)
         set(COMPILER_SUPPORT_ALTIVEC TRUE)
     else()


### PR DESCRIPTION
64 bit POWER little endian is called powerpc64le on FreeBSD.