### PR TITLE
Add support for macos `universal2` (`arm64`+`x86_64` build)

### DIFF
--- a/blosc/bitshuffle-altivec.c
+++ b/blosc/bitshuffle-altivec.c
@@ -26,9 +26,8 @@
 #include "bitshuffle-altivec.h"
 
 /* Make sure ALTIVEC is available for the compilation target and compiler. */
-#if !defined(__ALTIVEC__)
-  #error ALTIVEC is not supported by the target architecture/platform and/or this compiler.
-#endif
+#if defined(__ALTIVEC__)
+
 #include <altivec.h>
 #include "transpose-altivec.h"
 
@@ -590,3 +589,5 @@ int64_t bshuf_untrans_bit_elem_altivec(void* in, void* out, const size_t size,
 
   return count;
 }
+
+#endif /* defined(__ALTIVEC__) */

--- a/blosc/bitshuffle-avx2.c
+++ b/blosc/bitshuffle-avx2.c
@@ -27,9 +27,7 @@
 
 
 /* Make sure AVX2 is available for the compilation target and compiler. */
-#if !defined(__AVX2__)
-  #error AVX2 is not supported by the target architecture/platform and/or this compiler.
-#endif
+#if defined(__AVX2__)
 
 #include <immintrin.h>
 
@@ -255,3 +253,5 @@ int64_t bshuf_untrans_bit_elem_avx2(void* in, void* out, const size_t size,
 
   return count;
 }
+
+#endif /* defined(__AVX2__) */

--- a/blosc/bitshuffle-neon.c
+++ b/blosc/bitshuffle-neon.c
@@ -12,9 +12,7 @@
 #include "bitshuffle-neon.h"
 
 /* Make sure NEON is available for the compilation target and compiler. */
-#if !defined(__ARM_NEON)
-  #error NEON is not supported by the target architecture/platform and/or this compiler.
-#endif
+#if defined(__ARM_NEON)
 
 #include <arm_neon.h>
 
@@ -1000,6 +998,8 @@ bitunshuffle_neon(void* _src, void* _dest, const size_t size,
          so we're done processing here. */
       return count;
   }
-  
+
   return (int64_t)size * (int64_t)elem_size;
 }
+
+#endif /* defined(__ARM_NEON) */

--- a/blosc/bitshuffle-sse2.c
+++ b/blosc/bitshuffle-sse2.c
@@ -25,9 +25,7 @@
 #include "bitshuffle-sse2.h"
 
 /* Make sure SSE2 is available for the compilation target and compiler. */
-#if !defined(__SSE2__)
-  #error SSE2 is not supported by the target architecture/platform and/or this compiler.
-#endif
+#if defined(__SSE2__)
 
 #include <emmintrin.h>
 
@@ -474,3 +472,5 @@ int64_t bshuf_untrans_bit_elem_sse2(void* in, void* out, const size_t size,
 
   return count;
 }
+
+#endif /* defined(__SSE2__) */

--- a/blosc/shuffle-altivec.c
+++ b/blosc/shuffle-altivec.c
@@ -12,9 +12,7 @@
 #include "shuffle-altivec.h"
 
 /* Make sure ALTIVEC is available for the compilation target and compiler. */
-#if !defined(__ALTIVEC__)
-  #error ALTIVEC is not supported by the target architecture/platform and/or this compiler.
-#endif
+#if defined(__ALTIVEC__)
 
 #include <altivec.h>
 #include "transpose-altivec.h"
@@ -421,3 +419,5 @@ unshuffle_altivec(const int32_t bytesoftype, const int32_t blocksize,
     unshuffle_generic_inline(bytesoftype, vectorizable_bytes, blocksize, _src, _dest);
   }
 }
+
+#endif /* defined(__ALTIVEC__) */

--- a/blosc/shuffle-avx2.c
+++ b/blosc/shuffle-avx2.c
@@ -12,9 +12,7 @@
 #include "shuffle-avx2.h"
 
 /* Make sure AVX2 is available for the compilation target and compiler. */
-#if !defined(__AVX2__)
-  #error AVX2 is not supported by the target architecture/platform and/or this compiler.
-#endif
+#if defined(__AVX2__)
 
 #include <immintrin.h>
 
