### PR TITLE
Variant for the © symbol: (C) → (c)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Blosc - Blocked Shuffling and Compression Library
 #
-# Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+# Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
 # https://blosc.org
 # License: BSD 3-Clause (see LICENSE.txt)
 #

--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Blosc - Blocked Shuffling and Compression Library
 #
-# Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+# Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
 # https://blosc.org
 # License: BSD 3-Clause (see LICENSE.txt)
 #

--- a/bench/b2bench.c
+++ b/bench/b2bench.c
@@ -1,5 +1,5 @@
 /*********************************************************************
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/bench/b2nd/CMakeLists.txt
+++ b/bench/b2nd/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Blosc - Blocked Shuffling and Compression Library
 #
-# Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+# Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
 # https://blosc.org
 # License: BSD 3-Clause (see LICENSE.txt)
 #

--- a/bench/b2nd/bench_get_slice.c
+++ b/bench/b2nd/bench_get_slice.c
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/bench/b2nd/bench_zfp_getitem.c
+++ b/bench/b2nd/bench_zfp_getitem.c
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/bench/create_frame.c
+++ b/bench/create_frame.c
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/bench/delta_schunk.c
+++ b/bench/delta_schunk.c
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/bench/plot-speeds.py
+++ b/bench/plot-speeds.py
@@ -1,5 +1,5 @@
 """
-Copyright (C) 2021  The Blosc developers <blosc@blosc.org>
+Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
 https://blosc.org
 License: BSD 3-Clause (see LICENSE.txt)
 

--- a/bench/read-grid-150x150.py
+++ b/bench/read-grid-150x150.py
@@ -1,5 +1,5 @@
 """
-Copyright (C) 2021  The Blosc developers <blosc@blosc.org>
+Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
 https://blosc.org
 License: BSD 3-Clause (see LICENSE.txt)
 

--- a/bench/sframe_bench.c
+++ b/bench/sframe_bench.c
@@ -1,5 +1,5 @@
 /*********************************************************************
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/bench/sum_openmp.c
+++ b/bench/sum_openmp.c
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/bench/trunc_prec_schunk.c
+++ b/bench/trunc_prec_schunk.c
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/bench/zero_runlen.c
+++ b/bench/zero_runlen.c
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/blosc/CMakeLists.txt
+++ b/blosc/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Blosc - Blocked Shuffling and Compression Library
 #
-# Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+# Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
 # https://blosc.org
 # License: BSD 3-Clause (see LICENSE.txt)
 #

--- a/blosc/b2nd.c
+++ b/blosc/b2nd.c
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/blosc/b2nd_utils.c
+++ b/blosc/b2nd_utils.c
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/blosc/b2nd_utils.h
+++ b/blosc/b2nd_utils.h
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/blosc/bitshuffle-altivec.c
+++ b/blosc/bitshuffle-altivec.c
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/blosc/bitshuffle-altivec.h
+++ b/blosc/bitshuffle-altivec.h
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/blosc/bitshuffle-avx2.c
+++ b/blosc/bitshuffle-avx2.c
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/blosc/bitshuffle-avx2.h
+++ b/blosc/bitshuffle-avx2.h
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/blosc/bitshuffle-generic.c
+++ b/blosc/bitshuffle-generic.c
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/blosc/bitshuffle-generic.h
+++ b/blosc/bitshuffle-generic.h
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/blosc/bitshuffle-neon.c
+++ b/blosc/bitshuffle-neon.c
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/blosc/bitshuffle-neon.h
+++ b/blosc/bitshuffle-neon.h
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/blosc/bitshuffle-sse2.c
+++ b/blosc/bitshuffle-sse2.c
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/blosc/bitshuffle-sse2.h
+++ b/blosc/bitshuffle-sse2.h
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/blosc/blosc-private.h
+++ b/blosc/blosc-private.h
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/blosc/blosc2-stdio.c
+++ b/blosc/blosc2-stdio.c
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/blosc/blosc2.c
+++ b/blosc/blosc2.c
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/blosc/blosclz.c
+++ b/blosc/blosclz.c
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/blosc/blosclz.h
+++ b/blosc/blosclz.h
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/blosc/context.h
+++ b/blosc/context.h
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/blosc/delta.c
+++ b/blosc/delta.c
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/blosc/delta.h
+++ b/blosc/delta.h
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/blosc/directories.c
+++ b/blosc/directories.c
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/blosc/fastcopy.c
+++ b/blosc/fastcopy.c
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/blosc/fastcopy.h
+++ b/blosc/fastcopy.h
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/blosc/frame.c
+++ b/blosc/frame.c
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/blosc/frame.h
+++ b/blosc/frame.h
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/blosc/schunk.c
+++ b/blosc/schunk.c
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/blosc/sframe.c
+++ b/blosc/sframe.c
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/blosc/sframe.h
+++ b/blosc/sframe.h
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/blosc/shuffle-altivec.c
+++ b/blosc/shuffle-altivec.c
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc developers <blosc@blosc.org> and Jerome Kieffer <jerome.kieffer@esrf.fr>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org> and Jerome Kieffer <jerome.kieffer@esrf.fr>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/blosc/shuffle-altivec.h
+++ b/blosc/shuffle-altivec.h
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/blosc/shuffle-avx2.c
+++ b/blosc/shuffle-avx2.c
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/blosc/shuffle-avx2.c.orig
+++ b/blosc/shuffle-avx2.c.orig
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/blosc/shuffle-avx2.h
+++ b/blosc/shuffle-avx2.h
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/blosc/shuffle-generic.c
+++ b/blosc/shuffle-generic.c
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/blosc/shuffle-generic.h
+++ b/blosc/shuffle-generic.h
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/blosc/shuffle-neon.c
+++ b/blosc/shuffle-neon.c
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  Lucian Marc <ruben.lucian@gmail.com>
+  Copyright (c) 2021  Lucian Marc <ruben.lucian@gmail.com>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/blosc/shuffle-neon.h
+++ b/blosc/shuffle-neon.h
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/blosc/shuffle-sse2.c
+++ b/blosc/shuffle-sse2.c
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/blosc/shuffle-sse2.h
+++ b/blosc/shuffle-sse2.h
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/blosc/shuffle.c
+++ b/blosc/shuffle.c
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/blosc/shuffle.h
+++ b/blosc/shuffle.h
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/blosc/stune.c
+++ b/blosc/stune.c
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/blosc/stune.h
+++ b/blosc/stune.h
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/blosc/timestamp.c
+++ b/blosc/timestamp.c
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/blosc/transpose-altivec.h
+++ b/blosc/transpose-altivec.h
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc developers <blosc@blosc.org> and Jerome Kieffer <jerome.kieffer@esrf.fr>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org> and Jerome Kieffer <jerome.kieffer@esrf.fr>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/blosc/trunc-prec.c
+++ b/blosc/trunc-prec.c
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/blosc/trunc-prec.h
+++ b/blosc/trunc-prec.h
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/examples/b2nd/CMakeLists.txt
+++ b/examples/b2nd/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Blosc - Blocked Shuffling and Compression Library
 #
-# Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+# Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
 # https://blosc.org
 # License: BSD 3-Clause (see LICENSE.txt)
 #

--- a/examples/b2nd/example_empty_shape.c
+++ b/examples/b2nd/example_empty_shape.c
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/examples/b2nd/example_frame_generator.c
+++ b/examples/b2nd/example_frame_generator.c
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/examples/b2nd/example_oindex.c
+++ b/examples/b2nd/example_oindex.c
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/examples/b2nd/example_plainbuffer.c
+++ b/examples/b2nd/example_plainbuffer.c
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/examples/b2nd/example_plugins_codecs.c
+++ b/examples/b2nd/example_plugins_codecs.c
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/examples/b2nd/example_plugins_filters.c
+++ b/examples/b2nd/example_plugins_filters.c
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/examples/b2nd/example_print_meta.c
+++ b/examples/b2nd/example_print_meta.c
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/examples/b2nd/example_serialize.c
+++ b/examples/b2nd/example_serialize.c
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/examples/compress_file.c
+++ b/examples/compress_file.c
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/examples/contexts.c
+++ b/examples/contexts.c
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/examples/delta_schunk_ex.c
+++ b/examples/delta_schunk_ex.c
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/examples/find_roots.c
+++ b/examples/find_roots.c
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/examples/frame_backed_schunk.c
+++ b/examples/frame_backed_schunk.c
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/examples/frame_big.c
+++ b/examples/frame_big.c
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/examples/frame_metalayers.c
+++ b/examples/frame_metalayers.c
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/examples/frame_offset.c
+++ b/examples/frame_offset.c
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/examples/frame_roundtrip.c
+++ b/examples/frame_roundtrip.c
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/examples/frame_simple.c
+++ b/examples/frame_simple.c
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/examples/frame_vlmetalayers.c
+++ b/examples/frame_vlmetalayers.c
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/examples/get_set_slice.c
+++ b/examples/get_set_slice.c
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/examples/instrument_codec.c
+++ b/examples/instrument_codec.c
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2022  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2022  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/examples/many_compressors.c
+++ b/examples/many_compressors.c
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/examples/multithread.c
+++ b/examples/multithread.c
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/examples/noinit.c
+++ b/examples/noinit.c
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/examples/schunk_postfilter.c
+++ b/examples/schunk_postfilter.c
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/examples/schunk_simple.c
+++ b/examples/schunk_simple.c
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/examples/sframe_simple.c
+++ b/examples/sframe_simple.c
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/examples/simple.c
+++ b/examples/simple.c
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/examples/urcodecs.c
+++ b/examples/urcodecs.c
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/examples/urfilters.c
+++ b/examples/urfilters.c
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/examples/win-dynamic-linking.c
+++ b/examples/win-dynamic-linking.c
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/examples/zstd_dict.c
+++ b/examples/zstd_dict.c
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/include/b2nd.h
+++ b/include/b2nd.h
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/include/blosc2.h
+++ b/include/blosc2.h
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/include/blosc2/blosc2-common.h
+++ b/include/blosc2/blosc2-common.h
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/include/blosc2/blosc2-export.h
+++ b/include/blosc2/blosc2-export.h
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/include/blosc2/blosc2-stdio.h
+++ b/include/blosc2/blosc2-stdio.h
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/include/blosc2/codecs-registry.h
+++ b/include/blosc2/codecs-registry.h
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/include/blosc2/filters-registry.h
+++ b/include/blosc2/filters-registry.h
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Blosc - Blocked Shuffling and Compression Library
 #
-# Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+# Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
 # https://blosc.org
 # License: BSD 3-Clause (see LICENSE.txt)
 #

--- a/plugins/codecs/codecs-registry.c
+++ b/plugins/codecs/codecs-registry.c
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2021 The Blosc Developers
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 */

