### PR TITLE
Do not free() string before printing it

### DIFF
--- a/blosc/sframe.c
+++ b/blosc/sframe.c
@@ -33,11 +33,9 @@ void* sframe_open_index(const char* urlpath, const char* mode, const blosc2_io *
       return NULL;
     }
     fp = io_cb->open(index_path, mode, io->params);
-    free(index_path);
-    if (fp == NULL) {
+    if (fp == NULL)
       BLOSC_TRACE_ERROR("Error creating index path in: %s", index_path);
-      return NULL;
-    }
+    free(index_path);
   }
   return fp;
 }
@@ -54,11 +52,9 @@ void* sframe_open_chunk(const char* urlpath, int64_t nchunk, const char* mode, c
       return NULL;
     }
     fp = io_cb->open(chunk_path, mode, io->params);
-    free(chunk_path);
-    if (fp == NULL) {
+    if (fp == NULL)
       BLOSC_TRACE_ERROR("Error opening chunk path in: %s", chunk_path);
-      return NULL;
-    }
+    free(chunk_path);
   }
   return fp;
 }


### PR DESCRIPTION
GCC 13.1.1 on Fedora 39 is able to detect such missuses.

Fixes #482 