### PR TITLE
Fix invalid conversion from void*

### DIFF
--- a/include/b2nd.h
+++ b/include/b2nd.h
@@ -573,7 +573,7 @@ static inline int b2nd_deserialize_meta(
     int dtype_len;
     swap_store(&dtype_len, pmeta, sizeof(int32_t));
     pmeta += sizeof(int32_t);
-    *dtype = malloc(dtype_len + 1);
+    *dtype = (char*)malloc(dtype_len + 1);
     char* dtype_ = *dtype;
     memcpy(dtype_, (char*)pmeta, dtype_len);
     dtype_[dtype_len] = '\0';

--- a/include/blosc2.h
+++ b/include/blosc2.h
@@ -2080,7 +2080,7 @@ BLOSC_EXPORT int blosc2_meta_update(blosc2_schunk *schunk, const char *name, uin
 
 static inline void swap_store(void *dest, const void *pa, int size) {
   uint8_t *pa_ = (uint8_t *) pa;
-  uint8_t *pa2_ = malloc((size_t) size);
+  uint8_t *pa2_ = (uint8_t*)malloc((size_t) size);
   int i = 1; /* for big/little endian detection */
   char *p = (char *) &i;
 
@@ -2141,7 +2141,7 @@ static inline int blosc2_meta_get(blosc2_schunk *schunk, const char *name, uint8
     return nmetalayer;
   }
   *content_len = schunk->metalayers[nmetalayer]->content_len;
-  *content = malloc((size_t)*content_len);
+  *content = (uint8_t*)malloc((size_t)*content_len);
   memcpy(*content, schunk->metalayers[nmetalayer]->content, (size_t)*content_len);
   return nmetalayer;
 }


### PR DESCRIPTION
Fixes this, when building btune:

```
/home/jdavid/sandboxes/Francesc/c-blosc2/include/blosc2.h: In function ‘void swap_store(void*, const void*, int)’:
/home/jdavid/sandboxes/Francesc/c-blosc2/include/blosc2.h:2083:25: error: invalid conversion from ‘void*’ to ‘uint8_t*’ {aka ‘unsigned char*’} [-fpermissive]
 2083 |   uint8_t *pa2_ = malloc((size_t) size);
      |                   ~~~~~~^~~~~~~~~~~~~~~
      |                         |
      |                         void*
/home/jdavid/sandboxes/Francesc/c-blosc2/include/blosc2.h: In function ‘int blosc2_meta_get(blosc2_schunk*, const char*, uint8_t**, int32_t*)’:
/home/jdavid/sandboxes/Francesc/c-blosc2/include/blosc2.h:2144:20: error: invalid conversion from ‘void*’ to ‘uint8_t*’ {aka ‘unsigned char*’} [-fpermissive]
 2144 |   *content = malloc((size_t)*content_len);
      |              ~~~~~~^~~~~~~~~~~~~~~~~~~~~~
      |                    |
      |                    void*
In file included from /home/jdavid/sandboxes/Francesc/c-blosc2/blosc/context.h:27,
                 from /home/jdavid/sandboxes/Francesc/BTune/btune/btune_model.cpp:7:
/home/jdavid/sandboxes/Francesc/c-blosc2/include/b2nd.h: In function ‘int b2nd_deserialize_meta(const uint8_t*, int32_t, int8_t*, int64_t*, int32_t*, int32_t*, char**, int8_t*)’:
/home/jdavid/sandboxes/Francesc/c-blosc2/include/b2nd.h:576:20: error: invalid conversion from ‘void*’ to ‘char*’ [-fpermissive]
  576 |     *dtype = malloc(dtype_len + 1);
      |              ~~~~~~^~~~~~~~~~~~~~~
      |                    |
      |                    void*
```