### PR TITLE
Adapt getitem to use ZFP

### DIFF
--- a/blosc/blosc-private.h
+++ b/blosc/blosc-private.h
@@ -175,6 +175,9 @@ int register_filter_private(blosc2_filter *filter);
  */
 int register_codec_private(blosc2_codec *codec);
 
+int blosc_decompression_context_from_source(blosc2_context* context, const void* src, int32_t srcsize,
+                                            void* dest, int32_t destsize);
+
 #ifdef __cplusplus
 }
 #endif

--- a/blosc/blosc-private.h
+++ b/blosc/blosc-private.h
@@ -175,9 +175,6 @@ int register_filter_private(blosc2_filter *filter);
  */
 int register_codec_private(blosc2_codec *codec);
 
-int blosc_decompression_context_from_source(blosc2_context* context, const void* src, int32_t srcsize,
-                                            void* dest, int32_t destsize);
-
 #ifdef __cplusplus
 }
 #endif

--- a/blosc/blosc2.c
+++ b/blosc/blosc2.c
@@ -2621,24 +2621,6 @@ int blosc_compress(int clevel, int doshuffle, size_t typesize, size_t nbytes,
 }
 
 
-
-int blosc_decompression_context_from_source(blosc2_context* context, const void* src, int32_t srcsize,
-                                            void* dest, int32_t destsize) {
-    blosc_header header;
-    int rc = read_chunk_header(src, srcsize, true, &header);
-    if (rc < 0) {
-        return rc;
-    }
-    if (header.nbytes > destsize) {
-        // Not enough space for writing into the destination
-        return BLOSC2_ERROR_WRITE_BUFFER;
-    }
-
-    return initialize_context_decompression(context, &header, src, srcsize, dest, destsize);
-}
-
-
-
 int blosc_run_decompression_with_context(blosc2_context* context, const void* src, int32_t srcsize,
                                          void* dest, int32_t destsize) {
   blosc_header header;

--- a/blosc/blosc2.c
+++ b/blosc/blosc2.c
@@ -2851,6 +2851,19 @@ int _blosc_getitem(blosc2_context* context, blosc_header* header, const void* sr
       stopb = header->blocksize;
     }
     bsize2 = stopb - startb;
+#if defined(HAVE_PLUGINS)
+  uint8_t ndim;
+  for (int nmetalayer = 0; nmetalayer < context->schunk->nmetalayers; nmetalayer++) {
+      if (strcmp("caterva", context->schunk->metalayers[nmetalayer]->name) == 0) {
+          ndim = context->schunk->metalayers[nmetalayer]->content[2];
+      }
+  }
+  int cell_nitems = (int) (1u << (2 * ndim));
+  if ((context->compcode == BLOSC_CODEC_ZFP_FIXED_RATE) && (nitems <= cell_nitems)) {
+    context->cell_start = startb;
+    context->zfp_nitems = nitems;
+}
+#endif /* HAVE_PLUGINS */
 
     /* Do the actual data copy */
     // Regular decompression.  Put results in tmp2.
@@ -2875,6 +2888,8 @@ int _blosc_getitem(blosc2_context* context, blosc_header* header, const void* sr
     }
     ntbytes += bsize2;
   }
+
+  context->cell_start = -1;
 
   return ntbytes;
 }

--- a/blosc/blosc2.c
+++ b/blosc/blosc2.c
@@ -2612,6 +2612,23 @@ int blosc_compress(int clevel, int doshuffle, size_t typesize, size_t nbytes,
 
 
 
+int blosc_decompression_context_from_source(blosc2_context* context, const void* src, int32_t srcsize,
+                                            void* dest, int32_t destsize) {
+    blosc_header header;
+    int rc = read_chunk_header(src, srcsize, true, &header);
+    if (rc < 0) {
+        return rc;
+    }
+    if (header.nbytes > destsize) {
+        // Not enough space for writing into the destination
+        return BLOSC2_ERROR_WRITE_BUFFER;
+    }
+
+    return initialize_context_decompression(context, &header, src, srcsize, dest, destsize);
+}
+
+
+
 int blosc_run_decompression_with_context(blosc2_context* context, const void* src, int32_t srcsize,
                                          void* dest, int32_t destsize) {
   blosc_header header;

--- a/blosc/blosc2.c
+++ b/blosc/blosc2.c
@@ -1589,6 +1589,7 @@ static int blosc_d(
         return BLOSC2_ERROR_POSTFILTER;
       }
     }
+    context->zfp_cell_nitems = 0;
     return bsize_;
   }
 
