### PR TITLE
Add LGTM.com configuration file

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,0 +1,12 @@
+---
+# This file contains configuration for the LGTM.com static code analysis tool.
+# The c-blosc2 GitHub repository is continuously scanned by the LGTM.com
+# tool for security and/or code vulnerabilities. You can find the alerts here:
+# https://lgtm.com/projects/g/Blosc/c-blosc2/
+
+path_classifiers:
+  test:
+    - tests
+  generated:
+    # suppress alerts in vendored files
+    - internal-complibs


### PR DESCRIPTION
Add a configuration file for the LGTM.com static code analysis tool. It requires no CI integration, as the LGTM.com tool continuously scans the c-blosc2 GitHub repository for security and/or code vulnerabilities. You can find the alerts here:
https://lgtm.com/projects/g/Blosc/c-blosc2/

The YAML configuration file for the LGTM static analysis tool can be either `lgtm.yml` or `.lgtm.yml`:
https://lgtm.com/help/lgtm/lgtm.yml-configuration-file