@@ -745,3 +743,5 @@ unshuffle_avx2(const int32_t bytesoftype, const int32_t blocksize,
     unshuffle_generic_inline(bytesoftype, vectorizable_bytes, blocksize, _src, _dest);
   }
 }
+
+#endif /* defined(__AVX2__) */

--- a/blosc/shuffle-neon.c
+++ b/blosc/shuffle-neon.c
@@ -13,9 +13,7 @@
 #include "shuffle-neon.h"
 
 /* Make sure NEON is available for the compilation target and compiler. */
-#if !defined(__ARM_NEON)
-#error NEON is not supported by the target architecture/platform and/or this compiler.
-#endif
+#if defined(__ARM_NEON)
 
 #include <arm_neon.h>
 
@@ -414,3 +412,5 @@ unshuffle_neon(const int32_t bytesoftype, const int32_t blocksize,
         unshuffle_generic_inline(bytesoftype, vectorizable_bytes, blocksize, _src, _dest);
     }
 }
+
+#endif /* defined(__ARM_NEON) */

--- a/blosc/shuffle-sse2.c
+++ b/blosc/shuffle-sse2.c
@@ -12,9 +12,7 @@
 #include "shuffle-sse2.h"
 
 /* Make sure SSE2 is available for the compilation target and compiler. */
-#if !defined(__SSE2__)
-  #error SSE2 is not supported by the target architecture/platform and/or this compiler.
-#endif
+#if defined(__SSE2__)
 
 #include <emmintrin.h>
 
@@ -615,3 +613,5 @@ unshuffle_sse2(const int32_t bytesoftype, const int32_t blocksize,
     unshuffle_generic_inline(bytesoftype, vectorizable_bytes, blocksize, _src, _dest);
   }
 }
+
+#endif /* defined(__SSE2__) */

--- a/blosc/shuffle.c
+++ b/blosc/shuffle.c
@@ -141,7 +141,7 @@ __cpuidex(int32_t cpuInfo[4], int32_t function_id, int32_t subfunction_id) {
 
 // GCC folks added _xgetbv in immintrin.h starting in GCC 9
 // See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=71659
-#if !(defined(_IMMINTRIN_H_INCLUDED) && (BLOSC_GCC_VERSION >= 900))
+#if defined(__i386__) && !(defined(_IMMINTRIN_H_INCLUDED) && (BLOSC_GCC_VERSION >= 900))
 /* Reads the content of an extended control register.
    https://software.intel.com/en-us/articles/how-to-detect-new-instruction-support-in-the-4th-generation-intel-core-processor-family
 */
@@ -160,7 +160,7 @@ _xgetbv(uint32_t xcr) {
     );
   return ((uint64_t)edx << 32) | eax;
 }
-#endif  // !(defined(_IMMINTRIN_H_INCLUDED) && (BLOSC_GCC_VERSION >= 900))
+#endif  // defined(__i386__) && !(defined(_IMMINTRIN_H_INCLUDED) && (BLOSC_GCC_VERSION >= 900))
 #endif /* defined(_MSC_VER) */
 
 #ifndef _XCR_XFEATURE_ENABLED_MASK