--- a/plugins/codecs/ndlz/CMakeLists.txt
+++ b/plugins/codecs/ndlz/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Blosc - Blocked Shuffling and Compression Library
 #
-# Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+# Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
 # https://blosc.org
 # License: BSD 3-Clause (see LICENSE.txt)
 #

--- a/plugins/codecs/ndlz/ndlz-private.h
+++ b/plugins/codecs/ndlz/ndlz-private.h
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/plugins/codecs/ndlz/ndlz.c
+++ b/plugins/codecs/ndlz/ndlz.c
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/plugins/codecs/ndlz/ndlz.h
+++ b/plugins/codecs/ndlz/ndlz.h
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/plugins/codecs/ndlz/ndlz4x4.c
+++ b/plugins/codecs/ndlz/ndlz4x4.c
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/plugins/codecs/ndlz/ndlz4x4.h
+++ b/plugins/codecs/ndlz/ndlz4x4.h
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/plugins/codecs/ndlz/ndlz8x8.c
+++ b/plugins/codecs/ndlz/ndlz8x8.c
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/plugins/codecs/ndlz/ndlz8x8.h
+++ b/plugins/codecs/ndlz/ndlz8x8.h
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/plugins/codecs/ndlz/test_ndlz.c
+++ b/plugins/codecs/ndlz/test_ndlz.c
@@ -1,7 +1,7 @@
 /*********************************************************************
     Blosc - Blocked Shuffling and Compression Library
 
-    Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+    Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
     https://blosc.org
     License: BSD 3-Clause (see LICENSE.txt)
 

--- a/plugins/codecs/zfp/blosc2-zfp.c
+++ b/plugins/codecs/zfp/blosc2-zfp.c
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 */

