### PR TITLE
Forgot to pclose() in all cases in ca60217

### DIFF
--- a/include/blosc2/plugins-utils.h
+++ b/include/blosc2/plugins-utils.h
@@ -82,6 +82,7 @@ static inline void* load_lib(char *plugin_name, char *libpath) {
   }
   if (fgets(libpath, PATH_MAX, fp) == NULL) {
     BLOSC_TRACE_ERROR("Could not read python output");
+    pclose(fp);
     return NULL;
   }
   pclose(fp);


### PR DESCRIPTION
Error handling would be easier and more readable with `goto`. It helps release resources in the right order at the end of the function with a single return point. The alternative would be a bunch of nested `if`'s which impair readability and result in very long liens because of indention.

See for example:
* [MEM12-C. Consider using a goto chain when leaving a function on error when using and releasing resources](https://wiki.sei.cmu.edu/confluence/display/c/MEM12-C.+Consider+using+a+goto+chain+when+leaving+a+function+on+error+when+using+and+releasing+resources)
* https://lkml.org/lkml/2003/1/12/203