@@ -1712,7 +1713,7 @@ static int blosc_d(
 
 #if defined(HAVE_PLUGINS)
         if ((context->compcode == BLOSC_CODEC_ZFP_FIXED_RATE) && (context->zfp_cell_nitems > 0)) {
-        nbytes = zfp_getcell(context, src, cbytes, _dest, neblock);
+          nbytes = zfp_getcell(context, src, cbytes, _dest, neblock);
           if (nbytes < 0) {
             return BLOSC2_ERROR_DATA;
           }
@@ -1722,6 +1723,7 @@ static int blosc_d(
         }
 #endif /* HAVE_PLUGINS */
         if (!getcell) {
+          context->zfp_cell_nitems = 0;
           for (int i = 0; i < g_ncodecs; ++i) {
             if (g_codecs[i].compcode == context->compcode) {
               blosc2_dparams dparams;
@@ -2892,7 +2894,9 @@ int _blosc_getitem(blosc2_context* context, blosc_header* header, const void* sr
       ntbytes = cbytes;
       break;
     }
-    if (!get_single_block) {
+    if (context->zfp_cell_nitems > 0) {
+        memcpy((uint8_t *) dest, tmp2, (unsigned int) bsize2);
+    } else if (!get_single_block) {
       /* Copy to destination */
       memcpy((uint8_t *) dest + ntbytes, tmp2 + startb, (unsigned int) bsize2);
     }

--- a/blosc/blosc2.c
+++ b/blosc/blosc2.c
@@ -1736,9 +1736,9 @@ static int blosc_d(
               goto urcodecsuccess;
             }
           }
+          BLOSC_TRACE_ERROR("User-defined compressor codec %d not found during decompression", context->compcode);
+          return BLOSC2_ERROR_CODEC_SUPPORT;
         }
-        BLOSC_TRACE_ERROR("User-defined compressor codec %d not found during decompression", context->compcode);
-        return BLOSC2_ERROR_CODEC_SUPPORT;
       urcodecsuccess:
         ;
       }
@@ -1752,7 +1752,7 @@ static int blosc_d(
       }
 
       /* Check that decompressed bytes number is correct */
-      if (nbytes != neblock) {
+      if ((nbytes != neblock) && (context->zfp_cell_nitems == 0)) {
         return BLOSC2_ERROR_DATA;
       }
 
@@ -2870,7 +2870,7 @@ int _blosc_getitem(blosc2_context* context, blosc_header* header, const void* sr
 
 #if defined(HAVE_PLUGINS)
     if (context->compcode == BLOSC_CODEC_ZFP_FIXED_RATE) {
-      context->zfp_cell_start = startb;
+      context->zfp_cell_start = startb / context->typesize;
       context->zfp_cell_nitems = nitems;
     }
 #endif /* HAVE_PLUGINS */

--- a/blosc/blosc2.c
+++ b/blosc/blosc2.c
@@ -2861,6 +2861,19 @@ int _blosc_getitem(blosc2_context* context, blosc_header* header, const void* sr
       stopb = header->blocksize;
     }
     bsize2 = stopb - startb;
+#if defined(HAVE_PLUGINS)
+  uint8_t ndim;
+  for (int nmetalayer = 0; nmetalayer < context->schunk->nmetalayers; nmetalayer++) {
+      if (strcmp("caterva", context->schunk->metalayers[nmetalayer]->name) == 0) {
+          ndim = context->schunk->metalayers[nmetalayer]->content[2];
+      }
+  }
+  int cell_nitems = (int) (1u << (2 * ndim));
+  if ((context->compcode == BLOSC_CODEC_ZFP_FIXED_RATE) && (nitems <= cell_nitems)) {
+    context->cell_start = startb;
+    context->zfp_nitems = nitems;
+}
+#endif /* HAVE_PLUGINS */
 
     /* Do the actual data copy */
     // Regular decompression.  Put results in tmp2.
@@ -2885,6 +2898,8 @@ int _blosc_getitem(blosc2_context* context, blosc_header* header, const void* sr
     }
     ntbytes += bsize2;
   }
+
+  context->cell_start = -1;
 
   return ntbytes;
 }

--- a/blosc/blosc2.c
+++ b/blosc/blosc2.c
@@ -2887,7 +2887,12 @@ int _blosc_getitem(blosc2_context* context, blosc_header* header, const void* sr
       break;
     }
     if (context->zfp_cell_nitems > 0) {
+      if (cbytes == bsize2) {
         memcpy((uint8_t *) dest, tmp2, (unsigned int) bsize2);
+      } else if (cbytes == context->blocksize) {
+        memcpy((uint8_t *) dest, tmp2 + context->zfp_cell_start * context->typesize, (unsigned int) bsize2);
+        cbytes = bsize2;
+      }
     } else if (!get_single_block) {
       /* Copy to destination */
       memcpy((uint8_t *) dest + ntbytes, tmp2 + startb, (unsigned int) bsize2);

--- a/blosc/blosc2.c
+++ b/blosc/blosc2.c
@@ -1711,9 +1711,12 @@ static int blosc_d(
         bool getcell = false;
 
 #if defined(HAVE_PLUGINS)
-        if ((context->compcode == BLOSC_CODEC_ZFP_FIXED_RATE) && (context->zfp_nitems > 0)) {
-        nbytes = blosc2_zfp_getcell(context, src, cbytes, _dest, neblock);
-          if (nbytes == context->zfp_nitems * typesize) {
+        if ((context->compcode == BLOSC_CODEC_ZFP_FIXED_RATE) && (context->zfp_cell_nitems > 0)) {
+        nbytes = zfp_getcell(context, src, cbytes, _dest, neblock);
+          if (nbytes < 0) {
+            return BLOSC2_ERROR_DATA;
+          }
+          if (nbytes == context->zfp_cell_nitems * typesize) {
             getcell = true;
           }
         }
@@ -2867,8 +2870,8 @@ int _blosc_getitem(blosc2_context* context, blosc_header* header, const void* sr
 
 #if defined(HAVE_PLUGINS)
     if (context->compcode == BLOSC_CODEC_ZFP_FIXED_RATE) {
-      context->cell_start = startb;
-      context->zfp_nitems = nitems;
+      context->zfp_cell_start = startb;
+      context->zfp_cell_nitems = nitems;
     }
 #endif /* HAVE_PLUGINS */
 
@@ -2896,7 +2899,7 @@ int _blosc_getitem(blosc2_context* context, blosc_header* header, const void* sr
     ntbytes += bsize2;
   }
 
-  context->zfp_nitems = 0;
+  context->zfp_cell_nitems = 0;
 
   return ntbytes;
 }
@@ -3670,8 +3673,8 @@ blosc2_context* blosc2_create_dctx(blosc2_dparams dparams) {
   context->block_maskout = NULL;
   context->block_maskout_nitems = 0;
   context->schunk = dparams.schunk;
-  context->zfp_nitems = 0;
-  context->cell_start = 0;
+  context->zfp_cell_nitems = 0;
+  context->zfp_cell_start = 0;
 
   if (dparams.postfilter != NULL) {
     context->postfilter = dparams.postfilter;

--- a/blosc/blosc2.c
+++ b/blosc/blosc2.c
@@ -1709,12 +1709,15 @@ static int blosc_d(
   #endif /*  HAVE_ZSTD */
       else if (compformat == BLOSC_UDCODEC_FORMAT) {
         bool getcell = false;
+
+#if defined(HAVE_PLUGINS)
         if ((context->compcode == BLOSC_CODEC_ZFP_FIXED_RATE) && (context->zfp_nitems > 0)) {
-          nbytes = blosc2_zfp_getcell(context, src, cbytes, _dest, neblock);
+        nbytes = blosc2_zfp_getcell(context, src, cbytes, _dest, neblock);
           if (nbytes == context->zfp_nitems * typesize) {
             getcell = true;
           }
         }
+#endif /* HAVE_PLUGINS */
         if (!getcell) {
           for (int i = 0; i < g_ncodecs; ++i) {
             if (g_codecs[i].compcode == context->compcode) {

--- a/blosc/blosc2.c
+++ b/blosc/blosc2.c
@@ -19,6 +19,7 @@
 
 #include "blosc2.h"
 #include "blosc-private.h"
+#include "../plugins/codecs/zfp/blosc2-zfp.h"
 #include "frame.h"
 
 
@@ -1716,18 +1717,27 @@ static int blosc_d(
       }
   #endif /*  HAVE_ZSTD */
       else if (compformat == BLOSC_UDCODEC_FORMAT) {
-        for (int i = 0; i < g_ncodecs; ++i) {
-          if (g_codecs[i].compcode == context->compcode) {
-            blosc2_dparams dparams;
-            blosc2_ctx_get_dparams(context, &dparams);
-            nbytes = g_codecs[i].decoder(src,
-                                          cbytes,
-                                          _dest,
-                                          neblock,
-                                          context->compcode_meta,
-                                          &dparams,
-                                          context->src);
-            goto urcodecsuccess;
+        bool getcell = false;
+        if ((context->compcode == BLOSC_CODEC_ZFP_FIXED_RATE) && (context->zfp_nitems > 0)) {
+          nbytes = blosc2_zfp_getcell(context, src, cbytes, _dest, neblock);
+          if (nbytes == context->zfp_nitems * typesize) {
+            getcell = true;
+          }
+        }
+        if (!getcell) {
+          for (int i = 0; i < g_ncodecs; ++i) {
+            if (g_codecs[i].compcode == context->compcode) {
+              blosc2_dparams dparams;
+              blosc2_ctx_get_dparams(context, &dparams);
+              nbytes = g_codecs[i].decoder(src,
+                                           cbytes,
+                                           _dest,
+                                           neblock,
+                                           context->compcode_meta,
+                                           &dparams,
+                                           context->src);
+              goto urcodecsuccess;
+            }
           }
         }
         BLOSC_TRACE_ERROR("User-defined compressor codec %d not found during decompression", context->compcode);
@@ -2861,18 +2871,12 @@ int _blosc_getitem(blosc2_context* context, blosc_header* header, const void* sr
       stopb = header->blocksize;
     }
     bsize2 = stopb - startb;
+
 #if defined(HAVE_PLUGINS)
-  uint8_t ndim;
-  for (int nmetalayer = 0; nmetalayer < context->schunk->nmetalayers; nmetalayer++) {
-      if (strcmp("caterva", context->schunk->metalayers[nmetalayer]->name) == 0) {
-          ndim = context->schunk->metalayers[nmetalayer]->content[2];
-      }
-  }
-  int cell_nitems = (int) (1u << (2 * ndim));
-  if ((context->compcode == BLOSC_CODEC_ZFP_FIXED_RATE) && (nitems <= cell_nitems)) {
-    context->cell_start = startb;
-    context->zfp_nitems = nitems;
-}
+    if (context->compcode == BLOSC_CODEC_ZFP_FIXED_RATE) {
+      context->cell_start = startb;
+      context->zfp_nitems = nitems;
+    }
 #endif /* HAVE_PLUGINS */
 
     /* Do the actual data copy */
@@ -2899,7 +2903,7 @@ int _blosc_getitem(blosc2_context* context, blosc_header* header, const void* sr
     ntbytes += bsize2;
   }
 
-  context->cell_start = -1;
+  context->zfp_nitems = 0;
 
   return ntbytes;
 }
@@ -3673,6 +3677,8 @@ blosc2_context* blosc2_create_dctx(blosc2_dparams dparams) {
   context->block_maskout = NULL;
   context->block_maskout_nitems = 0;
   context->schunk = dparams.schunk;
+  context->zfp_nitems = 0;
+  context->cell_start = 0;
 
   if (dparams.postfilter != NULL) {
     context->postfilter = dparams.postfilter;

--- a/blosc/context.h
+++ b/blosc/context.h
@@ -64,6 +64,10 @@ struct blosc2_context_s {
   /* Type size */
   int32_t* bstarts;
   /* Starts for every block inside the compressed buffer */
+  int32_t cell_start;
+  /* Cell starter index for ZFP fixed-rate mode */
+  int32_t zfp_nitems;
+  /* Number of items to get for ZFP fixed-rate mode */
   int32_t special_type;
   /* Special type for chunk.  0 if not special. */
   int compcode;

--- a/blosc/context.h
+++ b/blosc/context.h
@@ -64,9 +64,9 @@ struct blosc2_context_s {
   /* Type size */
   int32_t* bstarts;
   /* Starts for every block inside the compressed buffer */
-  int32_t cell_start;
+  int32_t zfp_cell_start;
   /* Cell starter index for ZFP fixed-rate mode */
-  int32_t zfp_nitems;
+  int32_t zfp_cell_nitems;
   /* Number of items to get for ZFP fixed-rate mode */
   int32_t special_type;
   /* Special type for chunk.  0 if not special. */

--- a/plugins/codecs/codecs-registry.c
+++ b/plugins/codecs/codecs-registry.c
@@ -24,8 +24,8 @@ void register_codecs() {
     zfp_acc.compcode = BLOSC_CODEC_ZFP_FIXED_ACCURACY;
     zfp_acc.compver = 1;
     zfp_acc.complib = BLOSC_CODEC_ZFP_FIXED_ACCURACY;
-    zfp_acc.encoder = blosc2_zfp_acc_compress;
-    zfp_acc.decoder = blosc2_zfp_acc_decompress;
+    zfp_acc.encoder = zfp_acc_compress;
+    zfp_acc.decoder = zfp_acc_decompress;
     zfp_acc.compname = "zfp_acc";
     register_codec_private(&zfp_acc);
 
@@ -33,8 +33,8 @@ void register_codecs() {
     zfp_prec.compcode = BLOSC_CODEC_ZFP_FIXED_PRECISION;
     zfp_prec.compver = 1;
     zfp_prec.complib = BLOSC_CODEC_ZFP_FIXED_PRECISION;
-    zfp_prec.encoder = blosc2_zfp_prec_compress;
-    zfp_prec.decoder = blosc2_zfp_prec_decompress;
+    zfp_prec.encoder = zfp_prec_compress;
+    zfp_prec.decoder = zfp_prec_decompress;
     zfp_prec.compname = "zfp_prec";
     register_codec_private(&zfp_prec);
 
@@ -42,8 +42,8 @@ void register_codecs() {
     zfp_rate.compcode = BLOSC_CODEC_ZFP_FIXED_RATE;
     zfp_rate.compver = 1;
     zfp_rate.complib = BLOSC_CODEC_ZFP_FIXED_RATE;
-    zfp_rate.encoder = blosc2_zfp_rate_compress;
-    zfp_rate.decoder = blosc2_zfp_rate_decompress;
+    zfp_rate.encoder = zfp_rate_compress;
+    zfp_rate.decoder = zfp_rate_decompress;
     zfp_rate.compname = "zfp_rate";
     register_codec_private(&zfp_rate);
 }

--- a/plugins/codecs/zfp/CMakeLists.txt
+++ b/plugins/codecs/zfp/CMakeLists.txt
@@ -10,6 +10,7 @@ if(BUILD_TESTS)
     add_executable(test_zfp_acc_float test_zfp_acc_float.c)
     add_executable(test_zfp_prec_float test_zfp_prec_float.c)
     add_executable(test_zfp_rate_float test_zfp_rate_float.c)
+    add_executable(test_zfp_rate_getitem test_zfp_rate_getitem.c)
     # Define the BLOSC_TESTING symbol so normally-hidden functions
     # aren't hidden from the view of the test programs.
     set_property(
@@ -24,17 +25,22 @@ if(BUILD_TESTS)
     set_property(
             TARGET test_zfp_rate_float
             APPEND PROPERTY COMPILE_DEFINITIONS BLOSC_TESTING)
+    set_property(
+            TARGET test_zfp_rate_getitem
+            APPEND PROPERTY COMPILE_DEFINITIONS BLOSC_TESTING)
 
     target_link_libraries(test_zfp_acc_int blosc_testing)
     target_link_libraries(test_zfp_acc_float blosc_testing)
     target_link_libraries(test_zfp_prec_float blosc_testing)
     target_link_libraries(test_zfp_rate_float blosc_testing)
+    target_link_libraries(test_zfp_rate_getitem blosc_testing)
 
     # tests
     add_test(test_plugin_test_zfp_acc_int test_zfp_acc_int)
     add_test(test_plugin_test_zfp_acc_float test_zfp_acc_float)
     add_test(test_plugin_test_zfp_prec_float test_zfp_prec_float)
     add_test(test_plugin_test_zfp_rate_float test_zfp_rate_float)
+    add_test(test_plugin_test_zfp_rate_getitem test_zfp_rate_getitem)
 
     # Copy test files
     file(GLOB TESTS_DATA ../../test_data/example_float_cyclic.caterva ../../test_data/example_double_same_cells.caterva

--- a/plugins/codecs/zfp/blosc2-zfp.c
+++ b/plugins/codecs/zfp/blosc2-zfp.c
@@ -1,5 +1,4 @@
 #include "blosc2.h"
-#include "blosc2.c"
 #include "blosc-private.h"
 #include "frame.h"
 #include "blosc2/codecs-registry.h"
@@ -750,31 +749,8 @@ int blosc2_zfp_getcell(blosc2_schunk* schunk, int nchunk, int nblock, int ncell,
     }
 
     // Initialize the decompression context
-    blosc_header header;
-    int32_t ntbytes;
-    int rc;
-    int32_t nbytes, cbytes;
-    blosc2_cbuffer_sizes(chunk, &nbytes, &cbytes, NULL);
 
-    rc = read_chunk_header(chunk, cbytes, true, &header);
-    if (rc < 0) {
-        return rc;
-    }
-
-    if (header.nbytes > destsize) {
-        // Not enough space for writing into the destination
-        return BLOSC2_ERROR_WRITE_BUFFER;
-    }
-
-    context->src = chunk;
-    context->srcsize = cbytes;
-    context->dest = dest;
-    context->destsize = nbytes;
-
-    rc = blosc2_initialize_context_from_header(schunk->dctx, &header);
-    if (rc < 0) {
-        return rc;
-    }
+    // NEED TO APPEND CODE
 
 
     // Get the offset of the nblock

--- a/plugins/codecs/zfp/blosc2-zfp.c
+++ b/plugins/codecs/zfp/blosc2-zfp.c
@@ -3,7 +3,6 @@
 #include "frame.h"
 #include "blosc2/codecs-registry.h"
 #include "zfp.h"
-#include "zfp-private.h"
 #include "blosc2-zfp.h"
 #include <math.h>
 
@@ -974,28 +973,6 @@ int blosc2_zfp_getcell(blosc2_schunk* schunk, int nchunk, int nblock, int ncell,
 }
 
 
-static void index_unidim_to_multidim(int8_t ndim, int64_t *shape, int64_t i, int64_t *index) {
-    int64_t strides[ZFP_MAX_DIM];
-    strides[ndim - 1] = 1;
-    for (int j = ndim - 2; j >= 0; --j) {
-        strides[j] = shape[j + 1] * strides[j + 1];
-    }
-
-    index[0] = i / strides[0];
-    for (int j = 1; j < ndim; ++j) {
-        index[j] = (i % strides[j - 1]) / strides[j];
-    }
-}
-
-
-void index_multidim_to_unidim(int64_t *index, int8_t ndim, int64_t *strides, int64_t *i) {
-    *i = 0;
-    for (int j = 0; j < ndim; ++j) {
-        *i += index[j] * strides[j];
-    }
-}
-
-
 int blosc2_zfp_getitem(blosc2_schunk* schunk, int64_t index, void* item) {
     int32_t typesize = schunk->typesize;
     int8_t ndim;
@@ -1050,11 +1027,6 @@ int blosc2_zfp_getitem(blosc2_schunk* schunk, int64_t index, void* item) {
     int8_t *cell = malloc(cellsize);
     blosc2_zfp_getcell(schunk, (int) nchunk, (int) nblock, (int) ncell, cell, cellsize);
     memcpy(item, cell + ind * typesize, typesize);
-    printf("\n cell \n");
-    for (int i = 0; i < (cellsize / typesize); ++i) {
-        printf("%f, ", ((float *) cell)[i]);
-    }
-    printf("\n cell[ind] %f nchunk %ld nblock %ld ncell %ld ind %ld item %f", ((float *) cell)[ind], nchunk, nblock, ncell, ind, ((float*) item)[0]);
 
-    return 0;
+    return typesize;
 }

--- a/plugins/codecs/zfp/blosc2-zfp.c
+++ b/plugins/codecs/zfp/blosc2-zfp.c
@@ -749,9 +749,9 @@ int blosc2_zfp_getcell(blosc2_schunk* schunk, int nchunk, int nblock, int ncell,
     }
 
     // Initialize the decompression context
-
-    // NEED TO APPEND CODE
-
+    int32_t nbytes, cbytes;
+    blosc2_cbuffer_sizes(chunk, &nbytes, &cbytes, NULL);
+    blosc_decompression_context_from_source(schunk->dctx, chunk, cbytes, dest, nbytes);
 
     // Get the offset of the nblock
     bool memcpyed = context->header_flags & (uint8_t)BLOSC_MEMCPYED;

--- a/plugins/codecs/zfp/blosc2-zfp.c
+++ b/plugins/codecs/zfp/blosc2-zfp.c
@@ -1,4 +1,6 @@
 #include "blosc2.h"
+#include "blosc-private.h"
+#include "blosc2/codecs-registry.h"
 #include "zfp.h"
 #include "zfp-private.h"
 #include "blosc2-zfp.h"
@@ -706,3 +708,187 @@ int blosc2_zfp_rate_decompress(const uint8_t *input, int32_t input_len, uint8_t 
     return (int) output_len;
 }
 
+
+int blosc2_zfp_decompress_cell(blosc2_schunk* schunk, int nchunk, int nblock, int ncell, void *dest, size_t destsize) {
+
+    ZFP_ERROR_NULL(dest);
+
+    int8_t typesize = schunk->typesize;
+    int8_t ndim;
+    int32_t cellshape = 4;
+    int64_t *shape = malloc(8 * sizeof(int64_t));
+    int32_t *chunkshape = malloc(8 * sizeof(int32_t));
+    int32_t *blockshape = malloc(8 * sizeof(int32_t));
+    uint8_t *smeta;
+    uint32_t smeta_len;
+    if (blosc2_meta_get(schunk, "caterva", &smeta, &smeta_len) < 0) {
+        printf("Blosc error");
+        free(shape);
+        free(chunkshape);
+        free(blockshape);
+        return -1;
+    }
+    deserialize_meta(smeta, smeta_len, &ndim, shape, chunkshape, blockshape);
+    free(smeta);
+
+    // Get the chunk
+    blosc2_context *context = schunk->dctx;
+    bool is_lazy = false;
+ /*   if (schunk->storage->urlpath != NULL) {
+        is_lazy = true;
+    }
+*/
+    bool needs_free;
+    uint8_t *chunk;
+    if (is_lazy) {
+        blosc2_schunk_get_lazychunk(schunk, nchunk, &chunk, &needs_free);
+    } else {
+        blosc2_schunk_get_chunk(schunk, nchunk, &chunk, &needs_free);
+    }
+    uint8_t compcode = chunk[22];                                   // access to compressed chunk header
+    if (compcode != BLOSC_CODEC_ZFP_FIXED_RATE) {
+        BLOSC_TRACE_ERROR("\n Cell decompression only supported for ZFP FIXED_RATE mode\n");
+        return BLOSC2_ERROR_CODEC_SUPPORT;
+    }
+
+    // Get the offset of the nblock
+    bool memcpyed = context->header_flags & (uint8_t)BLOSC_MEMCPYED;
+    int32_t block_offset = memcpyed ?
+                         context->header_overhead + nblock * context->blocksize : sw32_(context->bstarts + nblock);
+
+    // Get the csize of the nblock
+    int32_t block_csize;
+    if (is_lazy) {
+        size_t trailer_offset = BLOSC_EXTENDED_HEADER_LENGTH + context->nblocks * sizeof(int32_t);
+        int32_t *block_csizes = (int32_t *)(chunk + trailer_offset + sizeof(int32_t) + sizeof(int64_t));
+        block_csize = block_csizes[nblock];
+    } else if (memcpyed) {
+        block_csize = context->blocksize;
+    } else {
+        block_csize = chunk[block_offset];
+    }
+    printf("\n cchunk \n");
+    for (int i = 0; i < (4 * block_csize); ++i) {
+        printf("%u, ", chunk[i]);
+    }
+    // Get the block
+    uint8_t *block;
+    if (is_lazy) {
+
+    } else {
+        block = chunk + block_offset + sizeof(int32_t);
+    }
+
+    // Get the ZFP stream
+    zfp_type type;     /* array scalar type */
+    zfp_stream *zfp;   /* compressed stream */
+    bitstream *stream; /* bit stream to write to or read from */
+
+    zfp = zfp_stream_open(NULL);
+
+    switch (typesize) {
+        case sizeof(float):
+            type = zfp_type_float;
+            break;
+        case sizeof(double):
+            type = zfp_type_double;
+            break;
+        default:
+            printf("\n ZFP is not available for this typesize \n");
+            free(shape);
+            free(chunkshape);
+            free(blockshape);
+            return 0;
+    }
+    uint8_t compmeta = chunk[23];                                 // access to compressed chunk header
+    double rate = (double) (compmeta * typesize * 8) / 100.0;     // convert from output size / input size to output bits per input value
+    zfp_stream_set_rate(zfp, rate, type, ndim, zfp_false);
+
+    stream = stream_open((void*) block, block_csize);
+    zfp_stream_set_bit_stream(zfp, stream);
+    zfp_stream_rewind(zfp);
+
+    // Check that ncell is a valid index
+    int ncells = (int) ((block_csize * 8) / zfp->maxbits);
+    if (ncell >= ncells) {
+        BLOSC_TRACE_ERROR("Invalid cell index");
+        return -1;
+    }
+
+    // Position the stream at the ncell bit offset for reading
+    stream_rseek(zfp->stream, ncell * zfp->maxbits);
+
+    // Get the cell
+    int zfpsize;
+    switch (ndim) {
+        case 1:
+            switch (type) {
+                case zfp_type_float:
+                    zfpsize = zfp_decode_block_float_1(zfp, dest);
+                    break;
+                case zfp_type_double:
+                    zfpsize = zfp_decode_block_double_1(zfp, dest);
+                    break;
+                default:
+                    printf("\n ZFP is not available for this typesize \n");
+                    free(shape);
+                    free(chunkshape);
+                    free(blockshape);
+                    return 0;
+            }
+            break;
+        case 2:
+            switch (type) {
+                case zfp_type_float:
+                    zfpsize = zfp_decode_block_float_2(zfp, dest);
+                    break;
+                case zfp_type_double:
+                    zfpsize = zfp_decode_block_double_2(zfp, dest);
+                    break;
+                default:
+                    printf("\n ZFP is not available for this typesize \n");
+                    free(shape);
+                    free(chunkshape);
+                    free(blockshape);
+                    return 0;
+            }
+            break;
+        case 3:
+            switch (type) {
+                case zfp_type_float:
+                    zfpsize = zfp_decode_block_float_3(zfp, dest);
+                    break;
+                case zfp_type_double:
+                    zfpsize = zfp_decode_block_double_3(zfp, dest);
+                    break;
+                default:
+                    printf("\n ZFP is not available for this typesize \n");
+                    free(shape);
+                    free(chunkshape);
+                    free(blockshape);
+                    return 0;
+            }
+            break;
+        case 4:
+            switch (type) {
+                case zfp_type_float:
+                    zfpsize = zfp_decode_block_float_4(zfp, dest);
+                    break;
+                case zfp_type_double:
+                    zfpsize = zfp_decode_block_double_4(zfp, dest);
+                    break;
+                default:
+                    printf("\n ZFP is not available for this typesize \n");
+                    free(shape);
+                    free(chunkshape);
+                    free(blockshape);
+                    return 0;
+            }
+            break;
+        default:
+            printf("\n ZFP is not available for this number of dims \n");
+            return 0;
+    }
+    return zfpsize;
+
+}

--- a/plugins/codecs/zfp/blosc2-zfp.c
+++ b/plugins/codecs/zfp/blosc2-zfp.c
@@ -857,10 +857,19 @@ int zfp_getcell(blosc2_context *context, const uint8_t *block, int32_t cbytes, u
             printf("\n ZFP is not available for this number of dims \n");
             return 0;
     }
-
-    memcpy(dest, &cell[context->zfp_cell_start * typesize], context->zfp_cell_nitems * typesize);
+    printf("\n cell\n");
+    for (int i = 0; i < cell_nitems; ++i) {
+        printf("%f, ", ((float *) cell)[i]);
+    }
+    memcpy(dest, &cell[cell_ind * typesize], context->zfp_cell_nitems * typesize);
+    printf("\n dest\n");
+    for (int i = 0; i < context->zfp_cell_nitems; ++i) {
+        printf("%f, ", ((float *) dest)[i]);
+    }
     zfp_stream_close(zfp);
     stream_close(stream);
+    printf("\n zfpsize %d, destsize %d, cell_nitems %d, items to get %d\n", zfpsize, destsize * 8,
+           cell_nitems * typesize * 8, context->zfp_cell_nitems * typesize * 8);
 
     if ((zfpsize < 0) || (zfpsize > (destsize * 8)) || (zfpsize > (cell_nitems * typesize * 8)) ||
         ((context->zfp_cell_nitems * typesize * 8) > zfpsize)) {

--- a/plugins/codecs/zfp/blosc2-zfp.c
+++ b/plugins/codecs/zfp/blosc2-zfp.c
@@ -857,19 +857,10 @@ int zfp_getcell(blosc2_context *context, const uint8_t *block, int32_t cbytes, u
             printf("\n ZFP is not available for this number of dims \n");
             return 0;
     }
-    printf("\n cell\n");
-    for (int i = 0; i < cell_nitems; ++i) {
-        printf("%f, ", ((float *) cell)[i]);
-    }
     memcpy(dest, &cell[cell_ind * typesize], context->zfp_cell_nitems * typesize);
-    printf("\n dest\n");
-    for (int i = 0; i < context->zfp_cell_nitems; ++i) {
-        printf("%f, ", ((float *) dest)[i]);
-    }
     zfp_stream_close(zfp);
     stream_close(stream);
-    printf("\n zfpsize %d, destsize %d, cell_nitems %d, items to get %d\n", zfpsize, destsize * 8,
-           cell_nitems * typesize * 8, context->zfp_cell_nitems * typesize * 8);
+    free(cell);
 
     if ((zfpsize < 0) || (zfpsize > (destsize * 8)) || (zfpsize > (cell_nitems * typesize * 8)) ||
         ((context->zfp_cell_nitems * typesize * 8) > zfpsize)) {

--- a/plugins/codecs/zfp/blosc2-zfp.c
+++ b/plugins/codecs/zfp/blosc2-zfp.c
@@ -783,14 +783,15 @@ int blosc2_zfp_getcell(blosc2_context *context, const uint8_t *block, int32_t cb
 
             // Get the cell
             size_t zfpsize;
+            uint8_t *cell = malloc(cell_nitems * typesize);
             switch (ndim) {
                 case 1:
                     switch (type) {
                         case zfp_type_float:
-                            zfpsize = zfp_decode_block_float_1(zfp, (float *) dest);
+                            zfpsize = zfp_decode_block_float_1(zfp, (float *) cell);
                             break;
                         case zfp_type_double:
-                            zfpsize = zfp_decode_block_double_1(zfp, (double *) dest);
+                            zfpsize = zfp_decode_block_double_1(zfp, (double *) cell);
                             break;
                         default:
                             printf("\n ZFP is not available for this typesize \n");
@@ -802,10 +803,10 @@ int blosc2_zfp_getcell(blosc2_context *context, const uint8_t *block, int32_t cb
                 case 2:
                     switch (type) {
                         case zfp_type_float:
-                            zfpsize = zfp_decode_block_float_2(zfp, (float *) dest);
+                            zfpsize = zfp_decode_block_float_2(zfp, (float *) cell);
                             break;
                         case zfp_type_double:
-                            zfpsize = zfp_decode_block_double_2(zfp, (double *) dest);
+                            zfpsize = zfp_decode_block_double_2(zfp, (double *) cell);
                             break;
                         default:
                             printf("\n ZFP is not available for this typesize \n");
@@ -817,10 +818,10 @@ int blosc2_zfp_getcell(blosc2_context *context, const uint8_t *block, int32_t cb
                 case 3:
                     switch (type) {
                         case zfp_type_float:
-                            zfpsize = zfp_decode_block_float_3(zfp, (float *) dest);
+                            zfpsize = zfp_decode_block_float_3(zfp, (float *) cell);
                             break;
                         case zfp_type_double:
-                            zfpsize = zfp_decode_block_double_3(zfp, (double *) dest);
+                            zfpsize = zfp_decode_block_double_3(zfp, (double *) cell);
                             break;
                         default:
                             printf("\n ZFP is not available for this typesize \n");
@@ -832,10 +833,10 @@ int blosc2_zfp_getcell(blosc2_context *context, const uint8_t *block, int32_t cb
                 case 4:
                     switch (type) {
                         case zfp_type_float:
-                            zfpsize = zfp_decode_block_float_4(zfp, (float *) dest);
+                            zfpsize = zfp_decode_block_float_4(zfp, (float *) cell);
                             break;
                         case zfp_type_double:
-                            zfpsize = zfp_decode_block_double_4(zfp, (double *) dest);
+                            zfpsize = zfp_decode_block_double_4(zfp, (double *) cell);
                             break;
                         default:
                             printf("\n ZFP is not available for this typesize \n");
@@ -849,15 +850,17 @@ int blosc2_zfp_getcell(blosc2_context *context, const uint8_t *block, int32_t cb
                     return 0;
             }
 
+            memcpy(dest, &cell[context->cell_start * typesize], context->zfp_nitems * typesize);
             zfp_stream_close(zfp);
             stream_close(stream);
 
-            if ((zfpsize < 0) || (zfpsize > (destsize * typesize * 8))) {
+            if ((zfpsize < 0) || (zfpsize > (destsize * 8)) || (zfpsize > (cell_nitems * typesize * 8)) ||
+                ((context->zfp_nitems * typesize * 8) > zfpsize)) {
                 BLOSC_TRACE_ERROR("ZFP error or small destsize");
                 return -1;
             }
 
-            return (int) zfpsize;
+            return (int) (context->zfp_nitems * typesize);
         }
     }
     return -1;

--- a/plugins/codecs/zfp/blosc2-zfp.c
+++ b/plugins/codecs/zfp/blosc2-zfp.c
@@ -1,11 +1,10 @@
 #include "blosc2.h"
 #include "blosc-private.h"
-#include "frame.h"
 #include "blosc2/codecs-registry.h"
 #include "zfp.h"
+#include "zfp-private.h"
 #include "blosc2-zfp.h"
 #include <math.h>
-#include "context.h"
 
 int blosc2_zfp_acc_compress(const uint8_t *input, int32_t input_len, uint8_t *output,
                             int32_t output_len, uint8_t meta, blosc2_cparams *cparams, const void* chunk) {
@@ -662,7 +661,7 @@ int blosc2_zfp_rate_decompress(const uint8_t *input, int32_t input_len, uint8_t 
             free(blockshape);
             return 0;
     }
-    double rate = ratio * (double) typesize * 8;     // convert from output size / input size to output bits per input value
+    double rate = ratio * typesize * 8;     // convert from output size / input size to output bits per input value
     zfp = zfp_stream_open(NULL);
     zfp_stream_set_rate(zfp, rate, type, ndim, zfp_false);
 
@@ -710,173 +709,18 @@ int blosc2_zfp_rate_decompress(const uint8_t *input, int32_t input_len, uint8_t 
 }
 
 
-int blosc2_zfp_getcell(blosc2_context *context, const uint8_t *block, int32_t cbytes, uint8_t *dest, int32_t destsize) {
-    uint8_t ndim;
-    int32_t blockshape[8];
-    for (int nmetalayer = 0; nmetalayer < context->schunk->nmetalayers; nmetalayer++) {
-        if (strcmp("caterva", context->schunk->metalayers[nmetalayer]->name) == 0) {
-            uint8_t *pmeta = context->schunk->metalayers[nmetalayer]->content;
-            ndim = pmeta[2];
-            pmeta += (6 + 2 * ndim * 9);
-            for (int8_t i = 0; i < ndim; i++) {
-                pmeta += 1;
-                swap_store(blockshape + i, pmeta, sizeof(int32_t));
-                pmeta += sizeof(int32_t);
-            }
-        }
-    }
-    if (ndim <= 4) {
-        int64_t cell_start_ndim[4], cell_ind_ndim[4], ncell_ndim[4], ind_strides[4], cell_strides[4];
-        int64_t cell_ind, ncell;
-        int cellshape = 4;
-        index_unidim_to_multidim((int8_t) ndim, (int64_t *) blockshape, context->cell_start, cell_start_ndim);
-        for (int i = 0; i < ndim; ++i) {
-            cell_ind_ndim[i] = cell_start_ndim[i] % cellshape;
-            ncell_ndim[i] = cell_start_ndim[i] / cellshape;
-        }
-        ind_strides[ndim - 1] = cell_strides[ndim - 1] = 1;
-        for (int i = ndim - 2; i >= 0; --i) {
-            ind_strides[i] = cellshape;
-            cell_strides[i] = (blockshape[i + 1] - 1) / cellshape + 1;
-        }
-        index_multidim_to_unidim(cell_ind_ndim, (int8_t) ndim, ind_strides, &cell_ind);
-        index_multidim_to_unidim(ncell_ndim, (int8_t) ndim, cell_strides, &ncell);
-        int cell_nitems = (int) (1u << (2 * ndim));
-        if ((context->compcode == BLOSC_CODEC_ZFP_FIXED_RATE) && (context->zfp_nitems <= cell_nitems) &&
-            ((cell_ind + context->zfp_nitems) <= cell_nitems)) {
+int blosc2_zfp_decompress_cell(blosc2_schunk* schunk, int nchunk, int nblock, int ncell, void *dest, size_t destsize) {
 
-            // Get the ZFP stream
-            zfp_type type;     /* array scalar type */
-            zfp_stream *zfp;   /* compressed stream */
-            bitstream *stream; /* bit stream to write to or read from */
-            int32_t typesize = context->typesize;
-            zfp = zfp_stream_open(NULL);
-
-            switch (typesize) {
-                case sizeof(float):
-                    type = zfp_type_float;
-                    break;
-                case sizeof(double):
-                    type = zfp_type_double;
-                    break;
-                default:
-                    printf("\n ZFP is not available for this typesize \n");
-                    return 0;
-            }
-            uint8_t compmeta = context->compcode_meta;                                 // access to compressed chunk header
-            double rate = (double) (compmeta * typesize * 8) /
-                          100.0;     // convert from output size / input size to output bits per input value
-            zfp_stream_set_rate(zfp, rate, type, ndim, zfp_false);
-
-            stream = stream_open((void *) block, cbytes);
-            zfp_stream_set_bit_stream(zfp, stream);
-            zfp_stream_rewind(zfp);
-
-            // Check that ncell is a valid index
-            int ncells = (int) ((cbytes * 8) / zfp->maxbits);
-            if (ncell >= ncells) {
-                BLOSC_TRACE_ERROR("Invalid cell index");
-                return -1;
-            }
-
-            // Position the stream at the ncell bit offset for reading
-            stream_rseek(zfp->stream, ncell * zfp->maxbits);
-
-            // Get the cell
-            size_t zfpsize;
-            uint8_t *cell = malloc(cell_nitems * typesize);
-            switch (ndim) {
-                case 1:
-                    switch (type) {
-                        case zfp_type_float:
-                            zfpsize = zfp_decode_block_float_1(zfp, (float *) cell);
-                            break;
-                        case zfp_type_double:
-                            zfpsize = zfp_decode_block_double_1(zfp, (double *) cell);
-                            break;
-                        default:
-                            printf("\n ZFP is not available for this typesize \n");
-                            zfp_stream_close(zfp);
-                            stream_close(stream);
-                            return 0;
-                    }
-                    break;
-                case 2:
-                    switch (type) {
-                        case zfp_type_float:
-                            zfpsize = zfp_decode_block_float_2(zfp, (float *) cell);
-                            break;
-                        case zfp_type_double:
-                            zfpsize = zfp_decode_block_double_2(zfp, (double *) cell);
-                            break;
-                        default:
-                            printf("\n ZFP is not available for this typesize \n");
-                            zfp_stream_close(zfp);
-                            stream_close(stream);
-                            return 0;
-                    }
-                    break;
-                case 3:
-                    switch (type) {
-                        case zfp_type_float:
-                            zfpsize = zfp_decode_block_float_3(zfp, (float *) cell);
-                            break;
-                        case zfp_type_double:
-                            zfpsize = zfp_decode_block_double_3(zfp, (double *) cell);
-                            break;
-                        default:
-                            printf("\n ZFP is not available for this typesize \n");
-                            zfp_stream_close(zfp);
-                            stream_close(stream);
-                            return 0;
-                    }
-                    break;
-                case 4:
-                    switch (type) {
-                        case zfp_type_float:
-                            zfpsize = zfp_decode_block_float_4(zfp, (float *) cell);
-                            break;
-                        case zfp_type_double:
-                            zfpsize = zfp_decode_block_double_4(zfp, (double *) cell);
-                            break;
-                        default:
-                            printf("\n ZFP is not available for this typesize \n");
-                            zfp_stream_close(zfp);
-                            stream_close(stream);
-                            return 0;
-                    }
-                    break;
-                default:
-                    printf("\n ZFP is not available for this number of dims \n");
-                    return 0;
-            }
-
-            memcpy(dest, &cell[context->cell_start * typesize], context->zfp_nitems * typesize);
-            zfp_stream_close(zfp);
-            stream_close(stream);
-
-            if ((zfpsize < 0) || (zfpsize > (destsize * 8)) || (zfpsize > (cell_nitems * typesize * 8)) ||
-                ((context->zfp_nitems * typesize * 8) > zfpsize)) {
-                BLOSC_TRACE_ERROR("ZFP error or small destsize");
-                return -1;
-            }
-
-            return (int) (context->zfp_nitems * typesize);
-        }
-    }
-    return -1;
-}
-
-/*
-int blosc2_zfp_getcell_old(blosc2_schunk* schunk, int nchunk, int nblock, int ncell, void *dest, size_t destsize) {
     ZFP_ERROR_NULL(dest);
-    int32_t typesize = schunk->typesize;
+
+    int8_t typesize = schunk->typesize;
     int8_t ndim;
+    int32_t cellshape = 4;
     int64_t *shape = malloc(8 * sizeof(int64_t));
     int32_t *chunkshape = malloc(8 * sizeof(int32_t));
     int32_t *blockshape = malloc(8 * sizeof(int32_t));
     uint8_t *smeta;
-    int32_t smeta_len;
+    uint32_t smeta_len;
     if (blosc2_meta_get(schunk, "caterva", &smeta, &smeta_len) < 0) {
         printf("Blosc error");
         free(shape);
@@ -890,10 +734,10 @@ int blosc2_zfp_getcell_old(blosc2_schunk* schunk, int nchunk, int nblock, int nc
     // Get the chunk
     blosc2_context *context = schunk->dctx;
     bool is_lazy = false;
-    if (schunk->storage->urlpath != NULL) {
+ /*   if (schunk->storage->urlpath != NULL) {
         is_lazy = true;
     }
-
+*/
     bool needs_free;
     uint8_t *chunk;
     if (is_lazy) {
@@ -907,11 +751,6 @@ int blosc2_zfp_getcell_old(blosc2_schunk* schunk, int nchunk, int nblock, int nc
         return BLOSC2_ERROR_CODEC_SUPPORT;
     }
 
-    // Initialize the decompression context
-    int32_t nbytes, cbytes;
-    blosc2_cbuffer_sizes(chunk, &nbytes, &cbytes, NULL);
-    blosc_decompression_context_from_source(schunk->dctx, chunk, cbytes, dest, nbytes);
-
     // Get the offset of the nblock
     bool memcpyed = context->header_flags & (uint8_t)BLOSC_MEMCPYED;
     int32_t block_offset = memcpyed ?
@@ -919,9 +758,8 @@ int blosc2_zfp_getcell_old(blosc2_schunk* schunk, int nchunk, int nblock, int nc
 
     // Get the csize of the nblock
     int32_t block_csize;
-    size_t trailer_offset;
     if (is_lazy) {
-        trailer_offset = BLOSC_EXTENDED_HEADER_LENGTH + context->nblocks * sizeof(int32_t);
+        size_t trailer_offset = BLOSC_EXTENDED_HEADER_LENGTH + context->nblocks * sizeof(int32_t);
         int32_t *block_csizes = (int32_t *)(chunk + trailer_offset + sizeof(int32_t) + sizeof(int64_t));
         block_csize = block_csizes[nblock];
     } else if (memcpyed) {
@@ -929,49 +767,23 @@ int blosc2_zfp_getcell_old(blosc2_schunk* schunk, int nchunk, int nblock, int nc
     } else {
         block_csize = chunk[block_offset];
     }
-
+    printf("\n cchunk \n");
+    for (int i = 0; i < (4 * block_csize); ++i) {
+        printf("%u, ", chunk[i]);
+    }
     // Get the block
     uint8_t *block;
-    int64_t chunk_offset;
     if (is_lazy) {
-        chunk_offset = *(int64_t*)(chunk + trailer_offset + sizeof(int32_t));
-        void* fp = NULL;
-        blosc2_io_cb *io_cb = blosc2_get_io_cb(schunk->storage->io->id);
-        if (io_cb == NULL) {
-            BLOSC_TRACE_ERROR("Error getting the input/output API");
-            return BLOSC2_ERROR_PLUGIN_IO;
-        }
-        blosc2_frame_s* frame = (blosc2_frame_s*)schunk->frame;
-        if (frame->sframe) {
-            // The chunk is not in the frame
-            char* chunkpath = malloc(strlen(frame->urlpath) + 1 + 8 + strlen(".chunk") + 1);
-            BLOSC_ERROR_NULL(chunkpath, BLOSC2_ERROR_MEMORY_ALLOC);
-            sprintf(chunkpath, "%s/%08X.chunk", frame->urlpath, nchunk);
-            fp = io_cb->open(chunkpath, "rb", schunk->storage->io->params);
-            free(chunkpath);
-            io_cb->seek(fp, block_offset + sizeof(int32_t), SEEK_SET);
-        }
-        else {
-            fp = io_cb->open(frame->urlpath, "rb", schunk->storage->io->params);
-            io_cb->seek(fp, chunk_offset + block_offset + sizeof(int32_t), SEEK_SET);
-        }
-        block_csize -= sizeof(int32_t);
-        block = malloc(block_csize);
-        int64_t rbytes = io_cb->read(block, 1, block_csize, fp);
-        io_cb->close(fp);
-        if ((int32_t)rbytes != block_csize) {
-            BLOSC_TRACE_ERROR("Cannot read the (lazy) block out of the fileframe.");
-            return BLOSC2_ERROR_READ_BUFFER;
-        }
+
     } else {
         block = chunk + block_offset + sizeof(int32_t);
     }
 
     // Get the ZFP stream
     zfp_type type;     /* array scalar type */
-  /*  zfp_stream *zfp;   /* compressed stream */
-   /* bitstream *stream; /* bit stream to write to or read from */
-/*
+    zfp_stream *zfp;   /* compressed stream */
+    bitstream *stream; /* bit stream to write to or read from */
+
     zfp = zfp_stream_open(NULL);
 
     switch (typesize) {
@@ -986,12 +798,6 @@ int blosc2_zfp_getcell_old(blosc2_schunk* schunk, int nchunk, int nblock, int nc
             free(shape);
             free(chunkshape);
             free(blockshape);
-            if (needs_free) {
-                free(chunk);
-            }
-            if (is_lazy) {
-                free(block);
-            }
             return 0;
     }
     uint8_t compmeta = chunk[23];                                 // access to compressed chunk header
@@ -1013,7 +819,7 @@ int blosc2_zfp_getcell_old(blosc2_schunk* schunk, int nchunk, int nblock, int nc
     stream_rseek(zfp->stream, ncell * zfp->maxbits);
 
     // Get the cell
-    size_t zfpsize;
+    int zfpsize;
     switch (ndim) {
         case 1:
             switch (type) {
@@ -1028,14 +834,6 @@ int blosc2_zfp_getcell_old(blosc2_schunk* schunk, int nchunk, int nblock, int nc
                     free(shape);
                     free(chunkshape);
                     free(blockshape);
-                    zfp_stream_close(zfp);
-                    stream_close(stream);
-                    if (needs_free) {
-                        free(chunk);
-                    }
-                    if (is_lazy) {
-                        free(block);
-                    }
                     return 0;
             }
             break;
@@ -1052,14 +850,6 @@ int blosc2_zfp_getcell_old(blosc2_schunk* schunk, int nchunk, int nblock, int nc
                     free(shape);
                     free(chunkshape);
                     free(blockshape);
-                    zfp_stream_close(zfp);
-                    stream_close(stream);
-                    if (needs_free) {
-                        free(chunk);
-                    }
-                    if (is_lazy) {
-                        free(block);
-                    }
                     return 0;
             }
             break;
@@ -1076,14 +866,6 @@ int blosc2_zfp_getcell_old(blosc2_schunk* schunk, int nchunk, int nblock, int nc
                     free(shape);
                     free(chunkshape);
                     free(blockshape);
-                    zfp_stream_close(zfp);
-                    stream_close(stream);
-                    if (needs_free) {
-                        free(chunk);
-                    }
-                    if (is_lazy) {
-                        free(block);
-                    }
                     return 0;
             }
             break;
@@ -1100,14 +882,6 @@ int blosc2_zfp_getcell_old(blosc2_schunk* schunk, int nchunk, int nblock, int nc
                     free(shape);
                     free(chunkshape);
                     free(blockshape);
-                    zfp_stream_close(zfp);
-                    stream_close(stream);
-                    if (needs_free) {
-                        free(chunk);
-                    }
-                    if (is_lazy) {
-                        free(block);
-                    }
                     return 0;
             }
             break;
@@ -1115,83 +889,6 @@ int blosc2_zfp_getcell_old(blosc2_schunk* schunk, int nchunk, int nblock, int nc
             printf("\n ZFP is not available for this number of dims \n");
             return 0;
     }
+    return zfpsize;
 
-    free(shape);
-    free(chunkshape);
-    free(blockshape);
-    zfp_stream_close(zfp);
-    stream_close(stream);
-    if (needs_free) {
-        free(chunk);
-    }
-    if (is_lazy) {
-        free(block);
-    }
-
-    if ((zfpsize < 0) || (zfpsize > (destsize * typesize * 8))) {
-        BLOSC_TRACE_ERROR("ZFP error or small destsize");
-        return -1;
-    }
-
-    return (int) zfpsize;
 }
-
-
-int blosc2_zfp_getitem(blosc2_schunk* schunk, int64_t index, void* item) {
-    int32_t typesize = schunk->typesize;
-    int8_t ndim;
-    int64_t *shape = malloc(8 * sizeof(int64_t));
-    int32_t *chunkshape = malloc(8 * sizeof(int64_t));
-    int32_t *blockshape = malloc(8 * sizeof(int64_t));
-    int64_t cellshape[ZFP_MAX_DIM] = {ZFP_CELL_SHAPE, ZFP_CELL_SHAPE, ZFP_CELL_SHAPE, ZFP_CELL_SHAPE};
-    uint8_t *smeta;
-    int32_t smeta_len;
-    if (blosc2_meta_get(schunk, "caterva", &smeta, &smeta_len) < 0) {
-        printf("Blosc error");
-        free(shape);
-        free(chunkshape);
-        free(blockshape);
-        return -1;
-    }
-    deserialize_meta(smeta, smeta_len, &ndim, shape, chunkshape, blockshape);
-    free(smeta);
-
-    int64_t index_ndim[ZFP_MAX_DIM];
-    int64_t index_chunk_ndim[ZFP_MAX_DIM];
-    int64_t index_block_ndim[ZFP_MAX_DIM];
-    int64_t index_cell_ndim[ZFP_MAX_DIM];
-    int64_t ind_ndim[ZFP_MAX_DIM];
-    index_unidim_to_multidim(ndim, shape, index, index_ndim);
-    int64_t cellsize = typesize;
-    for (int i = 0; i < ndim; ++i) {
-        index_chunk_ndim[i] = index_ndim[i] / chunkshape[i];
-        index_block_ndim[i] = (index_ndim[i] % chunkshape[i]) / blockshape[i];
-        index_cell_ndim[i] = ((index_ndim[i] % chunkshape[i]) % blockshape[i]) / ZFP_CELL_SHAPE;
-        ind_ndim[i] = ((index_ndim[i] % chunkshape[i]) % blockshape[i]) % ZFP_CELL_SHAPE;
-        cellsize *= cellshape[i];
-    }
-    int64_t chunk_strides[ZFP_MAX_DIM];
-    int64_t block_strides[ZFP_MAX_DIM];
-    int64_t cell_strides[ZFP_MAX_DIM];
-    int64_t item_strides[ZFP_MAX_DIM];
-    chunk_strides[ndim - 1] = block_strides[ndim - 1] = cell_strides[ndim - 1] = item_strides[ndim - 1] = 1;
-    for (int i = ndim - 2; i >= 0; --i) {
-        int j = i + 1;
-        chunk_strides[i] = (shape[j] - 1) / chunkshape[j] + 1;
-        block_strides[i] = (chunkshape[j] - 1) / blockshape[j] + 1;
-        cell_strides[i] = (blockshape[j] - 1) / cellshape[j] + 1;
-        item_strides[i] = cellshape[j];
-    }
-    int64_t nchunk, nblock, ncell, ind;
-    index_multidim_to_unidim(index_chunk_ndim, ndim, (int64_t*) chunk_strides, &nchunk);
-    index_multidim_to_unidim(index_block_ndim, ndim, (int64_t*) block_strides, &nblock);
-    index_multidim_to_unidim(index_cell_ndim, ndim, (int64_t*) cell_strides, &ncell);
-    index_multidim_to_unidim(ind_ndim, ndim, item_strides, &ind);
-
-    int8_t *cell = malloc(cellsize);
-    blosc2_zfp_getcell_old(schunk, (int) nchunk, (int) nblock, (int) ncell, cell, cellsize);
-    memcpy(item, cell + ind * typesize, typesize);
-
-    return typesize;
-}
-*/

--- a/plugins/codecs/zfp/blosc2-zfp.c
+++ b/plugins/codecs/zfp/blosc2-zfp.c
@@ -1,5 +1,4 @@
 #include "blosc2.h"
-#include "blosc-private.h"
 #include "frame.h"
 #include "blosc2/codecs-registry.h"
 #include "zfp.h"
@@ -26,7 +25,7 @@ int zfp_acc_compress(const uint8_t *input, int32_t input_len, uint8_t *output,
     int32_t *chunkshape = malloc(8 * sizeof(int32_t));
     int32_t *blockshape = malloc(8 * sizeof(int32_t));
     uint8_t *smeta;
-    uint32_t smeta_len;
+    int32_t smeta_len;
     if (blosc2_meta_get(cparams->schunk, "caterva", &smeta, &smeta_len) < 0) {
         printf("Blosc error");
         free(shape);
@@ -143,7 +142,7 @@ int zfp_acc_decompress(const uint8_t *input, int32_t input_len, uint8_t *output,
     int32_t *chunkshape = malloc(8 * sizeof(int32_t));
     int32_t *blockshape = malloc(8 * sizeof(int32_t));
     uint8_t *smeta;
-    uint32_t smeta_len;
+    int32_t smeta_len;
     if (blosc2_meta_get(dparams->schunk, "caterva", &smeta, &smeta_len) < 0) {
         printf("Blosc error");
         free(shape);
@@ -238,7 +237,7 @@ int zfp_prec_compress(const uint8_t *input, int32_t input_len, uint8_t *output,
     int32_t *chunkshape = malloc(8 * sizeof(int32_t));
     int32_t *blockshape = malloc(8 * sizeof(int32_t));
     uint8_t *smeta;
-    uint32_t smeta_len;
+    int32_t smeta_len;
     if (blosc2_meta_get(cparams->schunk, "caterva", &smeta, &smeta_len) < 0) {
         printf("Blosc error");
         free(shape);
@@ -378,7 +377,7 @@ int zfp_prec_decompress(const uint8_t *input, int32_t input_len, uint8_t *output
     int32_t *chunkshape = malloc(8 * sizeof(int32_t));
     int32_t *blockshape = malloc(8 * sizeof(int32_t));
     uint8_t *smeta;
-    uint32_t smeta_len;
+    int32_t smeta_len;
     if (blosc2_meta_get(dparams->schunk, "caterva", &smeta, &smeta_len) < 0) {
         printf("Blosc error");
         free(shape);
@@ -500,7 +499,7 @@ int zfp_rate_compress(const uint8_t *input, int32_t input_len, uint8_t *output,
     int32_t *chunkshape = malloc(8 * sizeof(int32_t));
     int32_t *blockshape = malloc(8 * sizeof(int32_t));
     uint8_t *smeta;
-    uint32_t smeta_len;
+    int32_t smeta_len;
     if (blosc2_meta_get(cparams->schunk, "caterva", &smeta, &smeta_len) < 0) {
         printf("Blosc error");
         free(shape);
@@ -530,6 +529,7 @@ int zfp_rate_compress(const uint8_t *input, int32_t input_len, uint8_t *output,
             break;
         default:
             printf("\n ZFP is not available for this typesize \n");
+            return 0;
     }
     double rate = ratio * typesize * 8;     // convert from output size / input size to output bits per input value
     uint cellsize = 1u << (2 * ndim);
@@ -632,7 +632,7 @@ int zfp_rate_decompress(const uint8_t *input, int32_t input_len, uint8_t *output
     int32_t *chunkshape = malloc(8 * sizeof(int32_t));
     int32_t *blockshape = malloc(8 * sizeof(int32_t));
     uint8_t *smeta;
-    uint32_t smeta_len;
+    int32_t smeta_len;
     if (blosc2_meta_get(dparams->schunk, "caterva", &smeta, &smeta_len) < 0) {
         printf("Blosc error");
         free(shape);
@@ -721,7 +721,7 @@ int zfp_getcell(blosc2_context *context, const uint8_t *block, int32_t cbytes, u
             uint8_t *pmeta = context->schunk->metalayers[nmetalayer]->content;
             ndim = (int8_t) pmeta[2];
             pmeta += (6 + ndim * 9 + ndim * 5);
-            for (int8_t i = 0; i < ndim; i++) {
+            for (int8_t i = 0; (uint8_t) i < ndim; i++) {
                 pmeta += 1;
                 swap_store(blockshape + i, pmeta, sizeof(int32_t));
                 pmeta += sizeof(int32_t);
@@ -787,7 +787,7 @@ int zfp_getcell(blosc2_context *context, const uint8_t *block, int32_t cbytes, u
     }
 
     // Position the stream at the ncell bit offset for reading
-    stream_rseek(zfp->stream, ncell * zfp->maxbits);
+    stream_rseek(zfp->stream, (size_t) (ncell * zfp->maxbits));
 
     // Get the cell
     size_t zfpsize;
@@ -870,335 +870,3 @@ int zfp_getcell(blosc2_context *context, const uint8_t *block, int32_t cbytes, u
 
     return (int) (context->zfp_cell_nitems * typesize);
 }
-
-/*
-
- int blosc2_zfp_getcell_old(blosc2_schunk* schunk, int nchunk, int nblock, int ncell, void *dest, size_t destsize) {
-    ZFP_ERROR_NULL(dest);
-    int32_t typesize = schunk->typesize;
-    int8_t ndim;
-    int64_t *shape = malloc(8 * sizeof(int64_t));
-    int32_t *chunkshape = malloc(8 * sizeof(int32_t));
-    int32_t *blockshape = malloc(8 * sizeof(int32_t));
-    uint8_t *smeta;
-    int32_t smeta_len;
-    if (blosc2_meta_get(schunk, "caterva", &smeta, &smeta_len) < 0) {
-        printf("Blosc error");
-        free(shape);
-        free(chunkshape);
-        free(blockshape);
-        return -1;
-    }
-    deserialize_meta(smeta, smeta_len, &ndim, shape, chunkshape, blockshape);
-    free(smeta);
-
-    // Get the chunk
-    blosc2_context *context = schunk->dctx;
-    bool is_lazy = false;
-    if (schunk->storage->urlpath != NULL) {
-        is_lazy = true;
-    }
-
-    bool needs_free;
-    uint8_t *chunk;
-    if (is_lazy) {
-        blosc2_schunk_get_lazychunk(schunk, nchunk, &chunk, &needs_free);
-    } else {
-        blosc2_schunk_get_chunk(schunk, nchunk, &chunk, &needs_free);
-    }
-    uint8_t compcode = chunk[22];                                   // access to compressed chunk header
-    if (compcode != BLOSC_CODEC_ZFP_FIXED_RATE) {
-        BLOSC_TRACE_ERROR("\n Cell decompression only supported for ZFP FIXED_RATE mode\n");
-        return BLOSC2_ERROR_CODEC_SUPPORT;
-    }
-
-    // Initialize the decompression context
-    int32_t nbytes, cbytes;
-    blosc2_cbuffer_sizes(chunk, &nbytes, &cbytes, NULL);
-    blosc_decompression_context_from_source(schunk->dctx, chunk, cbytes, dest, nbytes);
-
-    // Get the offset of the nblock
-    bool memcpyed = context->header_flags & (uint8_t)BLOSC_MEMCPYED;
-    int32_t block_offset = memcpyed ?
-                         context->header_overhead + nblock * context->blocksize : sw32_(context->bstarts + nblock);
-
-    // Get the csize of the nblock
-    int32_t block_csize;
-    size_t trailer_offset;
-    if (is_lazy) {
-        trailer_offset = BLOSC_EXTENDED_HEADER_LENGTH + context->nblocks * sizeof(int32_t);
-        int32_t *block_csizes = (int32_t *)(chunk + trailer_offset + sizeof(int32_t) + sizeof(int64_t));
-        block_csize = block_csizes[nblock];
-    } else if (memcpyed) {
-        block_csize = context->blocksize;
-    } else {
-        block_csize = chunk[block_offset];
-    }
-
-    // Get the block
-    uint8_t *block;
-    int64_t chunk_offset;
-    if (is_lazy) {
-        chunk_offset = *(int64_t*)(chunk + trailer_offset + sizeof(int32_t));
-        void* fp = NULL;
-        blosc2_io_cb *io_cb = blosc2_get_io_cb(schunk->storage->io->id);
-        if (io_cb == NULL) {
-            BLOSC_TRACE_ERROR("Error getting the input/output API");
-            return BLOSC2_ERROR_PLUGIN_IO;
-        }
-        blosc2_frame_s* frame = (blosc2_frame_s*)schunk->frame;
-        if (frame->sframe) {
-            // The chunk is not in the frame
-            char* chunkpath = malloc(strlen(frame->urlpath) + 1 + 8 + strlen(".chunk") + 1);
-            BLOSC_ERROR_NULL(chunkpath, BLOSC2_ERROR_MEMORY_ALLOC);
-            sprintf(chunkpath, "%s/%08X.chunk", frame->urlpath, nchunk);
-            fp = io_cb->open(chunkpath, "rb", schunk->storage->io->params);
-            free(chunkpath);
-            io_cb->seek(fp, block_offset + sizeof(int32_t), SEEK_SET);
-        }
-        else {
-            fp = io_cb->open(frame->urlpath, "rb", schunk->storage->io->params);
-            io_cb->seek(fp, chunk_offset + block_offset + sizeof(int32_t), SEEK_SET);
-        }
-        block_csize -= sizeof(int32_t);
-        block = malloc(block_csize);
-        int64_t rbytes = io_cb->read(block, 1, block_csize, fp);
-        io_cb->close(fp);
-        if ((int32_t)rbytes != block_csize) {
-            BLOSC_TRACE_ERROR("Cannot read the (lazy) block out of the fileframe.");
-            return BLOSC2_ERROR_READ_BUFFER;
-        }
-    } else {
-        block = chunk + block_offset + sizeof(int32_t);
-    }
-
-    // Get the ZFP stream
-    zfp_type type;     /* array scalar type */
-  /*  zfp_stream *zfp;   /* compressed stream */
-   /* bitstream *stream; /* bit stream to write to or read from */
-/*
-    zfp_stream *zfp;   /* compressed stream */
- /*   bitstream *stream; /* bit stream to write to or read from */
-  /*  zfp = zfp_stream_open(NULL);
-
-    switch (typesize) {
-        case sizeof(float):
-            type = zfp_type_float;
-            break;
-        case sizeof(double):
-            type = zfp_type_double;
-            break;
-        default:
-            printf("\n ZFP is not available for this typesize \n");
-            free(shape);
-            free(chunkshape);
-            free(blockshape);
-            if (needs_free) {
-                free(chunk);
-            }
-            if (is_lazy) {
-                free(block);
-            }
-            return 0;
-    }
-    uint8_t compmeta = chunk[23];                                 // access to compressed chunk header
-    double rate = (double) (compmeta * typesize * 8) / 100.0;     // convert from output size / input size to output bits per input value
-    zfp_stream_set_rate(zfp, rate, type, ndim, zfp_false);
-
-    stream = stream_open((void*) block, block_csize);
-    zfp_stream_set_bit_stream(zfp, stream);
-    zfp_stream_rewind(zfp);
-
-    // Check that ncell is a valid index
-    int ncells = (int) ((block_csize * 8) / zfp->maxbits);
-    if (ncell >= ncells) {
-        BLOSC_TRACE_ERROR("Invalid cell index");
-        return -1;
-    }
-
-    // Position the stream at the ncell bit offset for reading
-    stream_rseek(zfp->stream, ncell * zfp->maxbits);
-
-    // Get the cell
-    size_t zfpsize;
-    switch (ndim) {
-        case 1:
-            switch (type) {
-                case zfp_type_float:
-                    zfpsize = zfp_decode_block_float_1(zfp, dest);
-                    break;
-                case zfp_type_double:
-                    zfpsize = zfp_decode_block_double_1(zfp, dest);
-                    break;
-                default:
-                    printf("\n ZFP is not available for this typesize \n");
-                    free(shape);
-                    free(chunkshape);
-                    free(blockshape);
-                    zfp_stream_close(zfp);
-                    stream_close(stream);
-                    if (needs_free) {
-                        free(chunk);
-                    }
-                    if (is_lazy) {
-                        free(block);
-                    }
-                    return 0;
-            }
-            break;
-        case 2:
-            switch (type) {
-                case zfp_type_float:
-                    zfpsize = zfp_decode_block_float_2(zfp, dest);
-                    break;
-                case zfp_type_double:
-                    zfpsize = zfp_decode_block_double_2(zfp, dest);
-                    break;
-                default:
-                    printf("\n ZFP is not available for this typesize \n");
-                    free(shape);
-                    free(chunkshape);
-                    free(blockshape);
-                    zfp_stream_close(zfp);
-                    stream_close(stream);
-                    if (needs_free) {
-                        free(chunk);
-                    }
-                    if (is_lazy) {
-                        free(block);
-                    }
-                    return 0;
-            }
-            break;
-        case 3:
-            switch (type) {
-                case zfp_type_float:
-                    zfpsize = zfp_decode_block_float_3(zfp, dest);
-                    break;
-                case zfp_type_double:
-                    zfpsize = zfp_decode_block_double_3(zfp, dest);
-                    break;
-                default:
-                    printf("\n ZFP is not available for this typesize \n");
-                    free(shape);
-                    free(chunkshape);
-                    free(blockshape);
-                    zfp_stream_close(zfp);
-                    stream_close(stream);
-                    if (needs_free) {
-                        free(chunk);
-                    }
-                    if (is_lazy) {
-                        free(block);
-                    }
-                    return 0;
-            }
-            break;
-        case 4:
-            switch (type) {
-                case zfp_type_float:
-                    zfpsize = zfp_decode_block_float_4(zfp, dest);
-                    break;
-                case zfp_type_double:
-                    zfpsize = zfp_decode_block_double_4(zfp, dest);
-                    break;
-                default:
-                    printf("\n ZFP is not available for this typesize \n");
-                    free(shape);
-                    free(chunkshape);
-                    free(blockshape);
-                    zfp_stream_close(zfp);
-                    stream_close(stream);
-                    if (needs_free) {
-                        free(chunk);
-                    }
-                    if (is_lazy) {
-                        free(block);
-                    }
-                    return 0;
-            }
-            break;
-        default:
-            printf("\n ZFP is not available for this number of dims \n");
-            return 0;
-    }
-
-    free(shape);
-    free(chunkshape);
-    free(blockshape);
-    zfp_stream_close(zfp);
-    stream_close(stream);
-    if (needs_free) {
-        free(chunk);
-    }
-    if (is_lazy) {
-        free(block);
-    }
-
-    if ((zfpsize < 0) || (zfpsize > (destsize * typesize * 8))) {
-        BLOSC_TRACE_ERROR("ZFP error or small destsize");
-        return -1;
-    }
-
-    return (int) zfpsize;
-}
-
-
-int blosc2_zfp_getitem(blosc2_schunk* schunk, int64_t index, void* item) {
-    int32_t typesize = schunk->typesize;
-    int8_t ndim;
-    int64_t *shape = malloc(8 * sizeof(int64_t));
-    int32_t *chunkshape = malloc(8 * sizeof(int64_t));
-    int32_t *blockshape = malloc(8 * sizeof(int64_t));
-    int64_t cellshape[ZFP_MAX_DIM] = {ZFP_CELL_SHAPE, ZFP_CELL_SHAPE, ZFP_CELL_SHAPE, ZFP_CELL_SHAPE};
-    uint8_t *smeta;
-    int32_t smeta_len;
-    if (blosc2_meta_get(schunk, "caterva", &smeta, &smeta_len) < 0) {
-        printf("Blosc error");
-        free(shape);
-        free(chunkshape);
-        free(blockshape);
-        return -1;
-    }
-    deserialize_meta(smeta, smeta_len, &ndim, shape, chunkshape, blockshape);
-    free(smeta);
-
-    int64_t index_ndim[ZFP_MAX_DIM];
-    int64_t index_chunk_ndim[ZFP_MAX_DIM];
-    int64_t index_block_ndim[ZFP_MAX_DIM];
-    int64_t index_cell_ndim[ZFP_MAX_DIM];
-    int64_t ind_ndim[ZFP_MAX_DIM];
-    index_unidim_to_multidim(ndim, shape, index, index_ndim);
-    int64_t cellsize = typesize;
-    for (int i = 0; i < ndim; ++i) {
-        index_chunk_ndim[i] = index_ndim[i] / chunkshape[i];
-        index_block_ndim[i] = (index_ndim[i] % chunkshape[i]) / blockshape[i];
-        index_cell_ndim[i] = ((index_ndim[i] % chunkshape[i]) % blockshape[i]) / ZFP_CELL_SHAPE;
-        ind_ndim[i] = ((index_ndim[i] % chunkshape[i]) % blockshape[i]) % ZFP_CELL_SHAPE;
-        cellsize *= cellshape[i];
-    }
-    int64_t chunk_strides[ZFP_MAX_DIM];
-    int64_t block_strides[ZFP_MAX_DIM];
-    int64_t cell_strides[ZFP_MAX_DIM];
-    int64_t item_strides[ZFP_MAX_DIM];
-    chunk_strides[ndim - 1] = block_strides[ndim - 1] = cell_strides[ndim - 1] = item_strides[ndim - 1] = 1;
-    for (int i = ndim - 2; i >= 0; --i) {
-        int j = i + 1;
-        chunk_strides[i] = (shape[j] - 1) / chunkshape[j] + 1;
-        block_strides[i] = (chunkshape[j] - 1) / blockshape[j] + 1;
-        cell_strides[i] = (blockshape[j] - 1) / cellshape[j] + 1;
-        item_strides[i] = cellshape[j];
-    }
-    int64_t nchunk, nblock, ncell, ind;
-    index_multidim_to_unidim(index_chunk_ndim, ndim, (int64_t*) chunk_strides, &nchunk);
-    index_multidim_to_unidim(index_block_ndim, ndim, (int64_t*) block_strides, &nblock);
-    index_multidim_to_unidim(index_cell_ndim, ndim, (int64_t*) cell_strides, &ncell);
-    index_multidim_to_unidim(ind_ndim, ndim, item_strides, &ind);
-
-    int8_t *cell = malloc(cellsize);
-    blosc2_zfp_getcell_old(schunk, (int) nchunk, (int) nblock, (int) ncell, cell, cellsize);
-    memcpy(item, cell + ind * typesize, typesize);
-
-    return typesize;
-}
-*/

--- a/plugins/codecs/zfp/blosc2-zfp.c
+++ b/plugins/codecs/zfp/blosc2-zfp.c
@@ -14,12 +14,6 @@ int zfp_acc_compress(const uint8_t *input, int32_t input_len, uint8_t *output,
     ZFP_ERROR_NULL(cparams);
 
     double tol = (int8_t) meta;
-/*
-    printf("\n input \n");
-    for (int i = 0; i < input_len; i++) {
-        printf("%u, ", input[i]);
-    }
-*/
     int8_t ndim;
     int64_t *shape = malloc(8 * sizeof(int64_t));
     int32_t *chunkshape = malloc(8 * sizeof(int32_t));
@@ -226,12 +220,6 @@ int zfp_prec_compress(const uint8_t *input, int32_t input_len, uint8_t *output,
     ZFP_ERROR_NULL(output);
     ZFP_ERROR_NULL(cparams);
 
-/*
-    printf("\n input \n");
-    for (int i = 0; i < input_len; i++) {
-        printf("%u, ", input[i]);
-    }
-*/
     int8_t ndim;
     int64_t *shape = malloc(8 * sizeof(int64_t));
     int32_t *chunkshape = malloc(8 * sizeof(int32_t));
@@ -488,12 +476,6 @@ int zfp_rate_compress(const uint8_t *input, int32_t input_len, uint8_t *output,
     ZFP_ERROR_NULL(cparams);
 
     double ratio = (double) meta / 100.0;
-/*
-    printf("\n input \n");
-    for (int i = 0; i < input_len; i++) {
-        printf("%u, ", input[i]);
-    }
-*/
     int8_t ndim;
     int64_t *shape = malloc(8 * sizeof(int64_t));
     int32_t *chunkshape = malloc(8 * sizeof(int32_t));

--- a/plugins/codecs/zfp/blosc2-zfp.c
+++ b/plugins/codecs/zfp/blosc2-zfp.c
@@ -5,9 +5,11 @@
 #include "zfp.h"
 #include "blosc2-zfp.h"
 #include <math.h>
+#include "context.h"
+#include "assert.h"
 
-int blosc2_zfp_acc_compress(const uint8_t *input, int32_t input_len, uint8_t *output,
-                            int32_t output_len, uint8_t meta, blosc2_cparams *cparams, const void* chunk) {
+int zfp_acc_compress(const uint8_t *input, int32_t input_len, uint8_t *output,
+                     int32_t output_len, uint8_t meta, blosc2_cparams *cparams, const void* chunk) {
     ZFP_ERROR_NULL(input);
     ZFP_ERROR_NULL(output);
     ZFP_ERROR_NULL(cparams);
@@ -125,8 +127,8 @@ int blosc2_zfp_acc_compress(const uint8_t *input, int32_t input_len, uint8_t *ou
     return (int) zfpsize;
 }
 
-int blosc2_zfp_acc_decompress(const uint8_t *input, int32_t input_len, uint8_t *output,
-                              int32_t output_len, uint8_t meta, blosc2_dparams *dparams, const void* chunk) {
+int zfp_acc_decompress(const uint8_t *input, int32_t input_len, uint8_t *output,
+                       int32_t output_len, uint8_t meta, blosc2_dparams *dparams, const void* chunk) {
     ZFP_ERROR_NULL(input);
     ZFP_ERROR_NULL(output);
     ZFP_ERROR_NULL(dparams);
@@ -219,8 +221,8 @@ int blosc2_zfp_acc_decompress(const uint8_t *input, int32_t input_len, uint8_t *
     return (int) output_len;
 }
 
-int blosc2_zfp_prec_compress(const uint8_t *input, int32_t input_len, uint8_t *output,
-                            int32_t output_len, uint8_t meta, blosc2_cparams *cparams, const void* chunk) {
+int zfp_prec_compress(const uint8_t *input, int32_t input_len, uint8_t *output,
+                      int32_t output_len, uint8_t meta, blosc2_cparams *cparams, const void* chunk) {
     ZFP_ERROR_NULL(input);
     ZFP_ERROR_NULL(output);
     ZFP_ERROR_NULL(cparams);
@@ -362,8 +364,8 @@ int blosc2_zfp_prec_compress(const uint8_t *input, int32_t input_len, uint8_t *o
     return (int) zfpsize;
 }
 
-int blosc2_zfp_prec_decompress(const uint8_t *input, int32_t input_len, uint8_t *output,
-                              int32_t output_len, uint8_t meta, blosc2_dparams *dparams, const void* chunk) {
+int zfp_prec_decompress(const uint8_t *input, int32_t input_len, uint8_t *output,
+                        int32_t output_len, uint8_t meta, blosc2_dparams *dparams, const void* chunk) {
     ZFP_ERROR_NULL(input);
     ZFP_ERROR_NULL(output);
     ZFP_ERROR_NULL(dparams);
@@ -480,8 +482,8 @@ int blosc2_zfp_prec_decompress(const uint8_t *input, int32_t input_len, uint8_t 
     return (int) output_len;
 }
 
-int blosc2_zfp_rate_compress(const uint8_t *input, int32_t input_len, uint8_t *output,
-                             int32_t output_len, uint8_t meta, blosc2_cparams *cparams, const void* chunk) {
+int zfp_rate_compress(const uint8_t *input, int32_t input_len, uint8_t *output,
+                      int32_t output_len, uint8_t meta, blosc2_cparams *cparams, const void* chunk) {
     ZFP_ERROR_NULL(input);
     ZFP_ERROR_NULL(output);
     ZFP_ERROR_NULL(cparams);
@@ -614,8 +616,8 @@ int blosc2_zfp_rate_compress(const uint8_t *input, int32_t input_len, uint8_t *o
     return (int) zfpsize;
 }
 
-int blosc2_zfp_rate_decompress(const uint8_t *input, int32_t input_len, uint8_t *output,
-                              int32_t output_len, uint8_t meta, blosc2_dparams *dparams, const void* chunk) {
+int zfp_rate_decompress(const uint8_t *input, int32_t input_len, uint8_t *output,
+                        int32_t output_len, uint8_t meta, blosc2_dparams *dparams, const void* chunk) {
     ZFP_ERROR_NULL(input);
     ZFP_ERROR_NULL(output);
     ZFP_ERROR_NULL(dparams);
@@ -709,14 +711,16 @@ int blosc2_zfp_rate_decompress(const uint8_t *input, int32_t input_len, uint8_t 
 }
 
 
-int blosc2_zfp_getcell(blosc2_context *context, const uint8_t *block, int32_t cbytes, uint8_t *dest, int32_t destsize) {
+int zfp_getcell(blosc2_context *context, const uint8_t *block, int32_t cbytes, uint8_t *dest, int32_t destsize) {
+    bool meta = false;
     uint8_t ndim;
-    int32_t blockshape[8];
+    int32_t blockshape[4];      // ZFP only works for caterva datasets
     for (int nmetalayer = 0; nmetalayer < context->schunk->nmetalayers; nmetalayer++) {
         if (strcmp("caterva", context->schunk->metalayers[nmetalayer]->name) == 0) {
+            meta = true;
             uint8_t *pmeta = context->schunk->metalayers[nmetalayer]->content;
-            ndim = pmeta[2];
-            pmeta += (6 + 2 * ndim * 9);
+            ndim = (int8_t) pmeta[2];
+            pmeta += (6 + ndim * 9 + ndim * 5);
             for (int8_t i = 0; i < ndim; i++) {
                 pmeta += 1;
                 swap_store(blockshape + i, pmeta, sizeof(int32_t));
@@ -724,150 +728,152 @@ int blosc2_zfp_getcell(blosc2_context *context, const uint8_t *block, int32_t cb
             }
         }
     }
-    if (ndim <= 4) {
-        int64_t cell_start_ndim[4], cell_ind_ndim[4], ncell_ndim[4], ind_strides[4], cell_strides[4];
-        int64_t cell_ind, ncell;
-        int cellshape = 4;
-        index_unidim_to_multidim((int8_t) ndim, (int64_t *) blockshape, context->cell_start, cell_start_ndim);
-        for (int i = 0; i < ndim; ++i) {
-            cell_ind_ndim[i] = cell_start_ndim[i] % cellshape;
-            ncell_ndim[i] = cell_start_ndim[i] / cellshape;
-        }
-        ind_strides[ndim - 1] = cell_strides[ndim - 1] = 1;
-        for (int i = ndim - 2; i >= 0; --i) {
-            ind_strides[i] = cellshape;
-            cell_strides[i] = (blockshape[i + 1] - 1) / cellshape + 1;
-        }
-        index_multidim_to_unidim(cell_ind_ndim, (int8_t) ndim, ind_strides, &cell_ind);
-        index_multidim_to_unidim(ncell_ndim, (int8_t) ndim, cell_strides, &ncell);
-        int cell_nitems = (int) (1u << (2 * ndim));
-        if ((context->compcode == BLOSC_CODEC_ZFP_FIXED_RATE) && (context->zfp_nitems <= cell_nitems) &&
-            ((cell_ind + context->zfp_nitems) <= cell_nitems)) {
+    if (!meta) {
+        return -1;
+    }
+    assert(ndim <= 4);
+    int64_t cell_start_ndim[4], cell_ind_ndim[4], ncell_ndim[4], ind_strides[4], cell_strides[4];
+    int64_t cell_ind, ncell;
+    int cellshape = 4;
+    index_unidim_to_multidim(ndim, blockshape, context->zfp_cell_start, cell_start_ndim);
+    for (int i = 0; i < ndim; ++i) {
+        cell_ind_ndim[i] = cell_start_ndim[i] % cellshape;
+        ncell_ndim[i] = cell_start_ndim[i] / cellshape;
+    }
+    ind_strides[ndim - 1] = cell_strides[ndim - 1] = 1;
+    for (int i = ndim - 2; i >= 0; --i) {
+        ind_strides[i] = cellshape;
+        cell_strides[i] = (blockshape[i + 1] - 1) / cellshape + 1;
+    }
+    index_multidim_to_unidim(cell_ind_ndim, (int8_t) ndim, ind_strides, &cell_ind);
+    index_multidim_to_unidim(ncell_ndim, (int8_t) ndim, cell_strides, &ncell);
+    int cell_nitems = (int) (1u << (2 * ndim));
+    if ((context->zfp_cell_nitems > cell_nitems) || ((cell_ind + context->zfp_cell_nitems) > cell_nitems)) {
+        return 0;
+    }
 
-            // Get the ZFP stream
-            zfp_type type;     /* array scalar type */
-            zfp_stream *zfp;   /* compressed stream */
-            bitstream *stream; /* bit stream to write to or read from */
-            int32_t typesize = context->typesize;
-            zfp = zfp_stream_open(NULL);
+    // Get the ZFP stream
+    zfp_type type;     /* array scalar type */
+    zfp_stream *zfp;   /* compressed stream */
+    bitstream *stream; /* bit stream to write to or read from */
+    int32_t typesize = context->typesize;
+    zfp = zfp_stream_open(NULL);
 
-            switch (typesize) {
-                case sizeof(float):
-                    type = zfp_type_float;
+    switch (typesize) {
+        case sizeof(float):
+            type = zfp_type_float;
+            break;
+        case sizeof(double):
+            type = zfp_type_double;
+            break;
+        default:
+            printf("\n ZFP is not available for this typesize \n");
+            return 0;
+    }
+    uint8_t compmeta = context->compcode_meta;                                 // access to compressed chunk header
+    double rate = (double) (compmeta * typesize * 8) /
+                  100.0;     // convert from output size / input size to output bits per input value
+    zfp_stream_set_rate(zfp, rate, type, ndim, zfp_false);
+
+    stream = stream_open((void *) block, cbytes);
+    zfp_stream_set_bit_stream(zfp, stream);
+    zfp_stream_rewind(zfp);
+
+    // Check that ncell is a valid index
+    int ncells = (int) ((cbytes * 8) / zfp->maxbits);
+    if (ncell >= ncells) {
+        BLOSC_TRACE_ERROR("Invalid cell index");
+        return -1;
+    }
+
+    // Position the stream at the ncell bit offset for reading
+    stream_rseek(zfp->stream, ncell * zfp->maxbits);
+
+    // Get the cell
+    size_t zfpsize;
+    uint8_t *cell = malloc(cell_nitems * typesize);
+    switch (ndim) {
+        case 1:
+            switch (type) {
+                case zfp_type_float:
+                    zfpsize = zfp_decode_block_float_1(zfp, (float *) cell);
                     break;
-                case sizeof(double):
-                    type = zfp_type_double;
+                case zfp_type_double:
+                    zfpsize = zfp_decode_block_double_1(zfp, (double *) cell);
                     break;
                 default:
                     printf("\n ZFP is not available for this typesize \n");
+                    zfp_stream_close(zfp);
+                    stream_close(stream);
                     return 0;
             }
-            uint8_t compmeta = context->compcode_meta;                                 // access to compressed chunk header
-            double rate = (double) (compmeta * typesize * 8) /
-                          100.0;     // convert from output size / input size to output bits per input value
-            zfp_stream_set_rate(zfp, rate, type, ndim, zfp_false);
-
-            stream = stream_open((void *) block, cbytes);
-            zfp_stream_set_bit_stream(zfp, stream);
-            zfp_stream_rewind(zfp);
-
-            // Check that ncell is a valid index
-            int ncells = (int) ((cbytes * 8) / zfp->maxbits);
-            if (ncell >= ncells) {
-                BLOSC_TRACE_ERROR("Invalid cell index");
-                return -1;
-            }
-
-            // Position the stream at the ncell bit offset for reading
-            stream_rseek(zfp->stream, ncell * zfp->maxbits);
-
-            // Get the cell
-            size_t zfpsize;
-            uint8_t *cell = malloc(cell_nitems * typesize);
-            switch (ndim) {
-                case 1:
-                    switch (type) {
-                        case zfp_type_float:
-                            zfpsize = zfp_decode_block_float_1(zfp, (float *) cell);
-                            break;
-                        case zfp_type_double:
-                            zfpsize = zfp_decode_block_double_1(zfp, (double *) cell);
-                            break;
-                        default:
-                            printf("\n ZFP is not available for this typesize \n");
-                            zfp_stream_close(zfp);
-                            stream_close(stream);
-                            return 0;
-                    }
+            break;
+        case 2:
+            switch (type) {
+                case zfp_type_float:
+                    zfpsize = zfp_decode_block_float_2(zfp, (float *) cell);
                     break;
-                case 2:
-                    switch (type) {
-                        case zfp_type_float:
-                            zfpsize = zfp_decode_block_float_2(zfp, (float *) cell);
-                            break;
-                        case zfp_type_double:
-                            zfpsize = zfp_decode_block_double_2(zfp, (double *) cell);
-                            break;
-                        default:
-                            printf("\n ZFP is not available for this typesize \n");
-                            zfp_stream_close(zfp);
-                            stream_close(stream);
-                            return 0;
-                    }
-                    break;
-                case 3:
-                    switch (type) {
-                        case zfp_type_float:
-                            zfpsize = zfp_decode_block_float_3(zfp, (float *) cell);
-                            break;
-                        case zfp_type_double:
-                            zfpsize = zfp_decode_block_double_3(zfp, (double *) cell);
-                            break;
-                        default:
-                            printf("\n ZFP is not available for this typesize \n");
-                            zfp_stream_close(zfp);
-                            stream_close(stream);
-                            return 0;
-                    }
-                    break;
-                case 4:
-                    switch (type) {
-                        case zfp_type_float:
-                            zfpsize = zfp_decode_block_float_4(zfp, (float *) cell);
-                            break;
-                        case zfp_type_double:
-                            zfpsize = zfp_decode_block_double_4(zfp, (double *) cell);
-                            break;
-                        default:
-                            printf("\n ZFP is not available for this typesize \n");
-                            zfp_stream_close(zfp);
-                            stream_close(stream);
-                            return 0;
-                    }
+                case zfp_type_double:
+                    zfpsize = zfp_decode_block_double_2(zfp, (double *) cell);
                     break;
                 default:
-                    printf("\n ZFP is not available for this number of dims \n");
+                    printf("\n ZFP is not available for this typesize \n");
+                    zfp_stream_close(zfp);
+                    stream_close(stream);
                     return 0;
             }
-
-            memcpy(dest, &cell[context->cell_start * typesize], context->zfp_nitems * typesize);
-            zfp_stream_close(zfp);
-            stream_close(stream);
-
-            if ((zfpsize < 0) || (zfpsize > (destsize * 8)) || (zfpsize > (cell_nitems * typesize * 8)) ||
-                ((context->zfp_nitems * typesize * 8) > zfpsize)) {
-                BLOSC_TRACE_ERROR("ZFP error or small destsize");
-                return -1;
+            break;
+        case 3:
+            switch (type) {
+                case zfp_type_float:
+                    zfpsize = zfp_decode_block_float_3(zfp, (float *) cell);
+                    break;
+                case zfp_type_double:
+                    zfpsize = zfp_decode_block_double_3(zfp, (double *) cell);
+                    break;
+                default:
+                    printf("\n ZFP is not available for this typesize \n");
+                    zfp_stream_close(zfp);
+                    stream_close(stream);
+                    return 0;
             }
-
-            return (int) (context->zfp_nitems * typesize);
-        }
+            break;
+        case 4:
+            switch (type) {
+                case zfp_type_float:
+                    zfpsize = zfp_decode_block_float_4(zfp, (float *) cell);
+                    break;
+                case zfp_type_double:
+                    zfpsize = zfp_decode_block_double_4(zfp, (double *) cell);
+                    break;
+                default:
+                    printf("\n ZFP is not available for this typesize \n");
+                    zfp_stream_close(zfp);
+                    stream_close(stream);
+                    return 0;
+            }
+            break;
+        default:
+            printf("\n ZFP is not available for this number of dims \n");
+            return 0;
     }
-    return -1;
+
+    memcpy(dest, &cell[context->zfp_cell_start * typesize], context->zfp_cell_nitems * typesize);
+    zfp_stream_close(zfp);
+    stream_close(stream);
+
+    if ((zfpsize < 0) || (zfpsize > (destsize * 8)) || (zfpsize > (cell_nitems * typesize * 8)) ||
+        ((context->zfp_cell_nitems * typesize * 8) > zfpsize)) {
+        BLOSC_TRACE_ERROR("ZFP error or small destsize");
+        return -1;
+    }
+
+    return (int) (context->zfp_cell_nitems * typesize);
 }
 
+/*
 
-int blosc2_zfp_getcell_old(blosc2_schunk* schunk, int nchunk, int nblock, int ncell, void *dest, size_t destsize) {
+ int blosc2_zfp_getcell_old(blosc2_schunk* schunk, int nchunk, int nblock, int ncell, void *dest, size_t destsize) {
     ZFP_ERROR_NULL(dest);
     int32_t typesize = schunk->typesize;
     int8_t ndim;
@@ -968,10 +974,12 @@ int blosc2_zfp_getcell_old(blosc2_schunk* schunk, int nchunk, int nblock, int nc
 
     // Get the ZFP stream
     zfp_type type;     /* array scalar type */
+  /*  zfp_stream *zfp;   /* compressed stream */
+   /* bitstream *stream; /* bit stream to write to or read from */
+/*
     zfp_stream *zfp;   /* compressed stream */
-    bitstream *stream; /* bit stream to write to or read from */
-
-    zfp = zfp_stream_open(NULL);
+ /*   bitstream *stream; /* bit stream to write to or read from */
+  /*  zfp = zfp_stream_open(NULL);
 
     switch (typesize) {
         case sizeof(float):
@@ -1193,3 +1201,4 @@ int blosc2_zfp_getitem(blosc2_schunk* schunk, int64_t index, void* item) {
 
     return typesize;
 }
+*/

--- a/plugins/codecs/zfp/blosc2-zfp.c
+++ b/plugins/codecs/zfp/blosc2-zfp.c
@@ -724,8 +724,8 @@ int zfp_getcell(blosc2_context *context, const uint8_t *block, int32_t cbytes, u
     }
     ind_strides[ndim - 1] = cell_strides[ndim - 1] = 1;
     for (int i = ndim - 2; i >= 0; --i) {
-        ind_strides[i] = cellshape;
-        cell_strides[i] = (blockshape[i + 1] - 1) / cellshape + 1;
+        ind_strides[i] = cellshape * ind_strides[i + 1];
+        cell_strides[i] = ((blockshape[i + 1] - 1) / cellshape + 1) * cell_strides[i + 1];
     }
     index_multidim_to_unidim(cell_ind_ndim, (int8_t) ndim, ind_strides, &cell_ind);
     index_multidim_to_unidim(ncell_ndim, (int8_t) ndim, cell_strides, &ncell);

--- a/plugins/codecs/zfp/blosc2-zfp.c
+++ b/plugins/codecs/zfp/blosc2-zfp.c
@@ -5,6 +5,7 @@
 #include "zfp.h"
 #include "blosc2-zfp.h"
 #include <math.h>
+#include "context.h"
 
 int blosc2_zfp_acc_compress(const uint8_t *input, int32_t input_len, uint8_t *output,
                             int32_t output_len, uint8_t meta, blosc2_cparams *cparams, const void* chunk) {
@@ -866,7 +867,7 @@ int blosc2_zfp_getcell(blosc2_context *context, const uint8_t *block, int32_t cb
     return -1;
 }
 
-
+/*
 int blosc2_zfp_getcell_old(blosc2_schunk* schunk, int nchunk, int nblock, int ncell, void *dest, size_t destsize) {
     ZFP_ERROR_NULL(dest);
     int32_t typesize = schunk->typesize;
@@ -968,9 +969,9 @@ int blosc2_zfp_getcell_old(blosc2_schunk* schunk, int nchunk, int nblock, int nc
 
     // Get the ZFP stream
     zfp_type type;     /* array scalar type */
-    zfp_stream *zfp;   /* compressed stream */
-    bitstream *stream; /* bit stream to write to or read from */
-
+  /*  zfp_stream *zfp;   /* compressed stream */
+   /* bitstream *stream; /* bit stream to write to or read from */
+/*
     zfp = zfp_stream_open(NULL);
 
     switch (typesize) {
@@ -1193,3 +1194,4 @@ int blosc2_zfp_getitem(blosc2_schunk* schunk, int64_t index, void* item) {
 
     return typesize;
 }
+*/

--- a/plugins/codecs/zfp/blosc2-zfp.h
+++ b/plugins/codecs/zfp/blosc2-zfp.h
@@ -18,6 +18,8 @@
 extern "C" {
 #endif
 
+#define ZFP_MAX_DIM 4
+
 int blosc2_zfp_acc_compress(const uint8_t *input, int32_t input_len, uint8_t *output, int32_t output_len,
                             uint8_t meta, blosc2_cparams *cparams, const void* chunk);
 
@@ -36,7 +38,11 @@ int blosc2_zfp_rate_compress(const uint8_t *input, int32_t input_len, uint8_t *o
 int blosc2_zfp_rate_decompress(const uint8_t *input, int32_t input_len, uint8_t *output, int32_t output_len,
                                uint8_t meta, blosc2_dparams *dparams, const void* chunk);
 
-int blosc2_zfp_decompress_cell(blosc2_schunk* schunk, int nchunk, int nblock, int ncell, void *dest, size_t destsize);
+int blosc2_zfp_getcell(blosc2_schunk* schunk, int nchunk, int nblock, int ncell, void *dest, size_t destsize);
+
+int blosc2_zfp_get_partial_block(blosc2_schunk* schunk, int nchunk, int nblock, bool* block_mask, int mask_len, void *dest, size_t destsize);
+
+int blosc2_zfp_get_block_slice(blosc2_schunk* schunk, int nchunk, int nblock, int64_t *start, int64_t *stop, void *dest, size_t destsize);
 
 #if defined (__cplusplus)
 }

--- a/plugins/codecs/zfp/blosc2-zfp.h
+++ b/plugins/codecs/zfp/blosc2-zfp.h
@@ -19,6 +19,7 @@ extern "C" {
 #endif
 
 #define ZFP_MAX_DIM 4
+#define ZFP_CELL_SHAPE 4
 
 int blosc2_zfp_acc_compress(const uint8_t *input, int32_t input_len, uint8_t *output, int32_t output_len,
                             uint8_t meta, blosc2_cparams *cparams, const void* chunk);
@@ -40,9 +41,7 @@ int blosc2_zfp_rate_decompress(const uint8_t *input, int32_t input_len, uint8_t 
 
 int blosc2_zfp_getcell(blosc2_schunk* schunk, int nchunk, int nblock, int ncell, void *dest, size_t destsize);
 
-int blosc2_zfp_get_partial_block(blosc2_schunk* schunk, int nchunk, int nblock, bool* block_mask, int mask_len, void *dest, size_t destsize);
-
-int blosc2_zfp_get_block_slice(blosc2_schunk* schunk, int nchunk, int nblock, int64_t *start, int64_t *stop, void *dest, size_t destsize);
+int blosc2_zfp_getitem(blosc2_schunk* schunk, int64_t index, void* item);
 
 #if defined (__cplusplus)
 }

--- a/plugins/codecs/zfp/blosc2-zfp.h
+++ b/plugins/codecs/zfp/blosc2-zfp.h
@@ -36,6 +36,8 @@ int blosc2_zfp_rate_compress(const uint8_t *input, int32_t input_len, uint8_t *o
 int blosc2_zfp_rate_decompress(const uint8_t *input, int32_t input_len, uint8_t *output, int32_t output_len,
                                uint8_t meta, blosc2_dparams *dparams, const void* chunk);
 
+int blosc2_zfp_decompress_cell(blosc2_schunk* schunk, int nchunk, int nblock, int ncell, void *dest, size_t destsize);
+
 #if defined (__cplusplus)
 }
 #endif

--- a/plugins/codecs/zfp/blosc2-zfp.h
+++ b/plugins/codecs/zfp/blosc2-zfp.h
@@ -13,13 +13,12 @@
 #ifndef BLOSC2_ZFP_H
 #define BLOSC2_ZFP_H
 #include "context.h"
+#include "zfp-private.h"
 
 #if defined (__cplusplus)
 extern "C" {
 #endif
 
-#define ZFP_MAX_DIM 4
-#define ZFP_CELL_SHAPE 4
 
 int blosc2_zfp_acc_compress(const uint8_t *input, int32_t input_len, uint8_t *output, int32_t output_len,
                             uint8_t meta, blosc2_cparams *cparams, const void* chunk);

--- a/plugins/codecs/zfp/blosc2-zfp.h
+++ b/plugins/codecs/zfp/blosc2-zfp.h
@@ -20,30 +20,30 @@ extern "C" {
 #endif
 
 
-int blosc2_zfp_acc_compress(const uint8_t *input, int32_t input_len, uint8_t *output, int32_t output_len,
+int zfp_acc_compress(const uint8_t *input, int32_t input_len, uint8_t *output, int32_t output_len,
                             uint8_t meta, blosc2_cparams *cparams, const void* chunk);
 
-int blosc2_zfp_acc_decompress(const uint8_t *input, int32_t input_len, uint8_t *output, int32_t output_len,
+int zfp_acc_decompress(const uint8_t *input, int32_t input_len, uint8_t *output, int32_t output_len,
                               uint8_t meta, blosc2_dparams *dparams, const void* chunk);
 
-int blosc2_zfp_prec_compress(const uint8_t *input, int32_t input_len, uint8_t *output, int32_t output_len,
+int zfp_prec_compress(const uint8_t *input, int32_t input_len, uint8_t *output, int32_t output_len,
                             uint8_t meta, blosc2_cparams *cparams, const void* chunk);
 
-int blosc2_zfp_prec_decompress(const uint8_t *input, int32_t input_len, uint8_t *output, int32_t output_len,
+int zfp_prec_decompress(const uint8_t *input, int32_t input_len, uint8_t *output, int32_t output_len,
                               uint8_t meta, blosc2_dparams *dparams, const void* chunk);
 
-int blosc2_zfp_rate_compress(const uint8_t *input, int32_t input_len, uint8_t *output, int32_t output_len,
+int zfp_rate_compress(const uint8_t *input, int32_t input_len, uint8_t *output, int32_t output_len,
                              uint8_t meta, blosc2_cparams *cparams, const void* chunk);
 
-int blosc2_zfp_rate_decompress(const uint8_t *input, int32_t input_len, uint8_t *output, int32_t output_len,
+int zfp_rate_decompress(const uint8_t *input, int32_t input_len, uint8_t *output, int32_t output_len,
                                uint8_t meta, blosc2_dparams *dparams, const void* chunk);
 
-int blosc2_zfp_getcell(blosc2_context *context, const uint8_t *block, int32_t cbytes, uint8_t *dest, int32_t destsize);
-
+int zfp_getcell(blosc2_context *context, const uint8_t *block, int32_t cbytes, uint8_t *dest, int32_t destsize);
+/*
 int blosc2_zfp_getcell_old(blosc2_schunk* schunk, int nchunk, int nblock, int ncell, void *dest, size_t destsize);
 
 int blosc2_zfp_getitem(blosc2_schunk* schunk, int64_t index, void* item);
-
+*/
 #if defined (__cplusplus)
 }
 #endif

--- a/plugins/codecs/zfp/blosc2-zfp.h
+++ b/plugins/codecs/zfp/blosc2-zfp.h
@@ -12,12 +12,11 @@
 
 #ifndef BLOSC2_ZFP_H
 #define BLOSC2_ZFP_H
-#include "zfp-private.h"
+#include "context.h"
 
 #if defined (__cplusplus)
 extern "C" {
 #endif
-
 
 int blosc2_zfp_acc_compress(const uint8_t *input, int32_t input_len, uint8_t *output, int32_t output_len,
                             uint8_t meta, blosc2_cparams *cparams, const void* chunk);
@@ -37,11 +36,7 @@ int blosc2_zfp_rate_compress(const uint8_t *input, int32_t input_len, uint8_t *o
 int blosc2_zfp_rate_decompress(const uint8_t *input, int32_t input_len, uint8_t *output, int32_t output_len,
                                uint8_t meta, blosc2_dparams *dparams, const void* chunk);
 
-int blosc2_zfp_getcell(blosc2_context *context, const uint8_t *block, int32_t cbytes, uint8_t *dest, int32_t destsize);
-
-int blosc2_zfp_getcell_old(blosc2_schunk* schunk, int nchunk, int nblock, int ncell, void *dest, size_t destsize);
-
-int blosc2_zfp_getitem(blosc2_schunk* schunk, int64_t index, void* item);
+int blosc2_zfp_decompress_cell(blosc2_schunk* schunk, int nchunk, int nblock, int ncell, void *dest, size_t destsize);
 
 #if defined (__cplusplus)
 }

--- a/plugins/codecs/zfp/blosc2-zfp.h
+++ b/plugins/codecs/zfp/blosc2-zfp.h
@@ -39,11 +39,8 @@ int zfp_rate_decompress(const uint8_t *input, int32_t input_len, uint8_t *output
                                uint8_t meta, blosc2_dparams *dparams, const void* chunk);
 
 int zfp_getcell(blosc2_context *context, const uint8_t *block, int32_t cbytes, uint8_t *dest, int32_t destsize);
-/*
-int blosc2_zfp_getcell_old(blosc2_schunk* schunk, int nchunk, int nblock, int ncell, void *dest, size_t destsize);
 
-int blosc2_zfp_getitem(blosc2_schunk* schunk, int64_t index, void* item);
-*/
+
 #if defined (__cplusplus)
 }
 #endif

--- a/plugins/codecs/zfp/blosc2-zfp.h
+++ b/plugins/codecs/zfp/blosc2-zfp.h
@@ -12,7 +12,6 @@
 
 #ifndef BLOSC2_ZFP_H
 #define BLOSC2_ZFP_H
-#include "context.h"
 #include "zfp-private.h"
 
 #if defined (__cplusplus)

--- a/plugins/codecs/zfp/blosc2-zfp.h
+++ b/plugins/codecs/zfp/blosc2-zfp.h
@@ -38,7 +38,9 @@ int blosc2_zfp_rate_compress(const uint8_t *input, int32_t input_len, uint8_t *o
 int blosc2_zfp_rate_decompress(const uint8_t *input, int32_t input_len, uint8_t *output, int32_t output_len,
                                uint8_t meta, blosc2_dparams *dparams, const void* chunk);
 
-int blosc2_zfp_getcell(blosc2_schunk* schunk, int nchunk, int nblock, int ncell, void *dest, size_t destsize);
+int blosc2_zfp_getcell(blosc2_context *context, const uint8_t *block, int32_t cbytes, uint8_t *dest, int32_t destsize);
+
+int blosc2_zfp_getcell_old(blosc2_schunk* schunk, int nchunk, int nblock, int ncell, void *dest, size_t destsize);
 
 int blosc2_zfp_getitem(blosc2_schunk* schunk, int64_t index, void* item);
 

--- a/plugins/codecs/zfp/test_zfp_acc_float.c
+++ b/plugins/codecs/zfp/test_zfp_acc_float.c
@@ -65,12 +65,7 @@ static int test_zfp_acc_float(blosc2_schunk* schunk) {
             printf("Error decompressing chunk \n");
             return -1;
         }
-/*
-        printf("\n chunk \n");
-        for (int i = 0; i < (chunksize / cparams.typesize); i++) {
-            printf("%f, ", data_in[i]);
-        }
-*/
+
         /* Compress with clevel=5 and shuffle active  */
         csize = blosc2_compress_ctx(cctx, data_in, chunksize, data_out, chunksize + BLOSC_MAX_OVERHEAD);
         if (csize == 0) {
@@ -89,12 +84,6 @@ static int test_zfp_acc_float(blosc2_schunk* schunk) {
             printf("Decompression error.  Error code: %" PRId64 "\n", dsize);
             return (int) dsize;
         }
-/*
-        printf("\n dest \n");
-        for (int i = 0; i < (chunksize / cparams.typesize); i++) {
-            printf("%f, ", data_dest[i]);
-        }
-*/
         double tolerance = exp(zfp_tol);
         for (int i = 0; i < (chunksize / cparams.typesize); i++) {
             if (fabsf(data_in[i] - data_dest[i]) > tolerance) {
@@ -161,12 +150,7 @@ static int test_zfp_acc_double(blosc2_schunk* schunk) {
             printf("Error decompressing chunk \n");
             return -1;
         }
-/*
-        printf("\n chunk \n");
-        for (int i = 0; i < (chunksize / cparams.typesize); i++) {
-            printf("%f, ", data_in[i]);
-        }
-*/
+
         /* Compress with clevel=5 and shuffle active  */
         csize = blosc2_compress_ctx(cctx, data_in, chunksize, data_out, chunksize + BLOSC_MAX_OVERHEAD);
         if (csize == 0) {
@@ -185,12 +169,6 @@ static int test_zfp_acc_double(blosc2_schunk* schunk) {
             printf("Decompression error.  Error code: %" PRId64 "\n", dsize);
             return (int) dsize;
         }
-/*
-        printf("\n dest \n");
-        for (int i = 0; i < (chunksize / cparams.typesize); i++) {
-            printf("%f, ", data_dest[i]);
-        }
-*/
         double tolerance = exp(zfp_tol);
         for (int i = 0; i < (chunksize / cparams.typesize); i++) {
             if (fabs(data_in[i] - data_dest[i]) > tolerance) {

--- a/plugins/codecs/zfp/test_zfp_acc_int.c
+++ b/plugins/codecs/zfp/test_zfp_acc_int.c
@@ -60,13 +60,6 @@ static int test_zfp(blosc2_schunk* schunk) {
             return -1;
         }
 
-        /*
-        printf("\n chunk \n");
-        for (int i = 0; i < chunksize; i++) {
-            printf("%f, ", ((float *) data_in)[i]);
-        }
-        */
-
         /* Compress with clevel=5 and shuffle active  */
         csize = blosc2_compress_ctx(cctx, data_in, chunksize, data_out, chunksize + BLOSC_MAX_OVERHEAD);
         if (csize == 0) {
@@ -77,7 +70,6 @@ static int test_zfp(blosc2_schunk* schunk) {
             return (int) csize;
         }
         csize_f += csize;
-
 
         /* Decompress  */
         dsize = blosc2_decompress_ctx(dctx, data_out, chunksize + BLOSC_MAX_OVERHEAD, data_dest, chunksize);

--- a/plugins/codecs/zfp/test_zfp_prec_float.c
+++ b/plugins/codecs/zfp/test_zfp_prec_float.c
@@ -65,12 +65,7 @@ static int test_zfp_prec_float(blosc2_schunk* schunk) {
             printf("Error decompressing chunk \n");
             return -1;
         }
-/*
-        printf("\n chunk \n");
-        for (int i = 0; i < (chunksize / cparams.typesize); i++) {
-            printf("%f, ", data_in[i]);
-        }
-*/
+
         /* Compress with clevel=5 and shuffle active  */
         csize = blosc2_compress_ctx(cctx, data_in, chunksize, data_out, chunksize + BLOSC_MAX_OVERHEAD);
         if (csize == 0) {
@@ -89,12 +84,6 @@ static int test_zfp_prec_float(blosc2_schunk* schunk) {
             printf("Decompression error.  Error code: %" PRId64 "\n", dsize);
             return (int) dsize;
         }
-/*
-        printf("\n dest \n");
-        for (int i = 0; i < (chunksize / cparams.typesize); i++) {
-            printf("%f, ", data_dest[i]);
-        }
-*/
         double tolerance = 0.01;
         for (int i = 0; i < (chunksize / cparams.typesize); i++) {
             if ((data_in[i] == 0) || (data_dest[i] == 0)) {
@@ -167,12 +156,7 @@ static int test_zfp_prec_double(blosc2_schunk* schunk) {
             printf("Error decompressing chunk \n");
             return -1;
         }
-/*
-        printf("\n chunk \n");
-        for (int i = 0; i < (chunksize / cparams.typesize); i++) {
-            printf("%f, ", data_in[i]);
-        }
-*/
+
         /* Compress with clevel=5 and shuffle active  */
         csize = blosc2_compress_ctx(cctx, data_in, chunksize, data_out, chunksize + BLOSC_MAX_OVERHEAD);
         if (csize == 0) {
@@ -191,12 +175,6 @@ static int test_zfp_prec_double(blosc2_schunk* schunk) {
             printf("Decompression error.  Error code: %" PRId64 "\n", dsize);
             return (int) dsize;
         }
-/*
-        printf("\n dest \n");
-        for (int i = 0; i < (chunksize / cparams.typesize); i++) {
-            printf("%f, ", data_dest[i]);
-        }
-*/
         double tolerance = 0.01;
         for (int i = 0; i < (chunksize / cparams.typesize); i++) {
             if ((data_in[i] == 0) || (data_dest[i] == 0)) {

--- a/plugins/codecs/zfp/test_zfp_rate_getitem.c
+++ b/plugins/codecs/zfp/test_zfp_rate_getitem.c
@@ -84,10 +84,10 @@ static int test_zfp_rate_getitem_float(blosc2_schunk* schunk) {
             index = rand() % nelems;
             // Usual getitem
             dsize_blosc = blosc2_getitem_ctx(schunk->dctx, data_out, chunk_cbytes,
-                                             index, 1, &item_zfp, sizeof(item_zfp));
+                                             index, 1, &item_blosc, sizeof(item_blosc));
             // Optimized getitem using ZFP cell machinery
             dsize_zfp = blosc2_getitem_ctx(dctx, data_out, chunk_cbytes,
-                                           index, 1, &item_blosc, sizeof(item_blosc));
+                                           index, 1, &item_zfp, sizeof(item_zfp));
            if (dsize_blosc != dsize_zfp) {
                 printf("Different amount of items gotten");
                 return -1;
@@ -172,10 +172,10 @@ static int test_zfp_rate_getitem_double(blosc2_schunk* schunk) {
             index = rand() % nelems;
             // Usual getitem
             dsize_blosc = blosc2_getitem_ctx(schunk->dctx, data_out, chunk_cbytes,
-                                             index, 1, &item_zfp, sizeof(item_zfp));
+                                             index, 1, &item_blosc, sizeof(item_blosc));
             // Optimized getitem using ZFP cell machinery
             dsize_zfp = blosc2_getitem_ctx(dctx, data_out, chunk_cbytes,
-                                           index, 1, &item_blosc, sizeof(item_blosc));
+                                           index, 1, &item_zfp, sizeof(item_zfp));
             if (dsize_blosc != dsize_zfp) {
                 printf("Different amount of items gotten");
                 return -1;

--- a/plugins/codecs/zfp/test_zfp_rate_getitem.c
+++ b/plugins/codecs/zfp/test_zfp_rate_getitem.c
@@ -84,7 +84,8 @@ static int test_zfp_rate_getitem_float(blosc2_schunk* schunk) {
         int index, dsize_zfp, dsize_blosc;
         float item_zfp, item_blosc;
         blosc_timestamp_t t0, t1;
-        double zfp_time, blosc_time;
+        double zfp_time = 0;
+        double blosc_time = 0;
         int nelems = schunk->chunksize / schunk->typesize;
         for (int i = 0; i < 100; ++i) {
             srand(i);
@@ -188,7 +189,8 @@ static int test_zfp_rate_getitem_double(blosc2_schunk* schunk) {
         int index, dsize_zfp, dsize_blosc;
         double item_zfp, item_blosc;
         blosc_timestamp_t t0, t1;
-        double zfp_time, blosc_time;
+        double zfp_time = 0;
+        double blosc_time = 0;
         int nelems = schunk->chunksize / schunk->typesize;
         for (int i = 0; i < 100; ++i) {
             srand(i);
@@ -208,7 +210,7 @@ static int test_zfp_rate_getitem_double(blosc2_schunk* schunk) {
                 return -1;
             }
             if (item_blosc != item_zfp) {
-                printf("\nIn index %d different items extracted zfp %.10f blosc %.10tykf", index, item_zfp, item_blosc);
+                printf("\nIn index %d different items extracted zfp %.10f blosc %.10f", index, item_zfp, item_blosc);
                 return -1;
             }
 

--- a/plugins/codecs/zfp/zfp-private.h
+++ b/plugins/codecs/zfp/zfp-private.h
@@ -14,6 +14,9 @@
 #define ZFP_PRIVATE_H
 #include "context.h"
 
+#define ZFP_MAX_DIM 4
+#define ZFP_CELL_SHAPE 4
+
 #if defined (__cplusplus)
 extern "C" {
 #endif
@@ -113,6 +116,26 @@ static int32_t deserialize_meta(uint8_t *smeta, uint32_t smeta_len, int8_t *ndim
     }
     uint32_t slen = (uint32_t)(pmeta - smeta);
     return 0;
+}
+
+static void index_unidim_to_multidim(int8_t ndim, int64_t *shape, int64_t i, int64_t *index) {
+    int64_t strides[ZFP_MAX_DIM];
+    strides[ndim - 1] = 1;
+    for (int j = ndim - 2; j >= 0; --j) {
+        strides[j] = shape[j + 1] * strides[j + 1];
+    }
+
+    index[0] = i / strides[0];
+    for (int j = 1; j < ndim; ++j) {
+        index[j] = (i % strides[j - 1]) / strides[j];
+    }
+}
+
+static void index_multidim_to_unidim(int64_t *index, int8_t ndim, int64_t *strides, int64_t *i) {
+    *i = 0;
+    for (int j = 0; j < ndim; ++j) {
+        *i += index[j] * strides[j];
+    }
 }
 
 #if defined (__cplusplus)

--- a/plugins/codecs/zfp/zfp-private.h
+++ b/plugins/codecs/zfp/zfp-private.h
@@ -16,8 +16,6 @@
 #define ZFP_MAX_DIM 4
 #define ZFP_CELL_SHAPE 4
 
-#define ZFP_MAX_DIM 4
-#define ZFP_CELL_SHAPE 4
 
 #if defined (__cplusplus)
 extern "C" {

--- a/plugins/codecs/zfp/zfp-private.h
+++ b/plugins/codecs/zfp/zfp-private.h
@@ -12,7 +12,6 @@
 
 #ifndef ZFP_PRIVATE_H
 #define ZFP_PRIVATE_H
-#include "context.h"
 
 #define ZFP_MAX_DIM 4
 #define ZFP_CELL_SHAPE 4

--- a/plugins/codecs/zfp/zfp-private.h
+++ b/plugins/codecs/zfp/zfp-private.h
@@ -120,7 +120,7 @@ static int32_t deserialize_meta(uint8_t *smeta, uint32_t smeta_len, int8_t *ndim
     return 0;
 }
 
-static void index_unidim_to_multidim(int8_t ndim, int64_t *shape, int64_t i, int64_t *index) {
+static void index_unidim_to_multidim(uint8_t ndim, int32_t *shape, int64_t i, int64_t *index) {
     int64_t strides[ZFP_MAX_DIM];
     strides[ndim - 1] = 1;
     for (int j = ndim - 2; j >= 0; --j) {

--- a/plugins/codecs/zfp/zfp-private.h
+++ b/plugins/codecs/zfp/zfp-private.h
@@ -16,6 +16,9 @@
 #define ZFP_MAX_DIM 4
 #define ZFP_CELL_SHAPE 4
 
+#define ZFP_MAX_DIM 4
+#define ZFP_CELL_SHAPE 4
+
 #if defined (__cplusplus)
 extern "C" {
 #endif


### PR DESCRIPTION
The objective is to coordinate ZFP cell partition machinery with blosc getitem to decompress only cells instead of whole blocks. Moreover, a getitem test must be included in zfp/ folder.