--- a/plugins/codecs/zfp/blosc2-zfp.h
+++ b/plugins/codecs/zfp/blosc2-zfp.h
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/plugins/codecs/zfp/test_zfp_acc_float.c
+++ b/plugins/codecs/zfp/test_zfp_acc_float.c
@@ -1,7 +1,7 @@
 /*********************************************************************
     Blosc - Blocked Shuffling and Compression Library
 
-    Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+    Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
     https://blosc.org
     License: BSD 3-Clause (see LICENSE.txt)
 

--- a/plugins/codecs/zfp/test_zfp_prec_float.c
+++ b/plugins/codecs/zfp/test_zfp_prec_float.c
@@ -1,7 +1,7 @@
 /*********************************************************************
     Blosc - Blocked Shuffling and Compression Library
 
-    Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+    Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
     https://blosc.org
     License: BSD 3-Clause (see LICENSE.txt)
 

--- a/plugins/codecs/zfp/test_zfp_rate_float.c
+++ b/plugins/codecs/zfp/test_zfp_rate_float.c
@@ -1,7 +1,7 @@
 /*********************************************************************
     Blosc - Blocked Shuffling and Compression Library
 
-    Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+    Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
     https://blosc.org
     License: BSD 3-Clause (see LICENSE.txt)
 

--- a/plugins/codecs/zfp/test_zfp_rate_getitem.c
+++ b/plugins/codecs/zfp/test_zfp_rate_getitem.c
@@ -1,7 +1,7 @@
 /*********************************************************************
     Blosc - Blocked Shuffling and Compression Library
 
-    Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+    Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
     https://blosc.org
     License: BSD 3-Clause (see LICENSE.txt)
 

--- a/plugins/codecs/zfp/zfp-private.h
+++ b/plugins/codecs/zfp/zfp-private.h
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/plugins/filters/CMakeLists.txt
+++ b/plugins/filters/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Blosc - Blocked Shuffling and Compression Library
 #
-# Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+# Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
 # https://blosc.org
 # License: BSD 3-Clause (see LICENSE.txt)
 #

--- a/plugins/filters/bytedelta/CMakeLists.txt
+++ b/plugins/filters/bytedelta/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Blosc - Blocked Shuffling and Compression Library
 #
-# Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+# Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
 # https://blosc.org
 # License: BSD 3-Clause (see LICENSE.txt)
 #

--- a/plugins/filters/bytedelta/bytedelta.c
+++ b/plugins/filters/bytedelta/bytedelta.c
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/plugins/filters/bytedelta/bytedelta.h
+++ b/plugins/filters/bytedelta/bytedelta.h
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/plugins/filters/bytedelta/test_bytedelta.c
+++ b/plugins/filters/bytedelta/test_bytedelta.c
@@ -1,7 +1,7 @@
 /*********************************************************************
     Blosc - Blocked Shuffling and Compression Library
 
-    Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+    Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
     https://blosc.org
     License: BSD 3-Clause (see LICENSE.txt)
 

--- a/plugins/filters/filters-registry.c
+++ b/plugins/filters/filters-registry.c
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2021 The Blosc Developers
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org> 
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 */

