### PR TITLE
`BLOSC_STUNE` is not defined in c-blosc

### DIFF
--- a/include/blosc2.h
+++ b/include/blosc2.h
@@ -211,9 +211,7 @@ enum {
  * @brief Codes for the different tunes shipped with Blosc
  */
 enum {
-#ifndef BLOSC_H
     BLOSC_STUNE = 0,
-#endif // BLOSC_H
     BLOSC_LAST_TUNE = 1,
     //!< Determine the last tune defined by Blosc.
     BLOSC_LAST_REGISTERED_TUNE = BLOSC2_GLOBAL_REGISTERED_TUNE_START + BLOSC2_GLOBAL_REGISTERED_TUNES - 1,


### PR DESCRIPTION
Therefore, do not guard it with `BLOSC_H`, the include guard of `blosc.h` from previous version **c-blosc**.

Fixes #481.