### PR TITLE
typesize is unisgned, it cannot be negative

### DIFF
--- a/blosc/blosc2.c
+++ b/blosc/blosc2.c
@@ -668,7 +668,7 @@ int read_chunk_header(const uint8_t* src, int32_t srcsize, bool extended_header,
     BLOSC_TRACE_ERROR("`blocksize` greater than maximum allowed");
     return BLOSC2_ERROR_INVALID_HEADER;
   }
-  if (header->typesize <= 0 || header->typesize > BLOSC_MAX_TYPESIZE) {
+  if (header->typesize == 0 || header->typesize > BLOSC_MAX_TYPESIZE) {
     BLOSC_TRACE_ERROR("`typesize` is zero or greater than max allowed.");
     return BLOSC2_ERROR_INVALID_HEADER;
   }


### PR DESCRIPTION
https://github.com/Blosc/c-blosc2/blob/b2434ad1be6ea46e101e0691bfd6b2a43174cc8a/blosc/blosc2.c#L622

Additionally, the value of both `BLOSC_MAX_TYPESIZE` and `UINT8_MAX` is 255. It doesn't make sense to test whether an `uint8_t` is larger than 255. Perhaps it would make sense to define `BLOSC_MAX_TYPESIZE` as `UINT8_MAX` instead?
https://github.com/Blosc/c-blosc2/blob/b2434ad1be6ea46e101e0691bfd6b2a43174cc8a/include/blosc2.h#L105-L106