--- a/plugins/filters/ndcell/ndcell.c
+++ b/plugins/filters/ndcell/ndcell.c
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/plugins/filters/ndcell/ndcell.h
+++ b/plugins/filters/ndcell/ndcell.h
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/plugins/filters/ndcell/test_ndcell.c
+++ b/plugins/filters/ndcell/test_ndcell.c
@@ -1,7 +1,7 @@
 /*********************************************************************
     Blosc - Blocked Shuffling and Compression Library
 
-    Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+    Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
     https://blosc.org
     License: BSD 3-Clause (see LICENSE.txt)
 

--- a/plugins/filters/ndmean/ndmean.c
+++ b/plugins/filters/ndmean/ndmean.c
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2021 The Blosc Developers
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 */

--- a/plugins/filters/ndmean/ndmean.h
+++ b/plugins/filters/ndmean/ndmean.h
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/plugins/filters/ndmean/test_ndmean_mean.c
+++ b/plugins/filters/ndmean/test_ndmean_mean.c
@@ -1,7 +1,7 @@
 /*********************************************************************
     Blosc - Blocked Shuffling and Compression Library
 
-    Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+    Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
     https://blosc.org
     License: BSD 3-Clause (see LICENSE.txt)
 

--- a/plugins/filters/ndmean/test_ndmean_repart.c
+++ b/plugins/filters/ndmean/test_ndmean_repart.c
@@ -1,7 +1,7 @@
 /*********************************************************************
     Blosc - Blocked Shuffling and Compression Library
 
-    Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+    Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
     https://blosc.org
     License: BSD 3-Clause (see LICENSE.txt)
 

--- a/plugins/plugin_utils.c
+++ b/plugins/plugin_utils.c
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2021 The Blosc Developers
+  Copyright (c) 2021 The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 */

