### PR TITLE
Use proper types for native zlib-ng interface

### DIFF
--- a/blosc/blosc2.c
+++ b/blosc/blosc2.c
@@ -435,15 +435,15 @@ static int lz4_wrap_decompress(const char* input, size_t compressed_length,
 static int zlib_wrap_compress(const char* input, size_t input_length,
                               char* output, size_t maxout, int clevel) {
   int status;
-  uLongf cl = (uLongf)maxout;
-#ifdef ZLIB_COMPAT
-  status = compress2(
-#elif defined(HAVE_ZLIB_NG)
+#if defined(HAVE_ZLIB_NG) && ! defined(ZLIB_COMPAT)
+  size_t cl = maxout;
   status = zng_compress2(
+      (uint8_t*)output, &cl, (uint8_t*)input, input_length, clevel);
 #else
+  uLongf cl = (uLongf)maxout;
   status = compress2(
-#endif
       (Bytef*)output, &cl, (Bytef*)input, (uLong)input_length, clevel);
+#endif
   if (status != Z_OK) {
     return 0;
   }
@@ -453,15 +453,15 @@ static int zlib_wrap_compress(const char* input, size_t input_length,
 static int zlib_wrap_decompress(const char* input, size_t compressed_length,
                                 char* output, size_t maxout) {
   int status;
-  uLongf ul = (uLongf)maxout;
-#ifdef ZLIB_COMPAT
-  status = uncompress(
-#elif defined(HAVE_ZLIB_NG)
+#if defined(HAVE_ZLIB_NG) && ! defined(ZLIB_COMPAT)
+  size_t ul = maxout;
   status = zng_uncompress(
+      (uint8_t*)output, &ul, (uint8_t*)input, compressed_length);
 #else
+  uLongf ul = (uLongf)maxout;
   status = uncompress(
-#endif
       (Bytef*)output, &ul, (Bytef*)input, (uLong)compressed_length);
+#endif
   if (status != Z_OK) {
     return 0;
   }


### PR DESCRIPTION
This changes the types for the zlib wrappers in case of the native zlib-ng to follow the upstream interface.
Not only does this save some casting, it also makes sure that the types are fitting. Without this, in some cases the incoming `size_t` may not be compatible with the `uLongf` used by the original zlib, for example when MSVC uses the LLP64 model on windows.

This surfaced in conda-forge/c-blosc2-feedstock#22