### PR TITLE
blosc/blosc2.c: optimize the mutex lock with spin lock

### DIFF
--- a/blosc/context.h
+++ b/blosc/context.h
@@ -121,7 +121,7 @@ struct blosc2_context_s {
   int16_t end_threads;
   pthread_t *threads;
   struct thread_context *thread_contexts; /* only for user-managed threads */
-  pthread_mutex_t count_mutex;
+  pthread_spinlock_t count_spin;
   pthread_mutex_t nchunk_mutex;
 #ifdef BLOSC_POSIX_BARRIERS
   pthread_barrier_t barr_init;

--- a/blosc/win32/pthread.h
+++ b/blosc/win32/pthread.h
@@ -47,6 +47,11 @@
 #define pthread_mutex_lock EnterCriticalSection
 #define pthread_mutex_unlock LeaveCriticalSection
 
+#define pthread_spin_init(a,b) InitializeCriticalSection((a))
+#define pthread_spin_destroy(a) DeleteCriticalSection((a))
+#define pthread_spin_lock EnterCriticalSection
+#define pthread_spin_unlock LeaveCriticalSection
+
 /*
  * Implement simple condition variable for Windows threads, based on ACE
  * implementation.


### PR DESCRIPTION
The mutex lock cost lots of cycles in t_blosc_do_job when the thread number is large. The updating to global values of protected part is not that heavy. It will save lots of cycles if we replace the mutex lock with spin lock.

Apply the patch and test the c-blosc2/bench.
$ ./bench/b2bench blosclz noshuffle single 160 83886080 4

Score gain: 7.4%
CPU: ICX 8380 x 2 sockets
Core number: 160 threads