### PR TITLE
Fix typo found by codespell

### DIFF
--- a/blosc/blosc2.c
+++ b/blosc/blosc2.c
@@ -1845,7 +1845,7 @@ static int serial_blosc(struct thread_context* thread_context) {
                          context->destsize, context->src, j * context->blocksize,
                          context->dest + ntbytes, tmp, tmp2);
         if (cbytes == 0) {
-          ntbytes = 0;              /* uncompressible data */
+          ntbytes = 0;              /* incompressible data */
           break;
         }
       }
@@ -3137,7 +3137,7 @@ static void t_blosc_do_job(void *ctxt)
       }
 
       if ((cbytes == 0) || (ntdest + cbytes > maxbytes)) {
-        context->thread_giveup_code = 0;  /* uncompressible buf */
+        context->thread_giveup_code = 0;  /* incompressible buf */
         pthread_mutex_unlock(&context->count_mutex);
         break;
       }

--- a/compat/filegen.c
+++ b/compat/filegen.c
@@ -67,7 +67,7 @@ int main(int argc, char *argv[]) {
     /* Compress with clevel=9 and shuffle active  */
     csize = blosc1_compress(9, 1, sizeof(int32_t), isize, data, data_out, osize);
     if (csize == 0) {
-      printf("Buffer is uncompressible.  Giving up.\n");
+      printf("Buffer is incompressible.  Giving up.\n");
       return 1;
     } else if (csize < 0) {
       printf("Compression error.  Error code: %d\n", csize);

--- a/examples/contexts.c
+++ b/examples/contexts.c
@@ -60,7 +60,7 @@ int main(void) {
   csize = blosc2_compress_ctx(cctx, data, isize, data_out, osize);
   blosc2_free_ctx(cctx);
   if (csize == 0) {
-    printf("Buffer is uncompressible.  Giving up.\n");
+    printf("Buffer is incompressible.  Giving up.\n");
     return 1;
   }
   else if (csize < 0) {

--- a/examples/instrument_codec.c
+++ b/examples/instrument_codec.c
@@ -63,7 +63,7 @@ int main(void) {
   csize = blosc2_compress_ctx(cctx, data, isize, data_out, osize);
   blosc2_free_ctx(cctx);
   if (csize == 0) {
-    printf("Buffer is uncompressible.  Giving up.\n");
+    printf("Buffer is incompressible.  Giving up.\n");
     return 1;
   }
   else if (csize < 0) {

--- a/examples/noinit.c
+++ b/examples/noinit.c
@@ -56,7 +56,7 @@ int main(void){
   /* Compress with clevel=5 and shuffle active  */
   csize = blosc1_compress(5, 1, sizeof(float), isize, data, data_out, osize);
   if (csize == 0) {
-    printf("Buffer is uncompressible.  Giving up.\n");
+    printf("Buffer is incompressible.  Giving up.\n");
     return 1;
   }
   else if (csize < 0) {

--- a/examples/simple.c
+++ b/examples/simple.c
@@ -53,7 +53,7 @@ int main(void) {
   csize = blosc1_compress(5, BLOSC_BITSHUFFLE, sizeof(float), isize, data,
                           data_out, osize);
   if (csize == 0) {
-    printf("Buffer is uncompressible.  Giving up.\n");
+    printf("Buffer is incompressible.  Giving up.\n");
     return 1;
   }
   else if (csize < 0) {

--- a/examples/win-dynamic-linking.c
+++ b/examples/win-dynamic-linking.c
@@ -93,7 +93,7 @@ int main(void) {
   /* Compress with clevel=3, shuffle active, 16-bytes data size, blosclz and 2 threads */
   csize = blosc_compress_ctx(3, 1, 16, isize, data, data_out, osize, "blosclz", 0, 2);
   if (csize == 0) {
-    printf("Buffer is uncompressible.  Giving up.\n");
+    printf("Buffer is incompressible.  Giving up.\n");
     return 1;
   }
   else if (csize < 0) {

--- a/plugins/codecs/ndlz/test_ndlz.c
+++ b/plugins/codecs/ndlz/test_ndlz.c
@@ -77,7 +77,7 @@ static int test_ndlz_4(blosc2_schunk* schunk) {
         /* Compress with clevel=5 and shuffle active  */
         csize = blosc2_compress_ctx(cctx, data_in, chunksize, data_out, chunksize + BLOSC2_MAX_OVERHEAD);
         if (csize == 0) {
-            printf("Buffer is uncompressible.  Giving up.\n");
+            printf("Buffer is incompressible.  Giving up.\n");
             return 0;
         } else if (csize < 0) {
             printf("Compression error.  Error code: %" PRId64 "\n", csize);
@@ -157,7 +157,7 @@ static int test_ndlz_8(blosc2_schunk* schunk) {
         /* Compress with clevel=5 and shuffle active  */
         csize = blosc2_compress_ctx(cctx, data_in, chunksize, data_out, chunksize + BLOSC2_MAX_OVERHEAD);
         if (csize == 0) {
-            printf("Buffer is uncompressible.  Giving up.\n");
+            printf("Buffer is incompressible.  Giving up.\n");
             return 0;
         } else if (csize < 0) {
             printf("Compression error.  Error code: %" PRId64 "\n", csize);

--- a/plugins/codecs/zfp/test_zfp_acc_float.c
+++ b/plugins/codecs/zfp/test_zfp_acc_float.c
@@ -70,7 +70,7 @@ static int test_zfp_acc_float(blosc2_schunk* schunk) {
         /* Compress with clevel=5 and shuffle active  */
         csize = blosc2_compress_ctx(cctx, data_in, chunksize, data_out, chunksize + BLOSC2_MAX_OVERHEAD);
         if (csize == 0) {
-            printf("Buffer is uncompressible.  Giving up.\n");
+            printf("Buffer is incompressible.  Giving up.\n");
             return 0;
         } else if (csize < 0) {
             printf("Compression error.  Error code: %" PRId64 "\n", csize);
@@ -155,7 +155,7 @@ static int test_zfp_acc_double(blosc2_schunk* schunk) {
         /* Compress with clevel=5 and shuffle active  */
         csize = blosc2_compress_ctx(cctx, data_in, chunksize, data_out, chunksize + BLOSC2_MAX_OVERHEAD);
         if (csize == 0) {
-            printf("Buffer is uncompressible.  Giving up.\n");
+            printf("Buffer is incompressible.  Giving up.\n");
             return 0;
         } else if (csize < 0) {
             printf("Compression error.  Error code: %" PRId64 "\n", csize);

--- a/plugins/codecs/zfp/test_zfp_acc_int.c
+++ b/plugins/codecs/zfp/test_zfp_acc_int.c
@@ -64,7 +64,7 @@ static int test_zfp(blosc2_schunk* schunk) {
         /* Compress with clevel=5 and shuffle active  */
         csize = blosc2_compress_ctx(cctx, data_in, chunksize, data_out, chunksize + BLOSC2_MAX_OVERHEAD);
         if (csize == 0) {
-            printf("Buffer is uncompressible.  Giving up.\n");
+            printf("Buffer is incompressible.  Giving up.\n");
             return 0;
         } else if (csize < 0) {
             printf("Compression error.  Error code: %" PRId64 "\n", csize);

--- a/plugins/codecs/zfp/test_zfp_prec_float.c
+++ b/plugins/codecs/zfp/test_zfp_prec_float.c
@@ -70,7 +70,7 @@ static int test_zfp_prec_float(blosc2_schunk* schunk) {
         /* Compress with clevel=5 and shuffle active  */
         csize = blosc2_compress_ctx(cctx, data_in, chunksize, data_out, chunksize + BLOSC2_MAX_OVERHEAD);
         if (csize == 0) {
-            printf("Buffer is uncompressible.  Giving up.\n");
+            printf("Buffer is incompressible.  Giving up.\n");
             return 0;
         } else if (csize < 0) {
             printf("Compression error.  Error code: %" PRId64 "\n", csize);
@@ -161,7 +161,7 @@ static int test_zfp_prec_double(blosc2_schunk* schunk) {
         /* Compress with clevel=5 and shuffle active  */
         csize = blosc2_compress_ctx(cctx, data_in, chunksize, data_out, chunksize + BLOSC2_MAX_OVERHEAD);
         if (csize == 0) {
-            printf("Buffer is uncompressible.  Giving up.\n");
+            printf("Buffer is incompressible.  Giving up.\n");
             return 0;
         } else if (csize < 0) {
             printf("Compression error.  Error code: %" PRId64 "\n", csize);

--- a/plugins/codecs/zfp/test_zfp_rate_float.c
+++ b/plugins/codecs/zfp/test_zfp_rate_float.c
@@ -69,7 +69,7 @@ static int test_zfp_rate_float(blosc2_schunk* schunk) {
         /* Compress with clevel=5 and shuffle active  */
         csize = blosc2_compress_ctx(cctx, data_in, chunksize, data_out, chunksize + BLOSC2_MAX_OVERHEAD);
         if (csize == 0) {
-            printf("Buffer is uncompressible.  Giving up.\n");
+            printf("Buffer is incompressible.  Giving up.\n");
             return 0;
         } else if (csize < 0) {
             printf("Compression error.  Error code: %" PRId64 "\n", csize);
@@ -145,7 +145,7 @@ static int test_zfp_rate_double(blosc2_schunk* schunk) {
         /* Compress with clevel=5 and shuffle active  */
         csize = blosc2_compress_ctx(cctx, data_in, chunksize, data_out, chunksize + BLOSC2_MAX_OVERHEAD);
         if (csize == 0) {
-            printf("Buffer is uncompressible.  Giving up.\n");
+            printf("Buffer is incompressible.  Giving up.\n");
             return 0;
         } else if (csize < 0) {
             printf("Compression error.  Error code: %" PRId64 "\n", csize);

--- a/plugins/codecs/zfp/test_zfp_rate_getitem.c
+++ b/plugins/codecs/zfp/test_zfp_rate_getitem.c
@@ -70,7 +70,7 @@ static int test_zfp_rate_getitem_float(blosc2_schunk* schunk) {
         /* Compress using ZFP fixed-rate  */
         csize = blosc2_compress_ctx(cctx, data_in, chunksize, chunk_zfp, chunksize + BLOSC2_MAX_OVERHEAD);
         if (csize == 0) {
-            printf("Buffer is uncompressible.  Giving up.\n");
+            printf("Buffer is incompressible.  Giving up.\n");
             return 0;
         } else if (csize < 0) {
             printf("Compression error.  Error code: %" PRId64 "\n", csize);
@@ -87,7 +87,7 @@ static int test_zfp_rate_getitem_float(blosc2_schunk* schunk) {
         /* Compress not using ZFP fixed-rate  */
         csize = blosc2_compress_ctx(schunk->cctx, lossy_chunk, chunksize, chunk_blosc, chunksize + BLOSC2_MAX_OVERHEAD);
         if (csize == 0) {
-            printf("Buffer is uncompressible.  Giving up.\n");
+            printf("Buffer is incompressible.  Giving up.\n");
             return 0;
         } else if (csize < 0) {
             printf("Compression error.  Error code: %" PRId64 "\n", csize);
@@ -179,7 +179,7 @@ static int test_zfp_rate_getitem_double(blosc2_schunk* schunk) {
         /* Compress using ZFP fixed-rate  */
         csize = blosc2_compress_ctx(cctx, data_in, chunksize, chunk_zfp, chunksize + BLOSC2_MAX_OVERHEAD);
         if (csize == 0) {
-            printf("Buffer is uncompressible.  Giving up.\n");
+            printf("Buffer is incompressible.  Giving up.\n");
             return 0;
         } else if (csize < 0) {
             printf("Compression error.  Error code: %" PRId64 "\n", csize);
@@ -196,7 +196,7 @@ static int test_zfp_rate_getitem_double(blosc2_schunk* schunk) {
         /* Compress not using ZFP fixed-rate  */
         csize = blosc2_compress_ctx(schunk->cctx, lossy_chunk, chunksize, chunk_blosc, chunksize + BLOSC2_MAX_OVERHEAD);
         if (csize == 0) {
-            printf("Buffer is uncompressible.  Giving up.\n");
+            printf("Buffer is incompressible.  Giving up.\n");
             return 0;
         } else if (csize < 0) {
             printf("Compression error.  Error code: %" PRId64 "\n", csize);

--- a/plugins/filters/ndcell/test_ndcell.c
+++ b/plugins/filters/ndcell/test_ndcell.c
@@ -82,7 +82,7 @@ static int test_ndcell(blosc2_schunk* schunk) {
         /* Compress with clevel=5 and shuffle active  */
         csize = blosc2_compress_ctx(cctx, data_in, chunksize, data_out, chunksize + BLOSC2_MAX_OVERHEAD);
         if (csize == 0) {
-            printf("Buffer is uncompressible.  Giving up.\n");
+            printf("Buffer is incompressible.  Giving up.\n");
             return 0;
         } else if (csize < 0) {
             printf("Compression error.  Error code: %" PRId64 "\n", csize);

--- a/plugins/filters/ndmean/test_ndmean_mean.c
+++ b/plugins/filters/ndmean/test_ndmean_mean.c
@@ -132,7 +132,7 @@ static int test_ndmean(blosc2_schunk* schunk) {
         /* Compress with clevel=5 and shuffle active  */
         csize = blosc2_compress_ctx(cctx, data_in, chunksize, data_out, chunksize + BLOSC2_MAX_OVERHEAD);
         if (csize == 0) {
-            printf("Buffer is uncompressible.  Giving up.\n");
+            printf("Buffer is incompressible.  Giving up.\n");
             return 0;
         } else if (csize < 0) {
             printf("Compression error.  Error code: %" PRId64 "\n", csize);

--- a/plugins/filters/ndmean/test_ndmean_repart.c
+++ b/plugins/filters/ndmean/test_ndmean_repart.c
@@ -109,7 +109,7 @@ static int test_ndmean(blosc2_schunk* schunk) {
         /* Compress with clevel=5 and shuffle active  */
         csize = blosc2_compress_ctx(cctx, data_in, chunksize, data_out, chunksize + BLOSC2_MAX_OVERHEAD);
         if (csize == 0) {
-            printf("Buffer is uncompressible.  Giving up.\n");
+            printf("Buffer is incompressible.  Giving up.\n");
             return 0;
         } else if (csize < 0) {
             printf("Compression error.  Error code: %" PRId64 "\n", csize);

--- a/tests/gcc-segfault-issue.c
+++ b/tests/gcc-segfault-issue.c
@@ -63,7 +63,7 @@ int main(){
   /* Compress with clevel=9 and shuffle active */
   csize = blosc_compress(9, 1, sizeof(double), isize, data, data_out, osize);
   if (csize == 0) {
-    printf("Buffer is uncompressible.  Giving up.\n");
+    printf("Buffer is incompressible.  Giving up.\n");
     return 1;
   }
   else if (csize < 0) {

--- a/tests/test_bitshuffle_leftovers.c
+++ b/tests/test_bitshuffle_leftovers.c
@@ -52,7 +52,7 @@ static char* test_roundtrip_bitshuffle4(void) {
   int isize = size;
   int osize = size + BLOSC_MIN_HEADER_LENGTH;
   int csize = blosc1_compress(9, BLOSC_BITSHUFFLE, 4, isize, data, data_out, osize);
-  mu_assert("ERROR: Buffer is uncompressible.  Giving up.", csize != 0);
+  mu_assert("ERROR: Buffer is incompressible.  Giving up.", csize != 0);
   mu_assert("ERROR: Compression error.", csize > 0);
   printf("Compression: %d -> %d (%.1fx)\n", isize, csize, (1.*isize) / csize);
 

--- a/tests/test_contexts.c
+++ b/tests/test_contexts.c
@@ -58,7 +58,7 @@ int main(void) {
   csize = blosc2_compress_ctx(cctx, data, isize, data_out, osize);
   blosc2_free_ctx(cctx);
   if (csize == 0) {
-    printf("Buffer is uncompressible.  Giving up.\n");
+    printf("Buffer is incompressible.  Giving up.\n");
     free(data);
     free(data_out);
     free(data_dest);

--- a/tests/test_postfilter.c
+++ b/tests/test_postfilter.c
@@ -182,7 +182,7 @@ static char *test_postfilter2(void) {
   init_data();
 
   csize = blosc2_compress_ctx(cctx, data, isize, data_out, osize);
-  mu_assert("Buffer is uncompressible", csize != 0);
+  mu_assert("Buffer is incompressible", csize != 0);
   mu_assert("Compression error", csize > 0);
 
   // Set some postfilter parameters and function

--- a/tests/test_prefilter.c
+++ b/tests/test_prefilter.c
@@ -143,7 +143,7 @@ static char *test_prefilter2(void) {
   cctx = blosc2_create_cctx(cparams);
 
   csize = blosc2_compress_ctx(cctx, data, isize, data_out, osize);
-  mu_assert("Buffer is uncompressible", csize != 0);
+  mu_assert("Buffer is incompressible", csize != 0);
   mu_assert("Compression error", csize > 0);
 
   /* Create a context for decompression */


### PR DESCRIPTION
Although `uncompressible` is not uncommon, most dictionaries do not show it as valid:
* [Cambridge Dictionary](https://dictionary.cambridge.org/dictionary/english/incompressible)
* [Oxford Learner's Dictionaries](https://www.oxfordlearnersdictionaries.com/definition/english/incomprehensible)
* [Merriam-Webster](https://www.merriam-webster.com/dictionary/incompressible)
* [Collins](https://www.collinsdictionary.com/dictionary/english/incompressible)
* [Dictionary.com](https://www.dictionary.com/browse/incompressible)
* [TheFreeDictionary.com](https://www.thefreedictionary.com/incompressible)