### PR TITLE
b2nd: Use const where possible.

### DIFF
--- a/blosc/b2nd.c
+++ b/blosc/b2nd.c
@@ -17,8 +17,8 @@
 #include <inttypes.h>
 
 
-int b2nd_serialize_meta(int8_t ndim, int64_t *shape, int32_t *chunkshape,
-                        int32_t *blockshape, const char *dtype, const int8_t dtype_format,
+int b2nd_serialize_meta(int8_t ndim, const int64_t *shape, const int32_t *chunkshape,
+                        const int32_t *blockshape, const char *dtype, int8_t dtype_format,
                         uint8_t **smeta) {
   if (dtype == NULL) {
     dtype = B2ND_DEFAULT_DTYPE;
@@ -93,9 +93,9 @@ int b2nd_serialize_meta(int8_t ndim, int64_t *shape, int32_t *chunkshape,
 }
 
 
-int b2nd_deserialize_meta(uint8_t *smeta, int32_t smeta_len, int8_t *ndim, int64_t *shape,
+int b2nd_deserialize_meta(const uint8_t *smeta, int32_t smeta_len, int8_t *ndim, int64_t *shape,
                           int32_t *chunkshape, int32_t *blockshape, char **dtype, int8_t *dtype_format) {
-  uint8_t *pmeta = smeta;
+  const uint8_t *pmeta = smeta;
 
   // Check that we have an array with 7 entries (version, ndim, shape, chunkshape, blockshape, dtype_format, dtype)
   pmeta += 1;
@@ -384,7 +384,7 @@ int b2nd_zeros(b2nd_context_t *ctx, b2nd_array_t **array) {
 }
 
 
-int b2nd_full(b2nd_context_t *ctx, b2nd_array_t **array, void *fill_value) {
+int b2nd_full(b2nd_context_t *ctx, b2nd_array_t **array, const void *fill_value) {
   BLOSC_ERROR_NULL(ctx, BLOSC2_ERROR_NULL_POINTER);
   BLOSC_ERROR_NULL(array, BLOSC2_ERROR_NULL_POINTER);
 
@@ -463,7 +463,7 @@ int b2nd_from_schunk(blosc2_schunk *schunk, b2nd_array_t **array) {
 }
 
 
-int b2nd_to_cframe(b2nd_array_t *array, uint8_t **cframe, int64_t *cframe_len,
+int b2nd_to_cframe(const b2nd_array_t *array, uint8_t **cframe, int64_t *cframe_len,
                    bool *needs_free) {
   BLOSC_ERROR_NULL(array, BLOSC2_ERROR_NULL_POINTER);
   BLOSC_ERROR_NULL(cframe, BLOSC2_ERROR_NULL_POINTER);
@@ -535,7 +535,7 @@ int b2nd_free(b2nd_array_t *array) {
 }
 
 
-int b2nd_from_cbuffer(b2nd_context_t *ctx, b2nd_array_t **array, void *buffer, int64_t buffersize) {
+int b2nd_from_cbuffer(b2nd_context_t *ctx, b2nd_array_t **array, const void *buffer, int64_t buffersize) {
   BLOSC_ERROR_NULL(ctx, BLOSC2_ERROR_NULL_POINTER);
   BLOSC_ERROR_NULL(buffer, BLOSC2_ERROR_NULL_POINTER);
   BLOSC_ERROR_NULL(array, BLOSC2_ERROR_NULL_POINTER);
@@ -561,7 +561,7 @@ int b2nd_from_cbuffer(b2nd_context_t *ctx, b2nd_array_t **array, void *buffer, i
 }
 
 
-int b2nd_to_cbuffer(b2nd_array_t *array, void *buffer,
+int b2nd_to_cbuffer(const b2nd_array_t *array, void *buffer,
                     int64_t buffersize) {
   BLOSC_ERROR_NULL(array, BLOSC2_ERROR_NULL_POINTER);
   BLOSC_ERROR_NULL(buffer, BLOSC2_ERROR_NULL_POINTER);
@@ -575,15 +575,15 @@ int b2nd_to_cbuffer(b2nd_array_t *array, void *buffer,
   }
 
   int64_t start[B2ND_MAX_DIM] = {0};
-  int64_t *stop = array->shape;
+  const int64_t *stop = array->shape;
   BLOSC_ERROR(b2nd_get_slice_cbuffer(array, start, stop, buffer, array->shape, buffersize));
   return BLOSC2_ERROR_SUCCESS;
 }
 
 
 // Setting and getting slices
-int get_set_slice(void *buffer, int64_t buffersize, int64_t *start, int64_t *stop, int64_t *shape,
-                  b2nd_array_t *array, bool set_slice) {
+int get_set_slice(void *buffer, int64_t buffersize, const int64_t *start, const int64_t *stop,
+                  const int64_t *shape, b2nd_array_t *array, bool set_slice) {
   BLOSC_ERROR_NULL(buffer, BLOSC2_ERROR_NULL_POINTER);
   BLOSC_ERROR_NULL(start, BLOSC2_ERROR_NULL_POINTER);
   BLOSC_ERROR_NULL(stop, BLOSC2_ERROR_NULL_POINTER);
@@ -594,9 +594,9 @@ int get_set_slice(void *buffer, int64_t buffersize, int64_t *start, int64_t *sto
   }
 
   uint8_t *buffer_b = (uint8_t *) buffer;
-  int64_t *buffer_start = start;
-  int64_t *buffer_stop = stop;
-  int64_t *buffer_shape = shape;
+  const int64_t *buffer_start = start;
+  const int64_t *buffer_stop = stop;
+  const int64_t *buffer_shape = shape;
 
   int8_t ndim = array->ndim;
 
@@ -812,7 +812,7 @@ int get_set_slice(void *buffer, int64_t buffersize, int64_t *start, int64_t *sto
       }
 
       uint8_t *src = &buffer_b[0];
-      int64_t *src_pad_shape = buffer_shape;
+      const int64_t *src_pad_shape = buffer_shape;
 
       int64_t src_start[B2ND_MAX_DIM] = {0};
       int64_t src_stop[B2ND_MAX_DIM] = {0};
@@ -870,9 +870,8 @@ int get_set_slice(void *buffer, int64_t buffersize, int64_t *start, int64_t *sto
 }
 
 
-int b2nd_get_slice_cbuffer(b2nd_array_t *array,
-                           int64_t *start, int64_t *stop,
-                           void *buffer, int64_t *buffershape, int64_t buffersize) {
+int b2nd_get_slice_cbuffer(const b2nd_array_t *array, const int64_t *start, const int64_t *stop,
+                           void *buffer, const int64_t *buffershape, int64_t buffersize) {
   BLOSC_ERROR_NULL(array, BLOSC2_ERROR_NULL_POINTER);
   BLOSC_ERROR_NULL(start, BLOSC2_ERROR_NULL_POINTER);
   BLOSC_ERROR_NULL(stop, BLOSC2_ERROR_NULL_POINTER);
@@ -895,14 +894,14 @@ int b2nd_get_slice_cbuffer(b2nd_array_t *array,
   if (buffersize < size) {
     BLOSC_ERROR(BLOSC2_ERROR_INVALID_PARAM);
   }
-  BLOSC_ERROR(get_set_slice(buffer, buffersize, start, stop, buffershape, array, false));
+  BLOSC_ERROR(get_set_slice(buffer, buffersize, start, stop, buffershape, (b2nd_array_t *)array, false));
 
   return BLOSC2_ERROR_SUCCESS;
 }
 
 
-int b2nd_set_slice_cbuffer(void *buffer, int64_t *buffershape, int64_t buffersize,
-                           int64_t *start, int64_t *stop,
+int b2nd_set_slice_cbuffer(const void *buffer, const int64_t *buffershape, int64_t buffersize,
+                           const int64_t *start, const int64_t *stop,
                            b2nd_array_t *array) {
   BLOSC_ERROR_NULL(buffer, BLOSC2_ERROR_NULL_POINTER);
   BLOSC_ERROR_NULL(start, BLOSC2_ERROR_NULL_POINTER);
@@ -922,13 +921,13 @@ int b2nd_set_slice_cbuffer(void *buffer, int64_t *buffershape, int64_t buffersiz
     return BLOSC2_ERROR_SUCCESS;
   }
 
-  BLOSC_ERROR(get_set_slice(buffer, buffersize, start, stop, buffershape, array, true));
+  BLOSC_ERROR(get_set_slice((void*)buffer, buffersize, start, stop, (int64_t *)buffershape, array, true));
 
   return BLOSC2_ERROR_SUCCESS;
 }
 
 
-int b2nd_get_slice(b2nd_context_t *ctx, b2nd_array_t **array, b2nd_array_t *src, const int64_t *start,
+int b2nd_get_slice(b2nd_context_t *ctx, b2nd_array_t **array, const b2nd_array_t *src, const int64_t *start,
                    const int64_t *stop) {
   BLOSC_ERROR_NULL(src, BLOSC2_ERROR_NULL_POINTER);
   BLOSC_ERROR_NULL(start, BLOSC2_ERROR_NULL_POINTER);
@@ -1048,7 +1047,7 @@ int b2nd_squeeze_index(b2nd_array_t *array, const bool *index) {
 }
 
 
-int b2nd_copy(b2nd_context_t *ctx, b2nd_array_t *src, b2nd_array_t **array) {
+int b2nd_copy(b2nd_context_t *ctx, const b2nd_array_t *src, b2nd_array_t **array) {
   BLOSC_ERROR_NULL(src, BLOSC2_ERROR_NULL_POINTER);
   BLOSC_ERROR_NULL(array, BLOSC2_ERROR_NULL_POINTER);
 
@@ -1124,7 +1123,7 @@ int b2nd_copy(b2nd_context_t *ctx, b2nd_array_t *src, b2nd_array_t **array) {
 }
 
 
-int b2nd_save(b2nd_array_t *array, char *urlpath) {
+int b2nd_save(const b2nd_array_t *array, char *urlpath) {
   BLOSC_ERROR_NULL(array, BLOSC2_ERROR_NULL_POINTER);
   BLOSC_ERROR_NULL(urlpath, BLOSC2_ERROR_NULL_POINTER);
 
@@ -1146,7 +1145,7 @@ int b2nd_save(b2nd_array_t *array, char *urlpath) {
 }
 
 
-int b2nd_print_meta(b2nd_array_t *array) {
+int b2nd_print_meta(const b2nd_array_t *array) {
   BLOSC_ERROR_NULL(array, BLOSC2_ERROR_NULL_POINTER);
   int8_t ndim;
   int64_t shape[B2ND_MAX_DIM];
@@ -1382,8 +1381,8 @@ int b2nd_resize(b2nd_array_t *array, const int64_t *new_shape,
 }
 
 
-int b2nd_insert(b2nd_array_t *array, void *buffer, int64_t buffersize,
-                const int8_t axis, int64_t insert_start) {
+int b2nd_insert(b2nd_array_t *array, const void *buffer, int64_t buffersize,
+                int8_t axis, int64_t insert_start) {
 
   BLOSC_ERROR_NULL(array, BLOSC2_ERROR_NULL_POINTER);
   BLOSC_ERROR_NULL(buffer, BLOSC2_ERROR_NULL_POINTER);
@@ -1427,8 +1426,8 @@ int b2nd_insert(b2nd_array_t *array, void *buffer, int64_t buffersize,
 }
 
 
-int b2nd_append(b2nd_array_t *array, void *buffer, int64_t buffersize,
-                const int8_t axis) {
+int b2nd_append(b2nd_array_t *array, const void *buffer, int64_t buffersize,
+                int8_t axis) {
   BLOSC_ERROR_NULL(array, BLOSC2_ERROR_NULL_POINTER);
   BLOSC_ERROR_NULL(buffer, BLOSC2_ERROR_NULL_POINTER);
 
@@ -1828,21 +1827,22 @@ int orthogonal_selection(b2nd_array_t *array, int64_t **selection, int64_t *sele
 }
 
 
-int b2nd_get_orthogonal_selection(b2nd_array_t *array, int64_t **selection, int64_t *selection_size, void *buffer,
+int b2nd_get_orthogonal_selection(const b2nd_array_t *array, int64_t **selection, int64_t *selection_size, void *buffer,
                                   int64_t *buffershape, int64_t buffersize) {
-  return orthogonal_selection(array, selection, selection_size, buffer, buffershape, buffersize, true);
+  return orthogonal_selection((b2nd_array_t *)array, selection, selection_size, buffer, buffershape, buffersize, true);
 }
 
 
-int b2nd_set_orthogonal_selection(b2nd_array_t *array, int64_t **selection, int64_t *selection_size, void *buffer,
+int b2nd_set_orthogonal_selection(b2nd_array_t *array, int64_t **selection, int64_t *selection_size, const void *buffer,
                                   int64_t *buffershape, int64_t buffersize) {
-  return orthogonal_selection(array, selection, selection_size, buffer, buffershape, buffersize, false);
+  return orthogonal_selection(array, selection, selection_size, (void*)buffer, buffershape, buffersize, false);
 }
 
 
 b2nd_context_t *
-b2nd_create_ctx(blosc2_storage *b2_storage, int8_t ndim, int64_t *shape, int32_t *chunkshape, int32_t *blockshape,
-                char *dtype, int8_t dtype_format, blosc2_metalayer *metalayers, int32_t nmetalayers) {
+b2nd_create_ctx(const blosc2_storage *b2_storage, int8_t ndim, const int64_t *shape, const int32_t *chunkshape,
+                const int32_t *blockshape, const char *dtype, int8_t dtype_format, const blosc2_metalayer *metalayers,
+                int32_t nmetalayers) {
   b2nd_context_t *ctx = malloc(sizeof(b2nd_context_t));
   BLOSC_ERROR_NULL(ctx, NULL);
   blosc2_storage *params_b2_storage = malloc(sizeof(blosc2_storage));

--- a/blosc/blosc2.c
+++ b/blosc/blosc2.c
@@ -4153,7 +4153,7 @@ int blosc2_chunk_nans(blosc2_cparams cparams, const int32_t nbytes, void* dest, 
 
 /* Create a chunk made of repeated values */
 int blosc2_chunk_repeatval(blosc2_cparams cparams, const int32_t nbytes,
-                           void* dest, int32_t destsize, void* repeatval) {
+                           void* dest, int32_t destsize, const void* repeatval) {
   uint8_t typesize = cparams.typesize;
   if (destsize < BLOSC_EXTENDED_HEADER_LENGTH + typesize) {
     BLOSC_TRACE_ERROR("dest buffer is not long enough");

--- a/include/b2nd.h
+++ b/include/b2nd.h
@@ -133,8 +133,9 @@ typedef struct {
  *
  */
 BLOSC_EXPORT b2nd_context_t *
-b2nd_create_ctx(blosc2_storage *b2_storage, int8_t ndim, int64_t *shape, int32_t *chunkshape, int32_t *blockshape,
-                char *dtype, int8_t dtype_format, blosc2_metalayer *metalayers, int32_t nmetalayers);
+b2nd_create_ctx(const blosc2_storage *b2_storage, int8_t ndim, const int64_t *shape, const int32_t *chunkshape,
+                const int32_t *blockshape, const char *dtype, int8_t dtype_format, const blosc2_metalayer *metalayers,
+                int32_t nmetalayers);
 
 
 /**
@@ -194,7 +195,7 @@ BLOSC_EXPORT int b2nd_zeros(b2nd_context_t *ctx, b2nd_array_t **array);
  *
  * @return An error code.
  */
-BLOSC_EXPORT int b2nd_full(b2nd_context_t *ctx, b2nd_array_t **array, void *fill_value);
+BLOSC_EXPORT int b2nd_full(b2nd_context_t *ctx, b2nd_array_t **array, const void *fill_value);
 
 /**
  * @brief Free an array.
@@ -226,7 +227,7 @@ BLOSC_EXPORT int b2nd_from_schunk(blosc2_schunk *schunk, b2nd_array_t **array);
  *
  * @return An error code
  */
-BLOSC_EXPORT int b2nd_to_cframe(b2nd_array_t *array, uint8_t **cframe,
+BLOSC_EXPORT int b2nd_to_cframe(const b2nd_array_t *array, uint8_t **cframe,
                                 int64_t *cframe_len, bool *needs_free);
 
 /**
@@ -270,7 +271,7 @@ BLOSC_EXPORT int b2nd_open_offset(const char *urlpath, b2nd_array_t **array, int
  *
  * @return An error code.
  */
-BLOSC_EXPORT int b2nd_save(b2nd_array_t *array, char *urlpath);
+BLOSC_EXPORT int b2nd_save(const b2nd_array_t *array, char *urlpath);
 
 /**
  * @brief Create a b2nd array from a C buffer.
@@ -282,7 +283,7 @@ BLOSC_EXPORT int b2nd_save(b2nd_array_t *array, char *urlpath);
  *
  * @return An error code.
  */
-BLOSC_EXPORT int b2nd_from_cbuffer(b2nd_context_t *ctx, b2nd_array_t **array, void *buffer, int64_t buffersize);
+BLOSC_EXPORT int b2nd_from_cbuffer(b2nd_context_t *ctx, b2nd_array_t **array, const void *buffer, int64_t buffersize);
 
 /**
  * @brief Extract the data from a b2nd array into a C buffer.
@@ -293,8 +294,7 @@ BLOSC_EXPORT int b2nd_from_cbuffer(b2nd_context_t *ctx, b2nd_array_t **array, vo
  *
  * @return An error code.
  */
-BLOSC_EXPORT int b2nd_to_cbuffer(b2nd_array_t *array, void *buffer,
-                                 int64_t buffersize);
+BLOSC_EXPORT int b2nd_to_cbuffer(const b2nd_array_t *array, void *buffer, int64_t buffersize);
 
 /**
  * @brief Get a slice from an array and store it into a new array.
@@ -310,8 +310,8 @@ BLOSC_EXPORT int b2nd_to_cbuffer(b2nd_array_t *array, void *buffer,
  * @note The ndim and shape from ctx will be overwritten by the src and stop-start respectively.
  *
  */
-BLOSC_EXPORT int b2nd_get_slice(b2nd_context_t *ctx, b2nd_array_t **array, b2nd_array_t *src, const int64_t *start,
-                                const int64_t *stop);
+BLOSC_EXPORT int b2nd_get_slice(b2nd_context_t *ctx, b2nd_array_t **array, const b2nd_array_t *src,
+                                const int64_t *start, const int64_t *stop);
 
 /**
  * @brief Squeeze a b2nd array
@@ -349,9 +349,8 @@ BLOSC_EXPORT int b2nd_squeeze(b2nd_array_t *array);
  *
  * @return An error code.
  */
-BLOSC_EXPORT int b2nd_get_slice_cbuffer(b2nd_array_t *array,
-                                        int64_t *start, int64_t *stop,
-                                        void *buffer, int64_t *buffershape, int64_t buffersize);
+BLOSC_EXPORT int b2nd_get_slice_cbuffer(const b2nd_array_t *array, const int64_t *start, const int64_t *stop,
+                                        void *buffer, const int64_t *buffershape, int64_t buffersize);
 
 /**
  * @brief Set a slice in a b2nd array using a C buffer.
@@ -365,8 +364,8 @@ BLOSC_EXPORT int b2nd_get_slice_cbuffer(b2nd_array_t *array,
  *
  * @return An error code.
  */
-BLOSC_EXPORT int b2nd_set_slice_cbuffer(void *buffer, int64_t *buffershape, int64_t buffersize,
-                                        int64_t *start, int64_t *stop, b2nd_array_t *array);
+BLOSC_EXPORT int b2nd_set_slice_cbuffer(const void *buffer, const int64_t *buffershape, int64_t buffersize,
+                                        const int64_t *start, const int64_t *stop, b2nd_array_t *array);
 
 /**
  * @brief Make a copy of the array data. The copy is done into a new b2nd array.
@@ -380,7 +379,7 @@ BLOSC_EXPORT int b2nd_set_slice_cbuffer(void *buffer, int64_t *buffershape, int6
  * @note The ndim and shape in ctx will be overwritten by the src ctx.
  *
  */
-BLOSC_EXPORT int b2nd_copy(b2nd_context_t *ctx, b2nd_array_t *src, b2nd_array_t **array);
+BLOSC_EXPORT int b2nd_copy(b2nd_context_t *ctx, const b2nd_array_t *src, b2nd_array_t **array);
 
 /**
  * @brief Print metalayer parameters.
@@ -389,7 +388,7 @@ BLOSC_EXPORT int b2nd_copy(b2nd_context_t *ctx, b2nd_array_t *src, b2nd_array_t 
  *
  * @return An error code
  */
-BLOSC_EXPORT int b2nd_print_meta(b2nd_array_t *array);
+BLOSC_EXPORT int b2nd_print_meta(const b2nd_array_t *array);
 
 /**
  * @brief Resize the shape of an array
@@ -414,8 +413,8 @@ BLOSC_EXPORT int b2nd_resize(b2nd_array_t *array, const int64_t *new_shape, cons
  *
  * @return An error code.
  */
-BLOSC_EXPORT int b2nd_insert(b2nd_array_t *array, void *buffer, int64_t buffersize,
-                             const int8_t axis, int64_t insert_start);
+BLOSC_EXPORT int b2nd_insert(b2nd_array_t *array, const void *buffer, int64_t buffersize,
+                             int8_t axis, int64_t insert_start);
 
 /**
  * Append a buffer at the end of a b2nd array.
@@ -427,8 +426,8 @@ BLOSC_EXPORT int b2nd_insert(b2nd_array_t *array, void *buffer, int64_t buffersi
  *
  * @return An error code.
  */
-BLOSC_EXPORT int b2nd_append(b2nd_array_t *array, void *buffer, int64_t buffersize,
-                             const int8_t axis);
+BLOSC_EXPORT int b2nd_append(b2nd_array_t *array, const void *buffer, int64_t buffersize,
+                             int8_t axis);
 
 /**
  * @brief Delete shrinking the given axis delete_len items.
@@ -443,7 +442,7 @@ BLOSC_EXPORT int b2nd_append(b2nd_array_t *array, void *buffer, int64_t buffersi
  *
  * @note See also b2nd_resize
  */
-BLOSC_EXPORT int b2nd_delete(b2nd_array_t *array, const int8_t axis,
+BLOSC_EXPORT int b2nd_delete(b2nd_array_t *array, int8_t axis,
                              int64_t delete_start, int64_t delete_len);
 
 
@@ -463,7 +462,8 @@ BLOSC_EXPORT int b2nd_delete(b2nd_array_t *array, const int8_t axis,
  *
  * @note See also b2nd_set_orthogonal_selection.
  */
-BLOSC_EXPORT int b2nd_get_orthogonal_selection(b2nd_array_t *array, int64_t **selection, int64_t *selection_size, void *buffer,
+BLOSC_EXPORT int b2nd_get_orthogonal_selection(const b2nd_array_t *array, int64_t **selection,
+                                               int64_t *selection_size, void *buffer,
                                                int64_t *buffershape, int64_t buffersize);
 
 /**
@@ -481,7 +481,7 @@ BLOSC_EXPORT int b2nd_get_orthogonal_selection(b2nd_array_t *array, int64_t **se
  * @note See also b2nd_get_orthogonal_selection.
  */
 BLOSC_EXPORT int b2nd_set_orthogonal_selection(b2nd_array_t *array, int64_t **selection,
-                                               int64_t *selection_size, void *buffer,
+                                               int64_t *selection_size, const void *buffer,
                                                int64_t *buffershape, int64_t buffersize);
 
 
@@ -498,9 +498,9 @@ BLOSC_EXPORT int b2nd_set_orthogonal_selection(b2nd_array_t *array, int64_t **se
  *
  * @return An error code.
  */
-BLOSC_EXPORT int b2nd_serialize_meta(int8_t ndim, int64_t *shape, int32_t *chunkshape,
-                                     int32_t *blockshape, const char *dtype,
-                                     const int8_t dtype_format, uint8_t **smeta);
+BLOSC_EXPORT int b2nd_serialize_meta(int8_t ndim, const int64_t *shape, const int32_t *chunkshape,
+                                     const int32_t *blockshape, const char *dtype,
+                                     int8_t dtype_format, uint8_t **smeta);
 
 /**
  * @brief Read the metainfo in the b2nd metalayer.
@@ -516,7 +516,7 @@ BLOSC_EXPORT int b2nd_serialize_meta(int8_t ndim, int64_t *shape, int32_t *chunk
  *
  * @return An error code.
  */
-BLOSC_EXPORT int b2nd_deserialize_meta(uint8_t *smeta, int32_t smeta_len, int8_t *ndim,
+BLOSC_EXPORT int b2nd_deserialize_meta(const uint8_t *smeta, int32_t smeta_len, int8_t *ndim,
                                        int64_t *shape, int32_t *chunkshape, int32_t *blockshape,
                                        char **dtype, int8_t *dtype_format);
 

--- a/include/blosc2.h
+++ b/include/blosc2.h
@@ -1519,7 +1519,7 @@ BLOSC_EXPORT int blosc2_chunk_nans(blosc2_cparams cparams, int32_t nbytes,
  * If negative, there has been an error and @p dest is unusable.
  * */
 BLOSC_EXPORT int blosc2_chunk_repeatval(blosc2_cparams cparams, int32_t nbytes,
-                                        void* dest, int32_t destsize, void* repeatval);
+                                        void* dest, int32_t destsize, const void* repeatval);
 
 
 /**


### PR DESCRIPTION
The current API doesn't use `const` on pointers when treating them as read-only, which makes the API difficult to use in a const-safe way. It also makes it difficult for users to understand the semantics.

Note that casts had to be used internally in a few places because of the use of functions which handle both read and write paths depending on a flag.