### PR TITLE
fprintf(stderr) → BLOSC_TRACE_ERROR()

### DIFF
--- a/blosc/shuffle.c
+++ b/blosc/shuffle.c
@@ -8,6 +8,7 @@
   See LICENSE.txt for details about copyright and rights to use.
 **********************************************************************/
 
+#include "blosc2.h"
 #include "shuffle.h"
 #include "blosc2/blosc2-common.h"
 #include "shuffle-generic.h"
@@ -433,7 +434,7 @@ bitshuffle(const int32_t bytesoftype, const int32_t blocksize,
                                              size, bytesoftype, (void *) _tmp);
   if (ret < 0) {
     // Some error in bitshuffle (should not happen)
-    fprintf(stderr, "the impossible happened: the bitshuffle filter failed!");
+    BLOSC_TRACE_ERROR("the impossible happened: the bitshuffle filter failed!");
     return ret;
   }
 
@@ -463,7 +464,7 @@ int32_t bitunshuffle(const int32_t bytesoftype, const int32_t blocksize,
                                                    bytesoftype, (void *) _tmp);
       if (ret < 0) {
         // Some error in bitshuffle (should not happen)
-        fprintf(stderr, "the impossible happened: the bitunshuffle filter failed!");
+        BLOSC_TRACE_ERROR("the impossible happened: the bitunshuffle filter failed!");
         return ret;
       }
       /* Copy the leftovers (we do so starting from c-blosc 1.18 on) */
@@ -480,7 +481,7 @@ int32_t bitunshuffle(const int32_t bytesoftype, const int32_t blocksize,
     int ret = (int) (host_implementation.bitunshuffle)((void *) _src, (void *) _dest,
                                                  size, bytesoftype, (void *) _tmp);
     if (ret < 0) {
-      fprintf(stderr, "the impossible happened: the bitunshuffle filter failed!");
+      BLOSC_TRACE_ERROR("the impossible happened: the bitunshuffle filter failed!");
       return ret;
     }
 

--- a/blosc/trunc-prec.c
+++ b/blosc/trunc-prec.c
@@ -77,8 +77,8 @@ int truncate_precision(int8_t prec_bits, int32_t typesize, int32_t nbytes,
       return truncate_precision64(prec_bits, nbytes / typesize,
                               (int64_t *)src, (int64_t *)dest);
     default:
-      fprintf(stderr, "Error in trunc-prec filter: Precision for typesize %d "
-              "not handled", (int)typesize);
+      BLOSC_TRACE_ERROR("Error in trunc-prec filter: Precision for typesize %d not handled",
+                        (int)typesize);
       return -1;
   }
 }

--- a/examples/urcodecs.c
+++ b/examples/urcodecs.c
@@ -36,7 +36,7 @@ int codec_encoder(const uint8_t* input, int32_t input_len,
     return -1;
   }
   if (cparams->typesize != 4) {
-    BLOSC_TRACE_ERROR("Itemsize %d != 4", cparams->typesize);
+    fprintf(stderr, "Itemsize %d != 4", cparams->typesize);
     return BLOSC2_ERROR_FAILURE;
   }
 
@@ -49,7 +49,7 @@ int codec_encoder(const uint8_t* input, int32_t input_len,
   int32_t step = in_[1] - start;
   for (int i = 1; i < nelem - 1; ++i) {
     if (in_[i + 1] - in_[i] != step) {
-      BLOSC_TRACE_ERROR("Buffer is not an arange");
+      fprintf(stderr, "Buffer is not an arange");
       return BLOSC2_ERROR_FAILURE;
     }
   }

--- a/examples/urfilters.c
+++ b/examples/urfilters.c
@@ -46,7 +46,7 @@ int filter_forward(const uint8_t* src, uint8_t* dest, int32_t size, uint8_t meta
         ((int16_t *) dest)[i] = (int16_t)(((int16_t *) src)[i] + 1);
         break;
       default:
-        BLOSC_TRACE_ERROR("Item size %d not supported", schunk->typesize);
+        fprintf(stderr, "Item size %d not supported", schunk->typesize);
         return BLOSC2_ERROR_FAILURE;
     }
   }
@@ -71,7 +71,7 @@ int filter_backward(const uint8_t* src, uint8_t* dest, int32_t size, uint8_t met
         ((int16_t *) dest)[i] = (int16_t)(((int16_t *) src)[i] - 1);
         break;
       default:
-        BLOSC_TRACE_ERROR("Item size %d not supported", schunk->typesize);
+        fprintf(stderr, "Item size %d not supported", schunk->typesize);
         return BLOSC2_ERROR_FAILURE;
     }
   }

--- a/tests/test_urcodecs.c
+++ b/tests/test_urcodecs.c
@@ -30,7 +30,7 @@ int codec_encoder(const uint8_t* input, int32_t input_len,
     return -1;
   }
   if (cparams->typesize != 4) {
-    BLOSC_TRACE_ERROR("Itemsize %d != 4", cparams->typesize);
+    fprintf(stderr, "Itemsize %d != 4", cparams->typesize);
     return BLOSC2_ERROR_FAILURE;
   }
   uint8_t *content;
