### PR TITLE
Fix broken links

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,7 @@ A fast, compressed and persistent data store library for C
         :target: https://numfocus.org
 
 .. |Contributor Covenant| image:: https://img.shields.io/badge/Contributor%20Covenant-v2.0%20adopted-ff69b4.svg
-        :target: code_of_conduct.md
+        :target: https://github.com/Blosc/community/blob/master/code_of_conduct.md
 
 
 What is it?

--- a/RELEASING.rst
+++ b/RELEASING.rst
@@ -70,7 +70,7 @@ Tagging
 Check documentation
 -------------------
 
-Go the the `blosc2 rtfd <https://www.blosc.org/c-blosc2/c-blosc2.html/>`_ site and check that
+Go the the `blosc2 rtfd <https://www.blosc.org/c-blosc2/c-blosc2.html>`_ site and check that
 it contains the updated docs.
 
 


### PR DESCRIPTION
Found using `linkchecker https://www.blosc.org/c-blosc2/c-blosc2.html`

Should we link to https://github.com/Blosc/community/blob/master/code_of_conduct.md or https://github.com/Blosc/c-blosc2/blob/main/code_of_conduct.md?