### PR TITLE
Fix GCC warning: ignoring return value of `fgets`

### DIFF
--- a/include/blosc2/plugins-utils.h
+++ b/include/blosc2/plugins-utils.h
@@ -41,7 +41,7 @@ static inline void* load_lib(char *plugin_name, char *path) {
   char python_path[PATH_MAX] = {0};
   FILE *fp = popen("python -c \"exec(\\\"import sys\\npaths=sys.path\\nfor p in paths:\\n\\tif 'site-packages' in p:"
                    "\\n \\t\\tprint(p+'/', end='')\\n \\t\\tbreak\\\")\"", "r");
-  fgets(python_path, PATH_MAX, fp);
+  (void)fgets(python_path, PATH_MAX, fp);
   pclose(fp);
 
   if (strlen(python_path) == 0) {


### PR DESCRIPTION
GCC 11.3.0 on Ubuntu 22.04:
```
/my/path/c-blosc2/include/blosc2/plugins-utils.h:44:3: warning: ignoring return value of ‘fgets’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
   44 |   fgets(python_path, PATH_MAX, fp);
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```