### PR TITLE
Clean up use of 'extern "C"' in header files

### DIFF
--- a/blosc/b2nd_utils.h
+++ b/blosc/b2nd_utils.h
@@ -14,10 +14,6 @@
 #include <b2nd.h>
 #include <../plugins/plugin_utils.h>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 
 int b2nd_copy_buffer(int8_t ndim,
                      uint8_t itemsize,
@@ -25,9 +21,5 @@ int b2nd_copy_buffer(int8_t ndim,
                      int64_t *src_start, const int64_t *src_stop,
                      void *dst, const int64_t *dst_pad_shape,
                      int64_t *dst_start);
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif  // B2ND_B2ND_UTILS_H_

--- a/blosc/bitshuffle-altivec.h
+++ b/blosc/bitshuffle-altivec.h
@@ -15,10 +15,6 @@
 
 #include "blosc2/blosc2-common.h"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 
 BLOSC_NO_EXPORT int64_t
     bshuf_trans_byte_elem_altivec(void* in, void* out, const size_t size,
@@ -45,10 +41,5 @@ BLOSC_NO_EXPORT int64_t
 BLOSC_NO_EXPORT int64_t
     bshuf_untrans_bit_elem_altivec(void* in, void* out, const size_t size,
                                 const size_t elem_size, void* tmp_buf);
-
-#ifdef __cplusplus
-}
-#endif
-
 
 #endif /* BITSHUFFLE_ALTIVEC_H */

--- a/blosc/bitshuffle-avx2.h
+++ b/blosc/bitshuffle-avx2.h
@@ -15,10 +15,6 @@
 
 #include <blosc2/blosc2-common.h>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /**
   AVX2-accelerated bitshuffle routine.
 */
@@ -32,9 +28,5 @@ BLOSC_NO_EXPORT int64_t
 BLOSC_NO_EXPORT int64_t
     bshuf_untrans_bit_elem_avx2(void* in, void* out, const size_t size,
                                 const size_t elem_size, void* tmp_buf);
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif /* BITSHUFFLE_AVX2_H */

--- a/blosc/bitshuffle-generic.h
+++ b/blosc/bitshuffle-generic.h
@@ -20,10 +20,6 @@
 #include <blosc2/blosc2-common.h>
 #include <stdlib.h>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 
 /*  Macros. */
 #define CHECK_MULT_EIGHT(n) if ((n) % 8) return -80;
@@ -157,10 +153,5 @@ bshuf_trans_bit_elem_scal(const void* in, void* out, const size_t size,
 BLOSC_NO_EXPORT int64_t
 bshuf_untrans_bit_elem_scal(const void* in, void* out, const size_t size,
                             const size_t elem_size, void* tmp_buf);
-
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif /* BITSHUFFLE_GENERIC_H */

--- a/blosc/bitshuffle-neon.h
+++ b/blosc/bitshuffle-neon.h
@@ -17,10 +17,6 @@
 
 #include "blosc2/blosc2-common.h"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /**
   NEON-accelerated bitshuffle routine.
 */
@@ -32,9 +28,5 @@ BLOSC_NO_EXPORT int64_t bitshuffle_neon(void* _src, void* _dest, const size_t bl
 */
 BLOSC_NO_EXPORT int64_t bitunshuffle_neon(void* _src, void* _dest, const size_t blocksize,
                                           const size_t bytesoftype, void* tmp_buf);
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif /* BITSHUFFLE_NEON_H */

--- a/blosc/bitshuffle-sse2.h
+++ b/blosc/bitshuffle-sse2.h
@@ -15,10 +15,6 @@
 
 #include "blosc2/blosc2-common.h"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 
 BLOSC_NO_EXPORT int64_t
     bshuf_trans_byte_elem_sse2(void* in, void* out, const size_t size,
@@ -45,10 +41,6 @@ BLOSC_NO_EXPORT int64_t
 BLOSC_NO_EXPORT int64_t
     bshuf_untrans_bit_elem_sse2(void* in, void* out, const size_t size,
                                 const size_t elem_size, void* tmp_buf);
-
-#ifdef __cplusplus
-}
-#endif
 
 
 #endif /* BITSHUFFLE_SSE2_H */

--- a/blosc/blosc-private.h
+++ b/blosc/blosc-private.h
@@ -12,10 +12,6 @@
 #ifndef IARRAY_BLOSC_PRIVATE_H
 #define IARRAY_BLOSC_PRIVATE_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include "stdbool.h"
 #include "blosc2.h"
 #include "blosc2/blosc2-common.h"
@@ -181,8 +177,5 @@ int fill_tuner(blosc2_tuner *tuner);
 
 extern blosc2_tuner g_tuners[256];
 extern int g_ntuners;
-#ifdef __cplusplus
-}
-#endif
 
 #endif //IARRAY_BLOSC_PRIVATE_H

--- a/blosc/blosclz.h
+++ b/blosc/blosclz.h
@@ -19,10 +19,6 @@
 #define BLOSCLZ_H
 #include "context.h"
 
-#if defined (__cplusplus)
-extern "C" {
-#endif
-
 #define BLOSCLZ_VERSION_STRING "2.5.3"
 
 
@@ -62,9 +58,5 @@ int blosclz_compress(int opt_level, const void* input, int length,
  */
 
 int blosclz_decompress(const void* input, int length, void* output, int maxout);
-
-#if defined (__cplusplus)
-}
-#endif
 
 #endif /* BLOSCLZ_H */

--- a/blosc/shuffle-altivec.h
+++ b/blosc/shuffle-altivec.h
@@ -15,10 +15,6 @@
 
 #include "blosc2/blosc2-common.h"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /**
   ALTIVEC-accelerated shuffle routine.
 */
@@ -30,9 +26,5 @@ BLOSC_NO_EXPORT void shuffle_altivec(const int32_t bytesoftype, const int32_t bl
 */
 BLOSC_NO_EXPORT void unshuffle_altivec(const int32_t bytesoftype, const int32_t blocksize,
                                        const uint8_t *_src, uint8_t *_dest);
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif /* SHUFFLE_ALTIVEC_H */

--- a/blosc/shuffle-avx2.h
+++ b/blosc/shuffle-avx2.h
@@ -15,10 +15,6 @@
 
 #include "blosc2/blosc2-common.h"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /**
   AVX2-accelerated shuffle routine.
 */
@@ -30,9 +26,5 @@ BLOSC_NO_EXPORT void shuffle_avx2(const int32_t bytesoftype, const int32_t block
 */
 BLOSC_NO_EXPORT void unshuffle_avx2(const int32_t bytesoftype, const int32_t blocksize,
                                     const uint8_t *_src, uint8_t *_dest);
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif /* SHUFFLE_AVX2_H */

--- a/blosc/shuffle-generic.h
+++ b/blosc/shuffle-generic.h
@@ -23,10 +23,6 @@
 #include "blosc2/blosc2-common.h"
 #include <stdlib.h>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /**
   Generic (non-hardware-accelerated) shuffle routine.
   This is the pure element-copying nested loop. It is used by the
@@ -94,9 +90,5 @@ BLOSC_NO_EXPORT void shuffle_generic(const int32_t bytesoftype, const int32_t bl
 */
 BLOSC_NO_EXPORT void unshuffle_generic(const int32_t bytesoftype, const int32_t blocksize,
                                        const uint8_t *_src, uint8_t *_dest);
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif /* SHUFFLE_GENERIC_H */

--- a/blosc/shuffle-neon.h
+++ b/blosc/shuffle-neon.h
@@ -17,10 +17,6 @@
 
 #include "blosc2/blosc2-common.h"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /**
   NEON-accelerated shuffle routine.
 */
@@ -32,9 +28,5 @@ BLOSC_NO_EXPORT void shuffle_neon(const int32_t bytesoftype, const int32_t block
 */
 BLOSC_NO_EXPORT void unshuffle_neon(const int32_t bytesoftype, const int32_t blocksize,
                                     const uint8_t *_src, uint8_t *_dest);
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif /* SHUFFLE_NEON_H */

--- a/blosc/shuffle-sse2.h
+++ b/blosc/shuffle-sse2.h
@@ -15,10 +15,6 @@
 
 #include "blosc2/blosc2-common.h"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /**
   SSE2-accelerated shuffle routine.
 */
@@ -30,9 +26,5 @@ BLOSC_NO_EXPORT void shuffle_sse2(const int32_t bytesoftype, const int32_t block
 */
 BLOSC_NO_EXPORT void unshuffle_sse2(const int32_t bytesoftype, const int32_t blocksize,
                                     const uint8_t *_src, uint8_t *_dest);
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif /* SHUFFLE_SSE2_H */

--- a/blosc/shuffle.h
+++ b/blosc/shuffle.h
@@ -41,10 +41,6 @@
 #define SHUFFLE_USE_NEON
 #endif
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /**
   Primary shuffle and bitshuffle routines.
   This function dynamically dispatches to the appropriate hardware-accelerated
@@ -83,9 +79,5 @@ BLOSC_NO_EXPORT int32_t
     bitunshuffle(const int32_t bytesoftype, const int32_t blocksize,
                  const uint8_t *_src, const uint8_t *_dest,
                  const uint8_t *_tmp, const uint8_t format_version);
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif /* SHUFFLE_H */

--- a/blosc/transpose-altivec.h
+++ b/blosc/transpose-altivec.h
@@ -11,10 +11,6 @@
 #ifndef BLOSC_TRANSPOSE_ALTIVEC_H
 #define BLOSC_TRANSPOSE_ALTIVEC_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 static const __vector uint8_t even = (const __vector uint8_t) {
   0x00, 0x02, 0x04, 0x06, 0x08, 0x0a, 0x0c, 0x0e,
   0x10, 0x12, 0x14, 0x16, 0x18, 0x1a, 0x1c, 0x1e};
@@ -112,10 +108,5 @@ static void transpose16x16(__vector uint8_t * xmm0){
     xmm0[k+8] = vec_perm(xmm1[k], xmm1[k+8], odd);
   }
 }
-
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif //BLOSC_TRANSPOSE_ALTIVEC_H

--- a/include/blosc2.h
+++ b/include/blosc2.h
@@ -20,15 +20,9 @@
 #ifndef BLOSC2_H
 #define BLOSC2_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
 #include "blosc2/blosc2-export.h"
 #include "blosc2/blosc2-common.h"
 #include "blosc2/blosc2-stdio.h"
-#ifdef __cplusplus
-}
-#endif
 
 #if defined(_WIN32) && !defined(__MINGW32__)
 #include <windows.h>

--- a/include/blosc2/blosc2-stdio.h
+++ b/include/blosc2/blosc2-stdio.h
@@ -25,6 +25,10 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct {
   FILE *file;
 } blosc2_stdio_file;
@@ -36,5 +40,9 @@ BLOSC_EXPORT int blosc2_stdio_seek(void *stream, int64_t offset, int whence);
 BLOSC_EXPORT int64_t blosc2_stdio_write(const void *ptr, int64_t size, int64_t nitems, void *stream);
 BLOSC_EXPORT int64_t blosc2_stdio_read(void *ptr, int64_t size, int64_t nitems, void *stream);
 BLOSC_EXPORT int blosc2_stdio_truncate(void *stream, int64_t size);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif //BLOSC_BLOSC2_STDIO_H

--- a/include/blosc2/codecs-registry.h
+++ b/include/blosc2/codecs-registry.h
@@ -8,6 +8,10 @@
   See LICENSE.txt for details about copyright and rights to use.
 **********************************************************************/
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 enum {
     BLOSC_CODEC_NDLZ = 32,
     BLOSC_CODEC_ZFP_FIXED_ACCURACY = 33,
@@ -25,3 +29,7 @@ typedef struct {
 
 // Silence unused codec_info typedef warning
 static codec_info codec_info_defaults BLOSC_ATTRIBUTE_UNUSED = {0};
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/blosc2/filters-registry.h
+++ b/include/blosc2/filters-registry.h
@@ -8,6 +8,10 @@
   See LICENSE.txt for details about copyright and rights to use.
 **********************************************************************/
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 enum {
     BLOSC_FILTER_NDCELL = 32,
     BLOSC_FILTER_NDMEAN = 33,
@@ -21,3 +25,7 @@ typedef struct {
     char *forward;
     char *backward;
 } filter_info;
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/blosc2/plugins-utils.h
+++ b/include/blosc2/plugins-utils.h
@@ -18,6 +18,10 @@
 #define popen _popen
 #define pclose _pclose
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 static struct {
     long lasterror;
     const char *err_rutin;
@@ -98,3 +102,7 @@ static inline void* load_lib(char *plugin_name, char *libpath) {
   }
   return loaded_lib;
 }
+
+#ifdef __cplusplus
+}
+#endif

--- a/include/blosc2/tuners-registry.h
+++ b/include/blosc2/tuners-registry.h
@@ -8,6 +8,10 @@
   See LICENSE.txt for details about copyright and rights to use.
 **********************************************************************/
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 enum {
     BLOSC_BTUNE = 32,
 };
@@ -22,3 +26,7 @@ typedef struct {
     char *update;
     char *free;
 } tuner_info;
+
+#ifdef __cplusplus
+}
+#endif

--- a/plugins/codecs/ndlz/ndlz-private.h
+++ b/plugins/codecs/ndlz/ndlz-private.h
@@ -15,9 +15,6 @@
 
 #include "context.h"
 
-#if defined (__cplusplus)
-extern "C" {
-#endif
 #define XXH_INLINE_ALL
 
 #define NDLZ_ERROR_NULL(pointer)         \
@@ -26,10 +23,5 @@ extern "C" {
       return 0;                    \
     }                                \
   } while (0)
-
-
-#if defined (__cplusplus)
-}
-#endif
 
 #endif /* NDLZ_PRIVATE_H */

--- a/plugins/codecs/zfp/blosc2-zfp.h
+++ b/plugins/codecs/zfp/blosc2-zfp.h
@@ -16,10 +16,6 @@
 #include "zfp-private.h"
 #include "../plugins/plugin_utils.h"
 
-#if defined (__cplusplus)
-extern "C" {
-#endif
-
 
 int zfp_acc_compress(const uint8_t *input, int32_t input_len, uint8_t *output, int32_t output_len,
                      uint8_t meta, blosc2_cparams *cparams, const void *chunk);
@@ -40,10 +36,5 @@ int zfp_rate_decompress(const uint8_t *input, int32_t input_len, uint8_t *output
                         uint8_t meta, blosc2_dparams *dparams, const void *chunk);
 
 int zfp_getcell(void *thread_context, const uint8_t *block, int32_t cbytes, uint8_t *dest, int32_t destsize);
-
-
-#if defined (__cplusplus)
-}
-#endif
 
 #endif /* BLOSC2_ZFP_H */

--- a/plugins/codecs/zfp/zfp-private.h
+++ b/plugins/codecs/zfp/zfp-private.h
@@ -16,10 +16,6 @@
 #define ZFP_MAX_DIM 4
 #define ZFP_CELL_SHAPE 4
 
-
-#if defined (__cplusplus)
-extern "C" {
-#endif
 #define XXH_INLINE_ALL
 
 #define ZFP_ERROR_NULL(pointer)         \
@@ -28,10 +24,5 @@ extern "C" {
       return 0;                    \
     }                                \
   } while (0)
-
-
-#if defined (__cplusplus)
-}
-#endif
 
 #endif /* ZFP_PRIVATE_H */


### PR DESCRIPTION
Private header files are only seen by the C compiler that builds the library. They don't need `extern "C"`.

Public header files can be seen by a C++ compiler. They do need the `extern "C"`. And it's best done individually in each public header file. On the other hand, header files that just use directives of the preprocessor need not `extern "C"`.