--- a/plugins/plugin_utils.h
+++ b/plugins/plugin_utils.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2021 The Blosc Developers
+  Copyright (c) 2021 The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Blosc - Blocked Shuffling and Compression Library
 #
-# Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+# Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
 # https://blosc.org
 # License: BSD 3-Clause (see LICENSE.txt)
 #

--- a/tests/b2nd/CMakeLists.txt
+++ b/tests/b2nd/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Blosc - Blocked Shuffling and Compression Library
 #
-# Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+# Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
 # https://blosc.org
 # License: BSD 3-Clause (see LICENSE.txt)
 #

--- a/tests/b2nd/cutest.h
+++ b/tests/b2nd/cutest.h
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/tests/b2nd/test_b2nd_append.c
+++ b/tests/b2nd/test_b2nd_append.c
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/tests/b2nd/test_b2nd_copy.c
+++ b/tests/b2nd/test_b2nd_copy.c
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/tests/b2nd/test_b2nd_delete.c
+++ b/tests/b2nd/test_b2nd_delete.c
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/tests/b2nd/test_b2nd_full.c
+++ b/tests/b2nd/test_b2nd_full.c
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/tests/b2nd/test_b2nd_get_slice.c
+++ b/tests/b2nd/test_b2nd_get_slice.c
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/tests/b2nd/test_b2nd_get_slice_buffer.c
+++ b/tests/b2nd/test_b2nd_get_slice_buffer.c
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/tests/b2nd/test_b2nd_insert.c
+++ b/tests/b2nd/test_b2nd_insert.c
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/tests/b2nd/test_b2nd_metalayers.c
+++ b/tests/b2nd/test_b2nd_metalayers.c
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/tests/b2nd/test_b2nd_open_offset.c
+++ b/tests/b2nd/test_b2nd_open_offset.c
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 */

--- a/tests/b2nd/test_b2nd_persistency.c
+++ b/tests/b2nd/test_b2nd_persistency.c
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/tests/b2nd/test_b2nd_resize.c
+++ b/tests/b2nd/test_b2nd_resize.c
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/tests/b2nd/test_b2nd_roundtrip.c
+++ b/tests/b2nd/test_b2nd_roundtrip.c
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/tests/b2nd/test_b2nd_save.c
+++ b/tests/b2nd/test_b2nd_save.c
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/tests/b2nd/test_b2nd_serialize.c
+++ b/tests/b2nd/test_b2nd_serialize.c
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/tests/b2nd/test_b2nd_set_slice_buffer.c
+++ b/tests/b2nd/test_b2nd_set_slice_buffer.c
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/tests/b2nd/test_b2nd_squeeze.c
+++ b/tests/b2nd/test_b2nd_squeeze.c
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/tests/b2nd/test_b2nd_squeeze_index.c
+++ b/tests/b2nd/test_b2nd_squeeze_index.c
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/tests/b2nd/test_b2nd_uninit.c
+++ b/tests/b2nd/test_b2nd_uninit.c
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/tests/b2nd/test_b2nd_zeros.c
+++ b/tests/b2nd/test_b2nd_zeros.c
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/tests/b2nd/test_common.h
+++ b/tests/b2nd/test_common.h
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/tests/cutest.h
+++ b/tests/cutest.h
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/tests/fuzz/generate_inputs_corpus.c
+++ b/tests/fuzz/generate_inputs_corpus.c
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2021  The Blosc Developers
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/tests/gcc-segfault-issue.c
+++ b/tests/gcc-segfault-issue.c
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/tests/print_versions.c
+++ b/tests/print_versions.c
@@ -1,7 +1,7 @@
 /*********************************************************************
   Print versions for Blosc and all its internal compressors.
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/tests/test_api.c
+++ b/tests/test_api.c
@@ -3,7 +3,7 @@
 
   Unit tests for Blosc API.
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/tests/test_bitshuffle_leftovers.c
+++ b/tests/test_bitshuffle_leftovers.c
@@ -5,7 +5,7 @@
   See https://github.com/Blosc/python-blosc/issues/220
   Probably related: https://github.com/Blosc/c-blosc/issues/240
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/tests/test_blosc1_compat.c
+++ b/tests/test_blosc1_compat.c
@@ -3,7 +3,7 @@
 
   Unit tests for BLOSC_BLOSC1_COMPAT environment variable in Blosc.
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/tests/test_change_nthreads_append.c
+++ b/tests/test_change_nthreads_append.c
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/tests/test_compress_roundtrip.c
+++ b/tests/test_compress_roundtrip.c
@@ -3,7 +3,7 @@
 
   Roundtrip compression/decompression tests.
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/tests/test_compressor.c
+++ b/tests/test_compressor.c
@@ -3,7 +3,7 @@
 
   Unit tests for BLOSC_COMPRESSOR environment variable in Blosc.
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/tests/test_contexts.c
+++ b/tests/test_contexts.c
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 */

