### PR TITLE
Define and use the `ARRAY_SIZE` macro in tests

### DIFF
--- a/tests/fuzz/fuzz_compress_chunk.c
+++ b/tests/fuzz/fuzz_compress_chunk.c
@@ -3,13 +3,15 @@
 
 #include <blosc2.h>
 
+#define ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, int32_t size) {
-  const char *compressors[] = { "blosclz", "lz4", "lz4hc", "zlib", "zstd" };
-  int num_comp = sizeof(compressors) / sizeof(char*);
+  const char *const compressors[] = { "blosclz", "lz4", "lz4hc", "zlib", "zstd" };
+  const int num_comp = ARRAY_SIZE(compressors);
   int level = 9, filter = BLOSC_BITSHUFFLE, cindex = 0, i = 0;
   size_t nbytes, cbytes, blocksize;
   void *output, *input;

--- a/tests/fuzz/fuzz_compress_frame.c
+++ b/tests/fuzz/fuzz_compress_frame.c
@@ -5,12 +5,14 @@
 
 #include <blosc2.h>
 
+#define ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
-  const char *compressors[] = { "blosclz", "lz4", "lz4hc", "zlib", "zstd" };
+  const char *const compressors[] = { "blosclz", "lz4", "lz4hc", "zlib", "zstd" };
   int32_t i = 0, dsize = 0, filter = BLOSC_BITSHUFFLE;
   int32_t nchunk = 0, max_chunksize = 512;
   int64_t nchunks = 0;

--- a/tests/test_common.h
+++ b/tests/test_common.h
@@ -49,6 +49,8 @@ extern int tests_run;
 #define MB  (1024*KB)
 #define GB  (1024*MB)
 
+#define ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
+
 /*
   Memory functions.
 */