@@ -54,7 +54,7 @@ int codec_encoder(const uint8_t* input, int32_t input_len,
   int32_t step = in_[1] - start;
   for (int i = 1; i < nelem - 1; ++i) {
     if (in_[i + 1] - in_[i] != step) {
-      BLOSC_TRACE_ERROR("Buffer is not an arange");
+      fprintf(stderr, "Buffer is not an arange");
       return BLOSC2_ERROR_FAILURE;
     }
   }
@@ -175,7 +175,7 @@ CUTEST_TEST_TEST(urcodecs) {
   }
   int rc = blosc2_register_codec(&udcodec);
   if (rc != 0) {
-    BLOSC_TRACE_ERROR("Error registering the code.");
+    fprintf(stderr, "Error registering the code.");
     return BLOSC2_ERROR_FAILURE;
   }
 
@@ -211,7 +211,7 @@ CUTEST_TEST_TEST(urcodecs) {
     }
     int64_t nchunks_ = blosc2_schunk_append_buffer(schunk, bdata, isize);
     if (nchunks_ != nchunk + 1) {
-      BLOSC_TRACE_ERROR("Unexpected nchunks!");
+      fprintf(stderr, "Unexpected nchunks!");
       return -1;
     }
   }
@@ -223,7 +223,7 @@ CUTEST_TEST_TEST(urcodecs) {
   for (nchunk = NCHUNKS-1; nchunk >= 0; nchunk--) {
     dsize = blosc2_schunk_decompress_chunk(schunk, nchunk, bdata_dest, isize);
     if (dsize < 0) {
-      BLOSC_TRACE_ERROR("Decompression error.  Error code: %d\n", dsize);
+      fprintf(stderr, "Decompression error.  Error code: %d\n", dsize);
       return dsize;
     }
   }
@@ -237,11 +237,11 @@ CUTEST_TEST_TEST(urcodecs) {
     }
 
     if (!equals && correct_backward) {
-      BLOSC_TRACE_ERROR("Decompressed bdata differs from original!\n");
+      fprintf(stderr, "Decompressed bdata differs from original!\n");
       return -1;
     }
     if (equals && !correct_backward) {
-      BLOSC_TRACE_ERROR("Decompressed bdata is equal than original!\n");
+      fprintf(stderr, "Decompressed bdata is equal than original!\n");
       return -1;
     }
   }

--- a/tests/test_urfilters.c
+++ b/tests/test_urfilters.c
@@ -42,7 +42,7 @@ int filter_forward(const uint8_t* src, uint8_t* dest, int32_t size, uint8_t meta
         ((int16_t *) dest)[i] = (int16_t) (((int16_t *) src)[i] + 1);
         break;
       default:
-        BLOSC_TRACE_ERROR("Item size %d not supported", schunk->typesize);
+        fprintf(stderr, "Item size %d not supported", schunk->typesize);
         return BLOSC2_ERROR_FAILURE;
     }
   }
@@ -71,7 +71,7 @@ int filter_backward(const uint8_t* src, uint8_t* dest, int32_t size, uint8_t met
         ((int16_t *) dest)[i] = (int16_t)(((int16_t *) src)[i] - 1);
         break;
       default:
-        BLOSC_TRACE_ERROR("Item size %d not supported", schunk->typesize);
+        fprintf(stderr, "Item size %d not supported", schunk->typesize);
         return BLOSC2_ERROR_FAILURE;
     }
   }
@@ -101,7 +101,7 @@ int filter_backward_error(const uint8_t* src, uint8_t* dest, int32_t size, uint8
         ((int16_t *) dest)[i] = (int16_t)(((int16_t *) src)[i] - 13);
         break;
       default:
-        BLOSC_TRACE_ERROR("Item size %d not supported", schunk->typesize);
+        fprintf(stderr, "Item size %d not supported", schunk->typesize);
         return BLOSC2_ERROR_FAILURE;
     }
   }
@@ -191,13 +191,13 @@ CUTEST_TEST_TEST(urfilters) {
           ((int16_t *) bdata)[i] = (int16_t)(i * nchunk);
           break;
         default:
-          BLOSC_TRACE_ERROR("Itemsize %d not supported\n", itemsize);
+          fprintf(stderr, "Itemsize %d not supported\n", itemsize);
           return -1;
       }
     }
     int64_t nchunks_ = blosc2_schunk_append_buffer(schunk, bdata, isize);
     if (nchunks_ != nchunk + 1) {
-      BLOSC_TRACE_ERROR("Unexpected nchunks!");
+      fprintf(stderr, "Unexpected nchunks!");
       return -1;
     }
   }
@@ -206,7 +206,7 @@ CUTEST_TEST_TEST(urfilters) {
   for (nchunk = NCHUNKS-1; nchunk >= 0; nchunk--) {
     dsize = blosc2_schunk_decompress_chunk(schunk, nchunk, bdata_dest, isize);
     if (dsize < 0) {
-      BLOSC_TRACE_ERROR("Decompression error.  Error code: %d\n", dsize);
+      fprintf(stderr, "Decompression error.  Error code: %d\n", dsize);
       return dsize;
     }
   }
@@ -232,15 +232,15 @@ CUTEST_TEST_TEST(urfilters) {
         }
         break;
       default:
-        BLOSC_TRACE_ERROR("Itemsize %d not supported\n", itemsize);
+        fprintf(stderr, "Itemsize %d not supported\n", itemsize);
         return -1;
     }
     if (!equals && correct_backward) {
-      BLOSC_TRACE_ERROR("Decompressed bdata differs from original!\n");
+      fprintf(stderr, "Decompressed bdata differs from original!\n");
       return -1;
     }
     if (equals && !correct_backward) {
-      BLOSC_TRACE_ERROR("Decompressed bdata is equal than original!\n");
+      fprintf(stderr, "Decompressed bdata is equal than original!\n");
       return -1;
     }
   }


### PR DESCRIPTION
Fixes #471.

Use BLOSC_TRACE_ERROR() everywhere under:
- `blosc`
- `include`
- `plugins` (except `*_test.c` files)
    
Use `fprintf(stderr)` everywhere under;
- `examples`
- `tests`
    
Of course, do not modify:
- `internal-complibs`