--- a/tests/test_copy.c
+++ b/tests/test_copy.c
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/tests/test_delete_chunk.c
+++ b/tests/test_delete_chunk.c
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 */

--- a/tests/test_delta.c
+++ b/tests/test_delta.c
@@ -3,7 +3,7 @@
 
   Unit tests for BLOSC_COMPRESSOR environment variable in Blosc.
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/tests/test_delta_schunk.c
+++ b/tests/test_delta_schunk.c
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 */

--- a/tests/test_dict_schunk.c
+++ b/tests/test_dict_schunk.c
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 */

--- a/tests/test_empty_buffer.c
+++ b/tests/test_empty_buffer.c
@@ -3,7 +3,7 @@
 
   Unit tests for the blosc1_decompress() function.
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/tests/test_fill_special.c
+++ b/tests/test_fill_special.c
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/tests/test_frame.c
+++ b/tests/test_frame.c
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 */

--- a/tests/test_frame_get_offsets.c
+++ b/tests/test_frame_get_offsets.c
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 */

--- a/tests/test_frame_offset.c
+++ b/tests/test_frame_offset.c
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 */

--- a/tests/test_get_slice_buffer.c
+++ b/tests/test_get_slice_buffer.c
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/tests/test_getitem.c
+++ b/tests/test_getitem.c
@@ -3,7 +3,7 @@
 
   Unit tests for the blosc1_getitem() function.
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/tests/test_getitem_delta.c
+++ b/tests/test_getitem_delta.c
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/tests/test_insert_chunk.c
+++ b/tests/test_insert_chunk.c
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/tests/test_lazychunk.c
+++ b/tests/test_lazychunk.c
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/tests/test_lazychunk_memcpyed.c
+++ b/tests/test_lazychunk_memcpyed.c
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/tests/test_maskout.c
+++ b/tests/test_maskout.c
@@ -3,7 +3,7 @@
 
   Unit tests for BLOSC_COMPRESSOR environment variable in Blosc.
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/tests/test_maxout.c
+++ b/tests/test_maxout.c
@@ -3,7 +3,7 @@
 
   Unit tests for basic features in Blosc.
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/tests/test_noinit.c
+++ b/tests/test_noinit.c
@@ -1,7 +1,7 @@
 /*********************************************************************
   Blosc - Blocked Shuffling and Compression Library
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/tests/test_nolock.c
+++ b/tests/test_nolock.c
@@ -3,7 +3,7 @@
 
   Unit tests for BLOSC_NOLOCK environment variable in Blosc.
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/tests/test_nthreads.c
+++ b/tests/test_nthreads.c
@@ -3,7 +3,7 @@
 
   Unit tests for BLOSC_NTHREADS environment variable in Blosc.
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/tests/test_postfilter.c
+++ b/tests/test_postfilter.c
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 */

--- a/tests/test_prefilter.c
+++ b/tests/test_prefilter.c
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 */

