### PR TITLE
fix: surround all headers in blosc2.h with extern "C" in C++ mode

### DIFF
--- a/include/blosc2.h
+++ b/include/blosc2.h
@@ -25,9 +25,16 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdio.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 #include "blosc2/blosc2-export.h"
 #include "blosc2/blosc2-common.h"
 #include "blosc2/blosc2-stdio.h"
+#ifdef __cplusplus
+}
+#endif
 
 #if defined(_WIN32) && !defined(__MINGW32__)
 #include <windows.h>


### PR DESCRIPTION
Problem: not all headers in `blosc.h` are surrounded with a `extern "C"` in C++ mode. This leads to linkage problems with using this lib from C++.

This problem can be solved either by surrounding the `blosc2-*` headers in the top-level header (if only this header is intended for C++ use without manual `extern "C"`) or by using `extern "C"` in all headers. Please tell me which solution is preferred!