@@ -204,7 +204,7 @@ static blosc_cpu_features blosc_get_cpu_features(void) {
   bool ymm_state_enabled = false;
   //bool zmm_state_enabled = false;  // commented this out for avoiding an 'unused variable' warning
 
-#if defined(_XCR_XFEATURE_ENABLED_MASK)
+#if defined(__i386__) && defined(_XCR_XFEATURE_ENABLED_MASK)
   if (xsave_available && xsave_enabled_by_os && (
       sse2_available || sse3_available || ssse3_available
       || sse41_available || sse42_available
@@ -219,7 +219,7 @@ static blosc_cpu_features blosc_get_cpu_features(void) {
         restored as well as all of zmm16-zmm31 and the opmask registers. */
     //zmm_state_enabled = (xcr0_contents & 0x70) == 0x70;
   }
-#endif /* defined(_XCR_XFEATURE_ENABLED_MASK) */
+#endif /* defined(__i386__) && defined(_XCR_XFEATURE_ENABLED_MASK) */
 
 #if defined(BLOSC_DUMP_CPU_INFO)
   printf("Shuffle CPU Information:\n");

--- a/blosc/shuffle.h
+++ b/blosc/shuffle.h
@@ -22,6 +22,25 @@
 
 #include "blosc2/blosc2-common.h"
 
+/* Toggle hardware-accelerated routines based on SHUFFLE_*_ENABLED macros
+   and availability on the target architecture.
+*/
+#if defined(SHUFFLE_AVX2_ENABLED) && defined(__AVX2__)
+#define SHUFFLE_USE_AVX2
+#endif
+
+#if defined(SHUFFLE_SSE2_ENABLED) && defined(__SSE2__)
+#define SHUFFLE_USE_SSE2
+#endif
+
+#if defined(SHUFFLE_ALTIVEC_ENABLED) && defined(__ALTIVEC__)
+#define SHUFFLE_USE_ALTIVEC
+#endif
+
+#if defined(SHUFFLE_NEON_ENABLED) && defined(__ARM_NEON)
+#define SHUFFLE_USE_NEON
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/tests/test_shuffle_roundtrip_altivec.c
+++ b/tests/test_shuffle_roundtrip_altivec.c
@@ -17,7 +17,7 @@
 
 /* Include ALTIVEC-accelerated shuffle implementation if supported by this compiler.
    TODO: Need to also do run-time CPU feature support here. */
-#if defined(SHUFFLE_ALTIVEC_ENABLED)
+#if defined(SHUFFLE_USE_ALTIVEC)
   #include "../blosc/shuffle-altivec.h"
 #else
   #if defined(_MSC_VER)
@@ -25,13 +25,13 @@
   #else
     #warning ALTIVEC shuffle tests not enabled.
   #endif
-#endif  /* defined(SHUFFLE_ALTIVEC_ENABLED) */
+#endif  /* defined(SHUFFLE_USE_ALTIVEC) */
 
 
 /** Roundtrip tests for the ALTIVEC-accelerated shuffle/unshuffle. */
 static int test_shuffle_roundtrip_altivec(int32_t type_size, int32_t num_elements,
                                           size_t buffer_alignment, int test_type) {
-#if defined(SHUFFLE_ALTIVEC_ENABLED)
+#if defined(SHUFFLE_USE_ALTIVEC)
   int32_t buffer_size = type_size * num_elements;
 
   /* Allocate memory for the test. */
@@ -77,7 +77,7 @@ static int test_shuffle_roundtrip_altivec(int32_t type_size, int32_t num_element
   return exit_code;
 #else
   return EXIT_SUCCESS;
-#endif /* defined(SHUFFLE_ALTIVEC_ENABLED) */
+#endif /* defined(SHUFFLE_USE_ALTIVEC) */
 }
 
 

--- a/tests/test_shuffle_roundtrip_avx2.c
+++ b/tests/test_shuffle_roundtrip_avx2.c
@@ -17,7 +17,7 @@
 /* Include accelerated shuffles if supported by this compiler.
    TODO: Need to also do run-time CPU feature support here. */
 
-#if defined(SHUFFLE_AVX2_ENABLED)
+#if defined(SHUFFLE_USE_AVX2)
   #include "../blosc/shuffle-avx2.h"
 #else
   #if defined(_MSC_VER)
@@ -25,13 +25,13 @@
   #else
     #warning AVX2 shuffle tests not enabled.
   #endif
-#endif  /* defined(SHUFFLE_AVX2_ENABLED) */
+#endif  /* defined(SHUFFLE_USE_AVX2) */
 
 
 /** Roundtrip tests for the AVX2-accelerated shuffle/unshuffle. */
 static int test_shuffle_roundtrip_avx2(int32_t type_size, int32_t num_elements,
                                        size_t buffer_alignment, int test_type) {
-#if defined(SHUFFLE_AVX2_ENABLED)
+#if defined(SHUFFLE_USE_AVX2)
   int32_t buffer_size = type_size * num_elements;
 
   /* Allocate memory for the test. */
@@ -78,7 +78,7 @@ static int test_shuffle_roundtrip_avx2(int32_t type_size, int32_t num_elements,
   return exit_code;
 #else
   return EXIT_SUCCESS;
-#endif /* defined(SHUFFLE_AVX2_ENABLED) */
+#endif /* defined(SHUFFLE_USE_AVX2) */
 }
 
 

--- a/tests/test_shuffle_roundtrip_neon.c
+++ b/tests/test_shuffle_roundtrip_neon.c
@@ -17,7 +17,7 @@
 
 /* Include NEON-accelerated shuffle implementation if supported by this compiler.
    TODO: Need to also do run-time CPU feature support here. */
-#if defined(SHUFFLE_NEON_ENABLED)
+#if defined(SHUFFLE_USE_NEON)
   #include "../blosc/shuffle-neon.h"
 #else
   #if defined(_MSC_VER)
@@ -25,13 +25,13 @@
   #else
     #warning NEON shuffle tests not enabled.
   #endif
-#endif  /* defined(SHUFFLE_NEON_ENABLED) */
+#endif  /* defined(SHUFFLE_USE_NEON) */
 
 
 /** Roundtrip tests for the NEON-accelerated shuffle/unshuffle. */
 static int test_shuffle_roundtrip_neon(size_t type_size, size_t num_elements,
                                        size_t buffer_alignment, int test_type) {
-#if defined(SHUFFLE_NEON_ENABLED)
+#if defined(SHUFFLE_USE_NEON)
   size_t buffer_size = type_size * num_elements;
 
   /* Allocate memory for the test. */
@@ -77,7 +77,7 @@ static int test_shuffle_roundtrip_neon(size_t type_size, size_t num_elements,
   return exit_code;
 #else
   return EXIT_SUCCESS;
-#endif /* defined(SHUFFLE_NEON_ENABLED) */
+#endif /* defined(SHUFFLE_USE_NEON) */
 }
 
 

--- a/tests/test_shuffle_roundtrip_sse2.c
+++ b/tests/test_shuffle_roundtrip_sse2.c
@@ -17,7 +17,7 @@
 
 /* Include SSE2-accelerated shuffle implementation if supported by this compiler.
    TODO: Need to also do run-time CPU feature support here. */
-#if defined(SHUFFLE_SSE2_ENABLED)
+#if defined(SHUFFLE_USE_SSE2)
   #include "../blosc/shuffle-sse2.h"
 #else
   #if defined(_MSC_VER)
@@ -25,13 +25,13 @@
   #else
     #warning SSE2 shuffle tests not enabled.
   #endif
-#endif  /* defined(SHUFFLE_SSE2_ENABLED) */
+#endif  /* defined(SHUFFLE_USE_SSE2) */
 
 
 /** Roundtrip tests for the SSE2-accelerated shuffle/unshuffle. */
 static int test_shuffle_roundtrip_sse2(int32_t type_size, int32_t num_elements,
                                        size_t buffer_alignment, int test_type) {
-#if defined(SHUFFLE_SSE2_ENABLED)
+#if defined(SHUFFLE_USE_SSE2)
   int32_t buffer_size = type_size * num_elements;
 
   /* Allocate memory for the test. */
@@ -77,7 +77,7 @@ static int test_shuffle_roundtrip_sse2(int32_t type_size, int32_t num_elements,
   return exit_code;
 #else
   return EXIT_SUCCESS;
-#endif /* defined(SHUFFLE_SSE2_ENABLED) */
+#endif /* defined(SHUFFLE_USE_SSE2) */
 }
 
 


### PR DESCRIPTION
This PR proposes a fix to allow building c-blosc2 as part of a Python package that is built as a universal2 binary package on macos with enabled AVX2/SSE2 optimisation for the x86_64 target only, NEON for the arm target and ALTIVEC for ppc64le.

To achieve this, c-blosc2 should support defining SHUFFLE_*_ENABLED and be able to build all files (including *-avx2.c, *-sse2.c, *-neon.c and *-altivec.c) even when the compilation target does not support the given instruction set.

This is done by toggling SIMD instructions usage with both SHUFFLE_*_ENABLED and __AVX2__, __SSE2__, __ARM_NEON and __ALTIVEC__.

closes #430

related to https://github.com/Blosc/c-blosc/pull/347
related to https://github.com/silx-kit/hdf5plugin/pull/201