--- a/tests/test_reorder_offsets.c
+++ b/tests/test_reorder_offsets.c
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/tests/test_schunk.c
+++ b/tests/test_schunk.c
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/tests/test_schunk_frame.c
+++ b/tests/test_schunk_frame.c
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/tests/test_schunk_header.c
+++ b/tests/test_schunk_header.c
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/tests/test_set_slice_buffer.c
+++ b/tests/test_set_slice_buffer.c
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/tests/test_sframe.c
+++ b/tests/test_sframe.c
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/tests/test_sframe_lazychunk.c
+++ b/tests/test_sframe_lazychunk.c
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/tests/test_shuffle_roundtrip_altivec.c
+++ b/tests/test_shuffle_roundtrip_altivec.c
@@ -3,7 +3,7 @@
 
   Roundtrip tests for the ALTIVEC-accelerated shuffle/unshuffle.
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/tests/test_shuffle_roundtrip_avx2.c
+++ b/tests/test_shuffle_roundtrip_avx2.c
@@ -3,7 +3,7 @@
 
   Roundtrip tests for the AVX2-accelerated shuffle/unshuffle.
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/tests/test_shuffle_roundtrip_generic.c
+++ b/tests/test_shuffle_roundtrip_generic.c
@@ -3,7 +3,7 @@
 
   Roundtrip tests
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/tests/test_shuffle_roundtrip_neon.c
+++ b/tests/test_shuffle_roundtrip_neon.c
@@ -3,7 +3,7 @@
 
   Roundtrip tests for the NEON-accelerated shuffle/unshuffle.
 
-  Copyright (C) 2021  Lucian Marc <ruben.lucian@gmail.com>
+  Copyright (c) 2021  Lucian Marc <ruben.lucian@gmail.com>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/tests/test_shuffle_roundtrip_sse2.c
+++ b/tests/test_shuffle_roundtrip_sse2.c
@@ -3,7 +3,7 @@
 
   Roundtrip tests for the SSE2-accelerated shuffle/unshuffle.
 
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/tests/test_small_chunks.c
+++ b/tests/test_small_chunks.c
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 */

--- a/tests/test_udio.c
+++ b/tests/test_udio.c
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 */

--- a/tests/test_update_chunk.c
+++ b/tests/test_update_chunk.c
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 

--- a/tests/test_urcodecs.c
+++ b/tests/test_urcodecs.c
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 */

--- a/tests/test_urfilters.c
+++ b/tests/test_urfilters.c
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 */

--- a/tests/test_zero_runlen.c
+++ b/tests/test_zero_runlen.c
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2021  The Blosc Developers <blosc@blosc.org>
+  Copyright (c) 2021  The Blosc Developers <blosc@blosc.org>
   https://blosc.org
   License: BSD 3-Clause (see LICENSE.txt)
 


### PR DESCRIPTION
Related to #444.

Stubbornly stick to the examples provided in:

§ 4.2.2 of the [_Compendium of Copyright Office Practices, first ed._](https://copyright.gov/history/comp/compendium-one.pdf)

![compendium-one](https://user-images.githubusercontent.com/3234522/232288051-9f20c763-1801-4aad-8919-09afb6cd8943.png)

§ 1005.01(c) of the [_Compendium of Copyright Office Practices, second ed._](https://copyright.gov/history/comp/compendium-two.pdf)

![compendium-two](https://user-images.githubusercontent.com/3234522/232287852-cdcabe2a-e20a-4e42-a7b7-db1ebf5b9d9c.png)

§ [2204.4(A)](https://copyright.gov/comp3/chap2200/ch2200-notice.pdf#%5B%7B%22num%22%3A40%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C76%2C151%2C0%5D) of the [_Compendium of Copyright Office Practices, third ed._](https://copyright.gov/comp3/)
> #### 2204.4(A) Variants for the © Symbol
> 
> A variant of the symbol © is acceptable only if it resembles the © closely enough to
> indicate clearly that the variant is intended to be the copyright symbol. Acceptable
> variants include:
> * The letter c with a parenthesis over the top.
> * The letter c with a parenthesis under the bottom.
> * (c
> * c)
> * (c)
> * The letter c with an unenclosed circle around it.