--- a/tests/test_delete_chunk.c
+++ b/tests/test_delete_chunk.c
@@ -144,8 +144,8 @@ static char* test_delete_chunk(void) {
 
 static char *all_tests(void) {
 
-  for (int i = 0; i < (int) (sizeof(tstorage) / sizeof(test_storage)); ++i) {
-    for (int j = 0; j < (int) (sizeof(tndata) / sizeof(test_ndata)); ++j) {
+  for (int i = 0; i < (int) ARRAY_SIZE(tstorage); ++i) {
+    for (int j = 0; j < (int) ARRAY_SIZE(tndata); ++j) {
 
       tdata.contiguous = tstorage[i].contiguous;
       tdata.urlpath = tstorage[i].urlpath;

--- a/tests/test_frame.c
+++ b/tests/test_frame.c
@@ -274,7 +274,7 @@ static char* test_frame(void) {
 static char *all_tests(void) {
 
   // Iterate over all different parameters
-  for (int i = 0; i < (int)sizeof(nchunks_) / (int)sizeof(int); i++) {
+  for (int i = 0; i < (int) ARRAY_SIZE(nchunks_); i++) {
     nchunks = nchunks_[i];
     for (int isplits = 0; isplits < 2; isplits++) {
       for (int imultithread = 0; imultithread < 2; imultithread++) {
@@ -283,7 +283,7 @@ static char *all_tests(void) {
             for (int ifilter_pipeline = 0; ifilter_pipeline < 2; ifilter_pipeline++) {
               for (int imetalayers = 0; imetalayers < 2; imetalayers++) {
                 for (int ivlmetalayers = 0; ivlmetalayers < 2; ivlmetalayers++) {
-                  for (int iblocksize = 0; iblocksize < (int) (sizeof(blocksize_) / sizeof(int32_t)); ++iblocksize) {
+                  for (int iblocksize = 0; iblocksize < (int) ARRAY_SIZE(blocksize_); ++iblocksize) {
                         blocksize = blocksize_[iblocksize];
                         splits = (bool) isplits;
                         multithread = (bool) imultithread;

--- a/tests/test_get_slice_buffer.c
+++ b/tests/test_get_slice_buffer.c
@@ -135,8 +135,8 @@ static char* test_get_slice_buffer(void) {
 }
 
 static char *all_tests(void) {
-  for (int i = 0; i < (int) (sizeof(tstorage) / sizeof(test_storage)); ++i) {
-    for (int j = 0; j < (int) (sizeof(tndata) / sizeof(test_ndata)); ++j) {
+  for (int i = 0; i < (int) ARRAY_SIZE(tstorage); ++i) {
+    for (int j = 0; j < (int) ARRAY_SIZE(tndata); ++j) {
       tdata.contiguous = tstorage[i].contiguous;
       tdata.urlpath = tstorage[i].urlpath;
       tdata.nchunks = tndata[j].nchunks;

--- a/tests/test_insert_chunk.c
+++ b/tests/test_insert_chunk.c
@@ -170,9 +170,9 @@ static char* test_insert_chunk(void) {
 
 static char *all_tests(void) {
 
-  for (int i = 0; i < (int) (sizeof(tstorage) / sizeof(test_storage)); ++i) {
-    for (int j = 0; j < (int) (sizeof(tndata) / sizeof(test_ndata)); ++j) {
-      for (int k = 0; k < (int) (sizeof(tcopy) / sizeof(bool)); ++k) {
+  for (int i = 0; i < (int) ARRAY_SIZE(tstorage); ++i) {
+    for (int j = 0; j < (int) ARRAY_SIZE(tndata); ++j) {
+      for (int k = 0; k < (int) ARRAY_SIZE(tcopy); ++k) {
 
         tdata.contiguous = tstorage[i].contiguous;
         tdata.urlpath = tstorage[i].urlpath;

--- a/tests/test_reorder_offsets.c
+++ b/tests/test_reorder_offsets.c
@@ -102,8 +102,8 @@ static char* test_reorder_offsets(void) {
 
 static char *all_tests(void) {
 
-  for (int i = 0; i < (int) (sizeof(tstorage) / sizeof(test_storage)); ++i) {
-    for (int j = 0; j < (int) (sizeof(tnchunks) / sizeof(int32_t)); ++j) {
+  for (int i = 0; i < (int) ARRAY_SIZE(tstorage); ++i) {
+    for (int j = 0; j < (int) ARRAY_SIZE(tnchunks); ++j) {
 
       tdata.contiguous = tstorage[i].contiguous;
       tdata.urlpath = tstorage[i].urlpath;

--- a/tests/test_set_slice_buffer.c
+++ b/tests/test_set_slice_buffer.c
@@ -129,8 +129,8 @@ static char* test_set_slice_buffer(void) {
 }
 
 static char *all_tests(void) {
-  for (int i = 0; i < (int) (sizeof(tstorage) / sizeof(test_storage)); ++i) {
-    for (int j = 0; j < (int) (sizeof(tndata) / sizeof(test_ndata)); ++j) {
+  for (int i = 0; i < (int) ARRAY_SIZE(tstorage); ++i) {
+    for (int j = 0; j < (int) ARRAY_SIZE(tndata); ++j) {
       tdata.contiguous = tstorage[i].contiguous;
       tdata.urlpath = tstorage[i].urlpath;
       tdata.nchunks = tndata[j].nchunks;

--- a/tests/test_update_chunk.c
+++ b/tests/test_update_chunk.c
@@ -150,8 +150,8 @@ static char* test_update_chunk(void) {
 }
 
 static char *all_tests(void) {
-  for (int i = 0; i < (int) (sizeof(tstorage) / sizeof(test_storage)); ++i) {
-    for (int j = 0; j < (int) (sizeof(tndata) / sizeof(test_ndata)); ++j) {
+  for (int i = 0; i < (int) ARRAY_SIZE(tstorage); ++i) {
+    for (int j = 0; j < (int) ARRAY_SIZE(tndata); ++j) {
       tdata.contiguous = tstorage[i].contiguous;
       tdata.urlpath = tstorage[i].urlpath;
       tdata.nchunks = tndata[j].nchunks;


### PR DESCRIPTION
The resulting code is more readable.

Borrowed from the Linux kernel ([`include/linux/kernel.h`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/linux/kernel.h)).
[`ARRAY_SIZE(x)`](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/linux/kernel.h?id=890a3ee3ce416e2f1aed41718a8c1d42c82cf1b2#n52) returns the number of elements in array `x`.