### PR TITLE
Serialize splitmode and rename some fields from preparers and postfilters

### DIFF
--- a/README_CFRAME_FORMAT.rst
+++ b/README_CFRAME_FORMAT.rst
@@ -40,7 +40,7 @@ The header contains information needed to decompress the Blosc chunks contained 
       ^   ^   ^   ^   ^   ^                                   ^
       |   |   |   |   |   |                                   +--[msgpack] int64
       |   |   |   |   |   +--[msgpack] int64
-      |   |   |   |   +-- reserved flags
+      |   |   |   |   +-- other flags
       |   |   |   +--codec_flags (see below)
       |   |   +---frame_type (see below)
       |   +------general_flags (see below)
@@ -155,12 +155,25 @@ using the msgpack format. Here it is the format for the *metalayers*::
             reserved
         :``6``:
             The compressor is defined in the user-defined codec slot (see below).
-        :``5 to 15``:
+        :``7 to 15``:
             Reserved
     :``4`` to ``7``: Compression level (up to 16)
 
-:reserved_flags:
-    (``uint8``) Space reserved.
+:other_flags:
+    (``uint8``) Split mode and others.
+
+    :``0`` to ``1``:
+            Enumerated for splitmodes (up to 4).
+
+            :``0``:
+                ``BLOSC_ALWAYS_SPLIT``
+            :``1``:
+                ``BLOSC_NEVER_SPLIT``
+            :``2``:
+                ``BLOSC_AUTO_SPLIT``
+            :``3``:
+                ``BLOSC_FORWARD_COMPAT_SPLIT``
+    :``2`` to ``7``: Reserved.
 
 :uncompressed_size:
     (``int64``) Size of uncompressed data in frame (excluding metadata).

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,12 @@ Changes from 2.4.3 to 2.5.0
 ===========================
 
 * A new `splitmode` field has been added to the `blosc2_schunk` structure.
+* Changed some fields in `blosc2_preparams` and `blosc2_postparams` structs:
+  * `in` -> `input`
+  * `out` -> `output`
+  * `out_size` -> `output_size`
+  * `out_typesize` -> `output_typesize`
+  * `out_offset` -> `output_offset`
 
 
 Changes from 2.4.2 to 2.4.3

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,11 +1,11 @@
-Release notes for C-Blosc2 2.4.4
+Release notes for C-Blosc2 2.5.0
 ================================
 
 
-Changes from 2.4.3 to 2.4.4
+Changes from 2.4.3 to 2.5.0
 ===========================
 
-#XXX version-specific blurb XXX#
+* A new `splitmode` field has been added to the `blosc2_schunk` structure.
 
 
 Changes from 2.4.2 to 2.4.3

