### PR TITLE
Fix GCC compiler warning

### DIFF
--- a/tests/b2nd/cutest.h
+++ b/tests/b2nd/cutest.h
@@ -172,11 +172,9 @@ int _cutest_run(int (*test)(void), char *name) {
       snprintf(test_name, MAXLEN_TESTNAME, "%s%s[%d], ", aux, cutest_params[i].name,
                cutest_params_ind[i]);
     }
-    test_name[strlen(test_name) - 1] = 0;
-    strncpy(&test_name[strlen(test_name) - 1], ")", 1);
-    if (nparams == 0) {
-      test_name[strlen(test_name) - 1] = 0;
-    }
+    if (nparams > 0)
+      test_name[strlen(test_name) - 2] = ')';
+    test_name[strlen(test_name) - 1] = '\0';
     printf("%s ", test_name);
 
     cutest_total++;

--- a/tests/cutest.h
+++ b/tests/cutest.h
@@ -175,11 +175,9 @@ int _cutest_run(int (*test)(void *), void *test_data, char *name) {
       snprintf(test_name, MAXLEN_TESTNAME, "%s%s[%" PRId8 "], ", aux, cutest_params[i].name,
                cutest_params_ind[i]);
     }
-    test_name[strlen(test_name) - 1] = 0;
-    strncpy(&test_name[strlen(test_name) - 1], ")", 1);
-    if (nparams == 0) {
-      test_name[strlen(test_name) - 1] = 0;
-    }
+    if (nparams > 0)
+      test_name[strlen(test_name) - 2] = ')';
+    test_name[strlen(test_name) - 1] = '\0';
     printf("%s ", test_name);
 
     cutest_total++;


### PR DESCRIPTION
Fixes #501.
```
	/usr/include/x86_64-linux-gnu/bits/string_fortified.h:95:10: warning: ‘__builtin_strncpy’ output truncated before terminating nul copying 1 byte from a string of the same length [-Wstringop-truncation]
	   95 |   return __builtin___strncpy_chk (__dest, __src, __len,
	      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
	   96 |                                   __glibc_objsize (__dest));
	      |                                   ~~~~~~~~~~~~~~~~~~~~~~~~~
```