### PR TITLE
vlmeta len changed from uint32 to int32

### DIFF
--- a/blosc/schunk.c
+++ b/blosc/schunk.c
@@ -1187,7 +1187,7 @@ int metalayer_flush(blosc2_schunk* schunk) {
  *
  * If successful, return the index of the new metalayer.  Else, return a negative value.
  */
-int blosc2_meta_add(blosc2_schunk *schunk, const char *name, uint8_t *content, uint32_t content_len) {
+int blosc2_meta_add(blosc2_schunk *schunk, const char *name, uint8_t *content, int32_t content_len) {
   int nmetalayer = blosc2_meta_exists(schunk, name);
   if (nmetalayer >= 0) {
     BLOSC_TRACE_ERROR("Metalayer \"%s\" already exists.", name);
@@ -1219,7 +1219,7 @@ int blosc2_meta_add(blosc2_schunk *schunk, const char *name, uint8_t *content, u
  *
  * If successful, return the index of the new metalayer.  Else, return a negative value.
  */
-int blosc2_meta_update(blosc2_schunk *schunk, const char *name, uint8_t *content, uint32_t content_len) {
+int blosc2_meta_update(blosc2_schunk *schunk, const char *name, uint8_t *content, int32_t content_len) {
   int nmetalayer = blosc2_meta_exists(schunk, name);
   if (nmetalayer < 0) {
     BLOSC_TRACE_ERROR("Metalayer \"%s\" not found.", name);
@@ -1256,7 +1256,7 @@ int blosc2_meta_update(blosc2_schunk *schunk, const char *name, uint8_t *content
  * If successful, return the index of the new metalayer.  Else, return a negative value.
  */
 int blosc2_meta_get(blosc2_schunk *schunk, const char *name, uint8_t **content,
-                    uint32_t *content_len) {
+                    int32_t *content_len) {
   int nmetalayer = blosc2_meta_exists(schunk, name);
   if (nmetalayer < 0) {
     BLOSC_TRACE_ERROR("Metalayer \"%s\" not found.", name);
@@ -1309,7 +1309,7 @@ int vlmetalayer_flush(blosc2_schunk* schunk) {
  *
  * If successful, return the index of the new variable-length metalayer.  Else, return a negative value.
  */
-int blosc2_vlmeta_add(blosc2_schunk *schunk, const char *name, uint8_t *content, uint32_t content_len,
+int blosc2_vlmeta_add(blosc2_schunk *schunk, const char *name, uint8_t *content, int32_t content_len,
                       blosc2_cparams *cparams) {
   int nvlmetalayer = blosc2_vlmeta_exists(schunk, name);
   if (nvlmetalayer >= 0) {
@@ -1353,7 +1353,7 @@ int blosc2_vlmeta_add(blosc2_schunk *schunk, const char *name, uint8_t *content,
 
 
 int blosc2_vlmeta_get(blosc2_schunk *schunk, const char *name, uint8_t **content,
-                      uint32_t *content_len) {
+                      int32_t *content_len) {
   int nvlmetalayer = blosc2_vlmeta_exists(schunk, name);
   if (nvlmetalayer < 0) {
     BLOSC_TRACE_ERROR("User metalayer \"%s\" not found.", name);
@@ -1378,7 +1378,7 @@ int blosc2_vlmeta_get(blosc2_schunk *schunk, const char *name, uint8_t **content
   return nvlmetalayer;
 }
 
-int blosc2_vlmeta_update(blosc2_schunk *schunk, const char *name, uint8_t *content, uint32_t content_len,
+int blosc2_vlmeta_update(blosc2_schunk *schunk, const char *name, uint8_t *content, int32_t content_len,
                          blosc2_cparams *cparams) {
   int nvlmetalayer = blosc2_vlmeta_exists(schunk, name);
   if (nvlmetalayer < 0) {

--- a/include/blosc2.h
+++ b/include/blosc2.h
@@ -1773,7 +1773,7 @@ BLOSC_EXPORT int blosc2_meta_exists(blosc2_schunk *schunk, const char *name);
  * @return If successful, the index of the new metalayer. Else, return a negative value.
  */
 BLOSC_EXPORT int blosc2_meta_add(blosc2_schunk *schunk, const char *name, uint8_t *content,
-                                 uint32_t content_len);
+                                 int32_t content_len);
 
 /**
  * @brief Update the content of an existing metalayer.
@@ -1789,7 +1789,7 @@ BLOSC_EXPORT int blosc2_meta_add(blosc2_schunk *schunk, const char *name, uint8_
  * @return If successful, the index of the metalayer. Else, return a negative value.
  */
 BLOSC_EXPORT int blosc2_meta_update(blosc2_schunk *schunk, const char *name, uint8_t *content,
-                                    uint32_t content_len);
+                                    int32_t content_len);
 
 /**
  * @brief Get the content out of a metalayer.
@@ -1805,7 +1805,7 @@ BLOSC_EXPORT int blosc2_meta_update(blosc2_schunk *schunk, const char *name, uin
  * @return If successful, the index of the new metalayer. Else, return a negative value.
  */
 BLOSC_EXPORT int blosc2_meta_get(blosc2_schunk *schunk, const char *name, uint8_t **content,
-                                 uint32_t *content_len);
+                                 int32_t *content_len);
 
 
 /*********************************************************************
@@ -1835,7 +1835,7 @@ BLOSC_EXPORT int blosc2_vlmeta_exists(blosc2_schunk *schunk, const char *name);
  * @return If successful, the index of the new variable-length metalayer. Else, return a negative value.
  */
 BLOSC_EXPORT int blosc2_vlmeta_add(blosc2_schunk *schunk, const char *name,
-                                   uint8_t *content, uint32_t content_len,
+                                   uint8_t *content, int32_t content_len,
                                    blosc2_cparams *cparams);
 
 /**
@@ -1851,7 +1851,7 @@ BLOSC_EXPORT int blosc2_vlmeta_add(blosc2_schunk *schunk, const char *name,
  * @return If successful, the index of the variable-length metalayer. Else, return a negative value.
  */
 BLOSC_EXPORT int blosc2_vlmeta_update(blosc2_schunk *schunk, const char *name,
-                                      uint8_t *content, uint32_t content_len,
+                                      uint8_t *content, int32_t content_len,
                                       blosc2_cparams *cparams);
 
 /**
@@ -1868,7 +1868,7 @@ BLOSC_EXPORT int blosc2_vlmeta_update(blosc2_schunk *schunk, const char *name,
  * @return If successful, the index of the new variable-length metalayer. Else, return a negative value.
  */
 BLOSC_EXPORT int blosc2_vlmeta_get(blosc2_schunk *schunk, const char *name,
-                                   uint8_t **content, uint32_t *content_len);
+                                   uint8_t **content, int32_t *content_len);
 
 /**
  * @brief Delete the variable-length metalayer from the super-chunk.

--- a/plugins/codecs/ndlz/ndlz4x4.c
+++ b/plugins/codecs/ndlz/ndlz4x4.c
@@ -64,7 +64,7 @@ int ndlz4_compress(const uint8_t *input, int32_t input_len, uint8_t *output, int
   int32_t* chunkshape = malloc(8 * sizeof(int32_t));
   int32_t* blockshape = malloc(8 * sizeof(int32_t));
   uint8_t* smeta;
-  uint32_t smeta_len;
+  int32_t smeta_len;
   if (blosc2_meta_get(cparams->schunk, "caterva", &smeta, &smeta_len) < 0) {
     printf("Blosc error");
     return -1;
@@ -76,7 +76,7 @@ int ndlz4_compress(const uint8_t *input, int32_t input_len, uint8_t *output, int
     fprintf(stderr, "This codec only works for ndim = 2");
     return -1;
   }
-  
+
   if (input_len != (blockshape[0] * blockshape[1])) {
     printf("Length not equal to blocksize \n");
     return -1;

--- a/plugins/codecs/ndlz/ndlz8x8.c
+++ b/plugins/codecs/ndlz/ndlz8x8.c
@@ -66,7 +66,7 @@ int ndlz8_compress(const uint8_t *input, int32_t input_len, uint8_t *output, int
   int32_t* chunkshape = malloc(8 * sizeof(int32_t));
   int32_t* blockshape = malloc(8 * sizeof(int32_t));
   uint8_t* smeta;
-  uint32_t smeta_len;
+  int32_t smeta_len;
   if (blosc2_meta_get(cparams->schunk, "caterva", &smeta, &smeta_len) < 0) {
     printf("Blosc error");
     return 0;

--- a/plugins/filters/ndcell/ndcell.c
+++ b/plugins/filters/ndcell/ndcell.c
@@ -119,7 +119,7 @@ int ndcell_encoder(const uint8_t* input, uint8_t* output, int32_t length, int8_t
     int32_t* chunkshape = malloc(8 * sizeof(int32_t));
     int32_t* blockshape = malloc(8 * sizeof(int32_t));
     uint8_t* smeta;
-    uint32_t smeta_len;
+    int32_t smeta_len;
     if (blosc2_meta_get(cparams->schunk, "caterva", &smeta, &smeta_len) < 0) {
         free(shape);
         free(chunkshape);
@@ -241,7 +241,7 @@ int ndcell_decoder(const uint8_t* input, uint8_t* output, int32_t length, int8_t
     int32_t* chunkshape = malloc(8 * sizeof(int32_t));
     int32_t* blockshape = malloc(8 * sizeof(int32_t));
     uint8_t* smeta;
-    uint32_t smeta_len;
+    int32_t smeta_len;
     if (blosc2_meta_get(schunk, "caterva", &smeta, &smeta_len) < 0) {
         free(shape);
         free(chunkshape);

--- a/plugins/filters/ndmean/ndmean.c
+++ b/plugins/filters/ndmean/ndmean.c
@@ -123,7 +123,7 @@ int ndmean_encoder(const uint8_t* input, uint8_t* output, int32_t length, int8_t
     int32_t* chunkshape = malloc(8 * sizeof(int32_t));
     int32_t* blockshape = malloc(8 * sizeof(int32_t));
     uint8_t* smeta;
-    uint32_t smeta_len;
+    int32_t smeta_len;
     if (blosc2_meta_get(cparams->schunk, "caterva", &smeta, &smeta_len) < 0) {
         free(shape);
         free(chunkshape);
@@ -301,7 +301,7 @@ int ndmean_decoder(const uint8_t* input, uint8_t* output, int32_t length, int8_t
     int32_t* chunkshape = malloc(8 * sizeof(int32_t));
     int32_t* blockshape = malloc(8 * sizeof(int32_t));
     uint8_t* smeta;
-    uint32_t smeta_len;
+    int32_t smeta_len;
     if (blosc2_meta_get(schunk, "caterva", &smeta, &smeta_len) < 0) {
         free(shape);
         free(chunkshape);


### PR DESCRIPTION
The vlmeta data can never be larger than `2**31` (chunk limit in Blosc2), so there is little point in declaring this as `uint32_t`; `int32_t` is a much better fit. 

Although this is an API change, this is shallow enough to not represent a big problem in existing code dependent on it (besides having to fix some warnings).

Fixes the issue during conversation in https://github.com/Blosc/caterva/pull/86