--- a/blosc/blosc2.c
+++ b/blosc/blosc2.c
@@ -841,11 +841,11 @@ uint8_t* pipeline_forward(struct thread_context* thread_context, const int32_t b
     // Create new prefilter parameters for this block (must be private for each thread)
     blosc2_prefilter_params preparams;
     memcpy(&preparams, context->preparams, sizeof(preparams));
-    preparams.in = _src;
-    preparams.out = _dest;
-    preparams.out_size = bsize;
-    preparams.out_typesize = typesize;
-    preparams.out_offset = offset;
+    preparams.input = _src;
+    preparams.output = _dest;
+    preparams.output_size = bsize;
+    preparams.output_typesize = typesize;
+    preparams.output_offset = offset;
     preparams.nblock = offset / context->blocksize;
     preparams.nchunk = context->schunk != NULL ? context->schunk->current_nchunk : -1;
     preparams.tid = thread_context->tid;
@@ -1332,8 +1332,8 @@ int pipeline_backward(struct thread_context* thread_context, const int32_t bsize
     // Create new postfilter parameters for this block (must be private for each thread)
     blosc2_postfilter_params postparams;
     memcpy(&postparams, context->postparams, sizeof(postparams));
-    postparams.in = _src;
-    postparams.out = dest + offset;
+    postparams.input = _src;
+    postparams.output = dest + offset;
     postparams.size = bsize;
     postparams.typesize = typesize;
     postparams.offset = nblock * context->blocksize;
@@ -1595,8 +1595,8 @@ static int blosc_d(
       // Create new postfilter parameters for this block (must be private for each thread)
       blosc2_postfilter_params postparams;
       memcpy(&postparams, context->postparams, sizeof(postparams));
-      postparams.in = tmp;
-      postparams.out = dest + dest_offset;
+      postparams.input = tmp;
+      postparams.output = dest + dest_offset;
       postparams.size = bsize;
       postparams.typesize = typesize;
       postparams.offset = nblock * context->blocksize;

--- a/blosc/frame.h
+++ b/blosc/frame.h
@@ -26,6 +26,7 @@
 #define FRAME_FLAGS (FRAME_LEN + 8 + 1)  // 25
 #define FRAME_TYPE (FRAME_FLAGS + 1)  // 26
 #define FRAME_CODECS (FRAME_FLAGS + 2)  // 27
+#define FRAME_OTHER_FLAGS (FRAME_FLAGS + 3)  // 28
 #define FRAME_NBYTES (FRAME_FLAGS + 4 + 1)  // 30
 #define FRAME_CBYTES (FRAME_NBYTES + 8 + 1)  // 39
 #define FRAME_TYPESIZE (FRAME_CBYTES + 8 + 1) // 48

--- a/blosc/schunk.c
+++ b/blosc/schunk.c
@@ -55,6 +55,7 @@ int blosc2_schunk_get_cparams(blosc2_schunk *schunk, blosc2_cparams **cparams) {
   (*cparams)->clevel = schunk->clevel;
   (*cparams)->typesize = schunk->typesize;
   (*cparams)->blocksize = schunk->blocksize;
+  (*cparams)->splitmode = schunk->splitmode;
   if (schunk->cctx == NULL) {
     (*cparams)->nthreads = blosc2_get_nthreads();
   }
@@ -90,6 +91,7 @@ void update_schunk_properties(struct blosc2_schunk* schunk) {
   schunk->compcode = cparams->compcode;
   schunk->compcode_meta = cparams->compcode_meta;
   schunk->clevel = cparams->clevel;
+  schunk->splitmode = cparams->splitmode;
   schunk->typesize = cparams->typesize;
   schunk->blocksize = cparams->blocksize;
   schunk->chunksize = -1;
@@ -205,6 +207,7 @@ blosc2_schunk* blosc2_schunk_copy(blosc2_schunk *schunk, blosc2_storage *storage
     cparams.clevel = schunk->cctx->clevel;
     cparams.compcode = schunk->cctx->compcode;
     cparams.compcode_meta = schunk->cctx->compcode_meta;
+    cparams.splitmode = schunk->cctx->splitmode;
     cparams.use_dict = schunk->cctx->use_dict;
     cparams.blocksize = schunk->cctx->blocksize;
     memcpy(cparams.filters, schunk->cctx->filters, BLOSC2_MAX_FILTERS);

--- a/examples/schunk_postfilter.c
+++ b/examples/schunk_postfilter.c
@@ -28,8 +28,8 @@ typedef struct {
 
 int postfilter_func(blosc2_postfilter_params *postparams) {
   int nelems = postparams->size / postparams->typesize;
-  int32_t *in = ((int32_t *)(postparams->in));
-  int32_t *out = ((int32_t *)(postparams->out));
+  int32_t *in = ((int32_t *)(postparams->input));
+  int32_t *out = ((int32_t *)(postparams->output));
   my_postparams *user_data = postparams->user_data;
   for (int i = 0; i < nelems; i++) {
     out[i] = in[i] * user_data->mult + user_data->add ;

--- a/include/blosc2.h
+++ b/include/blosc2.h
@@ -977,11 +977,11 @@ typedef struct {
  */
 typedef struct {
   void *user_data;  // user-provided info (optional)
-  const uint8_t *in;  // the input buffer
-  uint8_t *out;  // the output buffer
-  int32_t out_size;  // the output size (in bytes)
-  int32_t out_typesize;  // the output typesize
-  int32_t out_offset; // offset to reach the start of the output buffer
+  const uint8_t *input;  // the input buffer
+  uint8_t *output;  // the output buffer
+  int32_t output_size;  // the output size (in bytes)
+  int32_t output_typesize;  // the output typesize
+  int32_t output_offset; // offset to reach the start of the output buffer
   int64_t nchunk;  // the current nchunk in associated schunk (if exists; if not -1)
   int32_t nblock;  // the current nblock in associated chunk
   int32_t tid;  // thread id
@@ -996,8 +996,8 @@ typedef struct {
  */
 typedef struct {
   void *user_data;  // user-provided info (optional)
-  const uint8_t *in;  // the input buffer
-  uint8_t *out;  // the output buffer
+  const uint8_t *input;  // the input buffer
+  uint8_t *output;  // the output buffer
   int32_t size;  // the input size (in bytes)
   int32_t typesize;  // the input typesize
   int32_t offset;  // offset to reach the start of the input buffer

--- a/include/blosc2.h
+++ b/include/blosc2.h
@@ -350,10 +350,10 @@ enum {
  */
 #ifndef BLOSC_H
 enum {
-  BLOSC_ALWAYS_SPLIT = 1,
-  BLOSC_NEVER_SPLIT = 2,
-  BLOSC_AUTO_SPLIT = 3,
-  BLOSC_FORWARD_COMPAT_SPLIT = 4,
+  BLOSC_ALWAYS_SPLIT = 0,
+  BLOSC_NEVER_SPLIT = 1,
+  BLOSC_AUTO_SPLIT = 2,
+  BLOSC_FORWARD_COMPAT_SPLIT = 3,
 };
 #endif // BLOSC_H
 
@@ -1504,6 +1504,8 @@ typedef struct blosc2_schunk {
   //!< The default compressor metadata. Each chunk can override this.
   uint8_t clevel;
   //!< The compression level and other compress params.
+  uint8_t splitmode;
+  //!< The split mode.
   int32_t typesize;
   //!< The type size.
   int32_t blocksize;
@@ -2208,7 +2210,6 @@ typedef struct {
  * @return 0 if succeeds. Else a negative code is returned.
  */
 BLOSC_EXPORT int blosc2_register_filter(blosc2_filter *filter);
-
 
 /*********************************************************************
   Directory utilities.

--- a/tests/test_postfilter.c
+++ b/tests/test_postfilter.c
@@ -59,22 +59,22 @@ int postfilter_func(blosc2_postfilter_params *postparams) {
   test_postparams *tpostparams = postparams->user_data;
   int nelems = postparams->size / postparams->typesize;
   if (tpostparams->ninputs == 0) {
-    int32_t *input0 = (int32_t *)postparams->in;
+    int32_t *input0 = (int32_t *)postparams->input;
     for (int i = 0; i < nelems; i++) {
-      ((int32_t*)(postparams->out))[i] = input0[i] * 2;
+      ((int32_t*)(postparams->output))[i] = input0[i] * 2;
     }
   }
   else if (tpostparams->ninputs == 1) {
     int32_t *input0 = ((int32_t *)(tpostparams->inputs[0] + postparams->offset));
     for (int i = 0; i < nelems; i++) {
-      ((int32_t*)(postparams->out))[i] = input0[i] * 3;
+      ((int32_t*)(postparams->output))[i] = input0[i] * 3;
     }
   }
   else if (tpostparams->ninputs == 2) {
     int32_t *input0 = ((int32_t *)(tpostparams->inputs[0] + postparams->offset));
     int32_t *input1 = ((int32_t *)(tpostparams->inputs[1] + postparams->offset));
     for (int i = 0; i < nelems; i++) {
-      ((int32_t *) (postparams->out))[i] = input0[i] + input1[i];
+      ((int32_t *) (postparams->output))[i] = input0[i] + input1[i];
     }
   }
   else {

--- a/tests/test_prefilter.c
+++ b/tests/test_prefilter.c
@@ -33,24 +33,24 @@ int csize;
 
 int prefilter_func(blosc2_prefilter_params *preparams) {
   test_preparams *tpreparams = preparams->user_data;
-  int nelems = preparams->out_size / preparams->out_typesize;
+  int nelems = preparams->output_size / preparams->output_typesize;
   if (tpreparams->ninputs == 0) {
-    int32_t *input0 = (int32_t *)preparams->in;
+    int32_t *input0 = (int32_t *)preparams->input;
     for (int i = 0; i < nelems; i++) {
-      ((int32_t*)(preparams->out))[i] = input0[i] * 2;
+      ((int32_t*)(preparams->output))[i] = input0[i] * 2;
     }
   }
   else if (tpreparams->ninputs == 1) {
-    int32_t *input0 = ((int32_t *)(tpreparams->inputs[0] + preparams->out_offset));
+    int32_t *input0 = ((int32_t *)(tpreparams->inputs[0] + preparams->output_offset));
     for (int i = 0; i < nelems; i++) {
-      ((int32_t*)(preparams->out))[i] = input0[i] * 3;
+      ((int32_t*)(preparams->output))[i] = input0[i] * 3;
     }
   }
   else if (tpreparams->ninputs == 2) {
-    int32_t *input0 = ((int32_t *)(tpreparams->inputs[0] + preparams->out_offset));
-    int32_t *input1 = ((int32_t *)(tpreparams->inputs[1] + preparams->out_offset));
+    int32_t *input0 = ((int32_t *)(tpreparams->inputs[0] + preparams->output_offset));
+    int32_t *input1 = ((int32_t *)(tpreparams->inputs[1] + preparams->output_offset));
     for (int i = 0; i < nelems; i++) {
-      ((int32_t *) (preparams->out))[i] = input0[i] + input1[i];
+      ((int32_t *) (preparams->output))[i] = input0[i] + input1[i];
     }
   }
   else {


### PR DESCRIPTION
* Serialize `splitmode`
* Rename some fields of the `blosc2_preparams` and `blosc2_postparams` structs to support pre filters and post filters in python-blosc2.