### PR TITLE
Clean up existing header guards, add missing ones

### DIFF
--- a/blosc/b2nd_utils.h
+++ b/blosc/b2nd_utils.h
@@ -8,8 +8,8 @@
   See LICENSE.txt for details about copyright and rights to use.
 **********************************************************************/
 
-#ifndef B2ND_B2ND_UTILS_H_
-#define B2ND_B2ND_UTILS_H_
+#ifndef BLOSC_B2ND_UTILS_H
+#define BLOSC_B2ND_UTILS_H
 
 #include <b2nd.h>
 #include <../plugins/plugin_utils.h>
@@ -22,4 +22,4 @@ int b2nd_copy_buffer(int8_t ndim,
                      void *dst, const int64_t *dst_pad_shape,
                      int64_t *dst_start);
 
-#endif  // B2ND_B2ND_UTILS_H_
+#endif /* BLOSC_B2ND_UTILS_H */

--- a/blosc/bitshuffle-altivec.h
+++ b/blosc/bitshuffle-altivec.h
@@ -10,8 +10,8 @@
 
 /* ALTIVEC-accelerated shuffle/unshuffle routines. */
 
-#ifndef BITSHUFFLE_ALTIVEC_H
-#define BITSHUFFLE_ALTIVEC_H
+#ifndef BLOSC_BITSHUFFLE_ALTIVEC_H
+#define BLOSC_BITSHUFFLE_ALTIVEC_H
 
 #include "blosc2/blosc2-common.h"
 
@@ -42,4 +42,4 @@ BLOSC_NO_EXPORT int64_t
     bshuf_untrans_bit_elem_altivec(void* in, void* out, const size_t size,
                                 const size_t elem_size, void* tmp_buf);
 
-#endif /* BITSHUFFLE_ALTIVEC_H */
+#endif /* BLOSC_BITSHUFFLE_ALTIVEC_H */

--- a/blosc/bitshuffle-avx2.h
+++ b/blosc/bitshuffle-avx2.h
@@ -10,8 +10,8 @@
 
 /* AVX2-accelerated shuffle/unshuffle routines. */
 
-#ifndef BITSHUFFLE_AVX2_H
-#define BITSHUFFLE_AVX2_H
+#ifndef BLOSC_BITSHUFFLE_AVX2_H
+#define BLOSC_BITSHUFFLE_AVX2_H
 
 #include <blosc2/blosc2-common.h>
 
@@ -29,4 +29,4 @@ BLOSC_NO_EXPORT int64_t
     bshuf_untrans_bit_elem_avx2(void* in, void* out, const size_t size,
                                 const size_t elem_size, void* tmp_buf);
 
-#endif /* BITSHUFFLE_AVX2_H */
+#endif /* BLOSC_BITSHUFFLE_AVX2_H */

--- a/blosc/bitshuffle-generic.h
+++ b/blosc/bitshuffle-generic.h
@@ -14,8 +14,8 @@
    accelerated functions to handle any remaining elements in a block
    which isn't a multiple of the hardware's vector size. */
 
-#ifndef BITSHUFFLE_GENERIC_H
-#define BITSHUFFLE_GENERIC_H
+#ifndef BLOSC_BITSHUFFLE_GENERIC_H
+#define BLOSC_BITSHUFFLE_GENERIC_H
 
 #include <blosc2/blosc2-common.h>
 #include <stdlib.h>
@@ -154,4 +154,4 @@ BLOSC_NO_EXPORT int64_t
 bshuf_untrans_bit_elem_scal(const void* in, void* out, const size_t size,
                             const size_t elem_size, void* tmp_buf);
 
-#endif /* BITSHUFFLE_GENERIC_H */
+#endif /* BLOSC_BITSHUFFLE_GENERIC_H */

--- a/blosc/bitshuffle-neon.h
+++ b/blosc/bitshuffle-neon.h
@@ -12,8 +12,8 @@
 
 /* NEON-accelerated bitshuffle/bitunshuffle routines. */
 
-#ifndef BITSHUFFLE_NEON_H
-#define BITSHUFFLE_NEON_H
+#ifndef BLOSC_BITSHUFFLE_NEON_H
+#define BLOSC_BITSHUFFLE_NEON_H
 
 #include "blosc2/blosc2-common.h"
 
@@ -29,4 +29,4 @@ BLOSC_NO_EXPORT int64_t bitshuffle_neon(void* _src, void* _dest, const size_t bl
 BLOSC_NO_EXPORT int64_t bitunshuffle_neon(void* _src, void* _dest, const size_t blocksize,
                                           const size_t bytesoftype, void* tmp_buf);
 
-#endif /* BITSHUFFLE_NEON_H */
+#endif /* BLOSC_BITSHUFFLE_NEON_H */

--- a/blosc/bitshuffle-sse2.h
+++ b/blosc/bitshuffle-sse2.h
@@ -10,8 +10,8 @@
 
 /* SSE2-accelerated shuffle/unshuffle routines. */
 
-#ifndef BITSHUFFLE_SSE2_H
-#define BITSHUFFLE_SSE2_H
+#ifndef BLOSC_BITSHUFFLE_SSE2_H
+#define BLOSC_BITSHUFFLE_SSE2_H
 
 #include "blosc2/blosc2-common.h"
 
@@ -43,4 +43,4 @@ BLOSC_NO_EXPORT int64_t
                                 const size_t elem_size, void* tmp_buf);
 
 
-#endif /* BITSHUFFLE_SSE2_H */
+#endif /* BLOSC_BITSHUFFLE_SSE2_H */

--- a/blosc/blosc-private.h
+++ b/blosc/blosc-private.h
@@ -9,8 +9,8 @@
 **********************************************************************/
 
 
-#ifndef IARRAY_BLOSC_PRIVATE_H
-#define IARRAY_BLOSC_PRIVATE_H
+#ifndef BLOSC_BLOSC_PRIVATE_H
+#define BLOSC_BLOSC_PRIVATE_H
 
 #include "stdbool.h"
 #include "blosc2.h"
@@ -178,4 +178,4 @@ int fill_tuner(blosc2_tuner *tuner);
 extern blosc2_tuner g_tuners[256];
 extern int g_ntuners;
 
-#endif //IARRAY_BLOSC_PRIVATE_H
+#endif /* BLOSC_BLOSC_PRIVATE_H */

--- a/blosc/blosclz.h
+++ b/blosc/blosclz.h
@@ -15,8 +15,9 @@
 **********************************************************************/
 
 
-#ifndef BLOSCLZ_H
-#define BLOSCLZ_H
+#ifndef BLOSC_BLOSCLZ_H
+#define BLOSC_BLOSCLZ_H
+
 #include "context.h"
 
 #define BLOSCLZ_VERSION_STRING "2.5.3"
@@ -59,4 +60,4 @@ int blosclz_compress(int opt_level, const void* input, int length,
 
 int blosclz_decompress(const void* input, int length, void* output, int maxout);
 
-#endif /* BLOSCLZ_H */
+#endif /* BLOSC_BLOSCLZ_H */

--- a/blosc/context.h
+++ b/blosc/context.h
@@ -8,8 +8,8 @@
   See LICENSE.txt for details about copyright and rights to use.
 **********************************************************************/
 
-#ifndef CONTEXT_H
-#define CONTEXT_H
+#ifndef BLOSC_CONTEXT_H
+#define BLOSC_CONTEXT_H
 
 #if defined(_WIN32) && !defined(__GNUC__)
   #include "win32/pthread.h"
@@ -149,4 +149,4 @@ struct thread_context {
 };
 
 
-#endif  /* CONTEXT_H */
+#endif  /* BLOSC_CONTEXT_H */

--- a/blosc/delta.h
+++ b/blosc/delta.h
@@ -20,4 +20,4 @@ void delta_encoder(const uint8_t* dref, int32_t offset, int32_t nbytes,
 void delta_decoder(const uint8_t* dref, int32_t offset, int32_t nbytes,
                    int32_t typesize, uint8_t* dest);
 
-#endif //BLOSC_DELTA_H
+#endif /* BLOSC_DELTA_H */

--- a/blosc/fastcopy.h
+++ b/blosc/fastcopy.h
@@ -17,4 +17,4 @@ unsigned char *fastcopy(unsigned char *out, const unsigned char *from, unsigned 
 /* Same as fastcopy() but without overwriting origin or destination when they overlap */
 unsigned char* copy_match(unsigned char *out, const unsigned char *from, unsigned len);
 
-#endif //BLOSC_FASTCOPY_H
+#endif /* BLOSC_FASTCOPY_H */

--- a/blosc/frame.h
+++ b/blosc/frame.h
@@ -168,4 +168,4 @@ int frame_update_trailer(blosc2_frame_s* frame, blosc2_schunk* schunk);
 int64_t frame_fill_special(blosc2_frame_s* frame, int64_t nitems, int special_value,
                        int32_t chunksize, blosc2_schunk* schunk);
 
-#endif //BLOSC_FRAME_H
+#endif /* BLOSC_FRAME_H */

--- a/blosc/sframe.h
+++ b/blosc/sframe.h
@@ -17,4 +17,4 @@ int sframe_delete_chunk(const char* urlpath, int64_t nchunk);
 void* sframe_create_chunk(blosc2_frame_s* frame, uint8_t* chunk, int64_t nchunk, int64_t cbytes);
 int32_t sframe_get_chunk(blosc2_frame_s* frame, int64_t nchunk, uint8_t** chunk, bool* needs_free);
 
-#endif //BLOSC_SFRAME_H
+#endif /* BLOSC_SFRAME_H */

--- a/blosc/shuffle-altivec.h
+++ b/blosc/shuffle-altivec.h
@@ -10,8 +10,8 @@
 
 /* ALTIVEC-accelerated shuffle/unshuffle routines. */
 
-#ifndef SHUFFLE_ALTIVEC_H
-#define SHUFFLE_ALTIVEC_H
+#ifndef BLOSC_SHUFFLE_ALTIVEC_H
+#define BLOSC_SHUFFLE_ALTIVEC_H
 
 #include "blosc2/blosc2-common.h"
 
@@ -27,4 +27,4 @@ BLOSC_NO_EXPORT void shuffle_altivec(const int32_t bytesoftype, const int32_t bl
 BLOSC_NO_EXPORT void unshuffle_altivec(const int32_t bytesoftype, const int32_t blocksize,
                                        const uint8_t *_src, uint8_t *_dest);
 
-#endif /* SHUFFLE_ALTIVEC_H */
+#endif /* BLOSC_SHUFFLE_ALTIVEC_H */

--- a/blosc/shuffle-generic.h
+++ b/blosc/shuffle-generic.h
@@ -17,8 +17,8 @@
 **********************************************************************/
 
 
-#ifndef SHUFFLE_GENERIC_H
-#define SHUFFLE_GENERIC_H
+#ifndef BLOSC_SHUFFLE_GENERIC_H
+#define BLOSC_SHUFFLE_GENERIC_H
 
 #include "blosc2/blosc2-common.h"
 #include <stdlib.h>
@@ -91,4 +91,4 @@ BLOSC_NO_EXPORT void shuffle_generic(const int32_t bytesoftype, const int32_t bl
 BLOSC_NO_EXPORT void unshuffle_generic(const int32_t bytesoftype, const int32_t blocksize,
                                        const uint8_t *_src, uint8_t *_dest);
 
-#endif /* SHUFFLE_GENERIC_H */
+#endif /* BLOSC_SHUFFLE_GENERIC_H */

--- a/blosc/shuffle-neon.h
+++ b/blosc/shuffle-neon.h
@@ -12,8 +12,8 @@
 
 /* NEON-accelerated shuffle/unshuffle routines. */
 
-#ifndef SHUFFLE_NEON_H
-#define SHUFFLE_NEON_H
+#ifndef BLOSC_SHUFFLE_NEON_H
+#define BLOSC_SHUFFLE_NEON_H
 
 #include "blosc2/blosc2-common.h"
 
@@ -29,4 +29,4 @@ BLOSC_NO_EXPORT void shuffle_neon(const int32_t bytesoftype, const int32_t block
 BLOSC_NO_EXPORT void unshuffle_neon(const int32_t bytesoftype, const int32_t blocksize,
                                     const uint8_t *_src, uint8_t *_dest);
 
-#endif /* SHUFFLE_NEON_H */
+#endif /* BLOSC_SHUFFLE_NEON_H */

--- a/blosc/shuffle-sse2.h
+++ b/blosc/shuffle-sse2.h
@@ -10,8 +10,8 @@
 
 /* SSE2-accelerated shuffle/unshuffle routines. */
 
-#ifndef SHUFFLE_SSE2_H
-#define SHUFFLE_SSE2_H
+#ifndef BLOSC_SHUFFLE_SSE2_H
+#define BLOSC_SHUFFLE_SSE2_H
 
 #include "blosc2/blosc2-common.h"
 
@@ -27,4 +27,4 @@ BLOSC_NO_EXPORT void shuffle_sse2(const int32_t bytesoftype, const int32_t block
 BLOSC_NO_EXPORT void unshuffle_sse2(const int32_t bytesoftype, const int32_t blocksize,
                                     const uint8_t *_src, uint8_t *_dest);
 
-#endif /* SHUFFLE_SSE2_H */
+#endif /* BLOSC_SHUFFLE_SSE2_H */

--- a/blosc/shuffle.h
+++ b/blosc/shuffle.h
@@ -17,8 +17,8 @@
 **********************************************************************/
 
 
-#ifndef SHUFFLE_H
-#define SHUFFLE_H
+#ifndef BLOSC_SHUFFLE_H
+#define BLOSC_SHUFFLE_H
 
 #include "blosc2/blosc2-common.h"
 
@@ -80,4 +80,4 @@ BLOSC_NO_EXPORT int32_t
                  const uint8_t *_src, const uint8_t *_dest,
                  const uint8_t *_tmp, const uint8_t format_version);
 
-#endif /* SHUFFLE_H */
+#endif /* BLOSC_SHUFFLE_H */

--- a/blosc/stune.h
+++ b/blosc/stune.h
@@ -8,8 +8,8 @@
   See LICENSE.txt for details about copyright and rights to use.
 **********************************************************************/
 
-#ifndef STUNE_H
-#define STUNE_H
+#ifndef BLOSC_STUNE_H
+#define BLOSC_STUNE_H
 
 #include "context.h"
 
@@ -37,4 +37,4 @@ void blosc_stune_free(blosc2_context * context);
 /* Conditions for splitting a block before compressing with a codec. */
 int split_block(blosc2_context *context, int32_t typesize, int32_t blocksize);
 
-#endif  /* STUNE_H */
+#endif  /* BLOSC_STUNE_H */

--- a/blosc/transpose-altivec.h
+++ b/blosc/transpose-altivec.h
@@ -109,4 +109,4 @@ static void transpose16x16(__vector uint8_t * xmm0){
   }
 }
 
-#endif //BLOSC_TRANSPOSE_ALTIVEC_H
+#endif /* BLOSC_TRANSPOSE_ALTIVEC_H */

--- a/blosc/trunc-prec.h
+++ b/blosc/trunc-prec.h
@@ -17,4 +17,4 @@
 int truncate_precision(int8_t prec_bits, int32_t typesize, int32_t nbytes,
                        const uint8_t* src, uint8_t* dest);
 
-#endif //BLOSC_TRUNC_PREC_H
+#endif /* BLOSC_TRUNC_PREC_H */

--- a/include/b2nd.h
+++ b/include/b2nd.h
@@ -15,8 +15,8 @@
  * @author Blosc Development Team <blosc@blosc.org>
  */
 
-#ifndef B2ND_B2ND_H_
-#define B2ND_B2ND_H_
+#ifndef BLOSC_B2ND_H
+#define BLOSC_B2ND_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -603,4 +603,4 @@ static inline int b2nd_deserialize_meta(
 }
 #endif
 
-#endif  // B2ND_B2ND_H_
+#endif  /* BLOSC_B2ND_H */

--- a/include/blosc2.h
+++ b/include/blosc2.h
@@ -16,9 +16,8 @@
   @author The Blosc Development Team <blosc@blosc.org>
 **********************************************************************/
 
-
-#ifndef BLOSC2_H
-#define BLOSC2_H
+#ifndef BLOSC_BLOSC2_H
+#define BLOSC_BLOSC2_H
 
 #include "blosc2/blosc2-export.h"
 #include "blosc2/blosc2-common.h"
@@ -2479,5 +2478,4 @@ BLOSC_EXPORT void blosc2_multidim_to_unidim(const int64_t *index, int8_t ndim, c
 }
 #endif
 
-
-#endif  /* BLOSC2_H */
+#endif /* BLOSC_BLOSC2_H */

--- a/include/blosc2/blosc2-common.h
+++ b/include/blosc2/blosc2-common.h
@@ -8,8 +8,8 @@
   See LICENSE.txt for details about copyright and rights to use.
 **********************************************************************/
 
-#ifndef SHUFFLE_COMMON_H
-#define SHUFFLE_COMMON_H
+#ifndef BLOSC_BLOSC2_BLOSC2_COMMON_H
+#define BLOSC_BLOSC2_BLOSC2_COMMON_H
 
 #include "blosc2-export.h"
 
@@ -77,4 +77,4 @@
   #include <immintrin.h>
 #endif
 
-#endif  /* SHUFFLE_COMMON_H */
+#endif  /* BLOSC_BLOSC2_BLOSC2_COMMON_H */

--- a/include/blosc2/blosc2-export.h
+++ b/include/blosc2/blosc2-export.h
@@ -8,8 +8,8 @@
   See LICENSE.txt for details about copyright and rights to use.
 **********************************************************************/
 
-#ifndef BLOSC_EXPORT_H
-#define BLOSC_EXPORT_H
+#ifndef BLOSC_BLOSC2_BLOSC2_EXPORT_H
+#define BLOSC_BLOSC2_BLOSC2_EXPORT_H
 
 /* Macros for specifying exported symbols.
    BLOSC_EXPORT is used to decorate symbols that should be
@@ -45,4 +45,4 @@
   #define BLOSC_NO_EXPORT BLOSC_EXPORT
 #endif  /* defined(BLOSC_TESTING) */
 
-#endif  /* BLOSC_EXPORT_H */
+#endif /* BLOSC_BLOSC2_BLOSC2_EXPORT_H */

--- a/include/blosc2/blosc2-stdio.h
+++ b/include/blosc2/blosc2-stdio.h
@@ -8,10 +8,8 @@
   See LICENSE.txt for details about copyright and rights to use.
 **********************************************************************/
 
-
-#ifndef BLOSC_BLOSC2_STDIO_H
-#define BLOSC_BLOSC2_STDIO_H
-
+#ifndef BLOSC_BLOSC2_BLOSC2_STDIO_H
+#define BLOSC_BLOSC2_BLOSC2_STDIO_H
 
 #include "blosc2-export.h"
 
@@ -45,4 +43,4 @@ BLOSC_EXPORT int blosc2_stdio_truncate(void *stream, int64_t size);
 }
 #endif
 
-#endif //BLOSC_BLOSC2_STDIO_H
+#endif /* BLOSC_BLOSC2_BLOSC2_STDIO_H */

--- a/include/blosc2/codecs-registry.h
+++ b/include/blosc2/codecs-registry.h
@@ -8,6 +8,9 @@
   See LICENSE.txt for details about copyright and rights to use.
 **********************************************************************/
 
+#ifndef BLOSC_BLOSC2_CODECS_REGISTRY_H
+#define BLOSC_BLOSC2_CODECS_REGISTRY_H
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -33,3 +36,5 @@ static codec_info codec_info_defaults BLOSC_ATTRIBUTE_UNUSED = {0};
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* BLOSC_BLOSC2_CODECS_REGISTRY_H */

--- a/include/blosc2/filters-registry.h
+++ b/include/blosc2/filters-registry.h
@@ -8,6 +8,9 @@
   See LICENSE.txt for details about copyright and rights to use.
 **********************************************************************/
 
+#ifndef BLOSC_BLOSC2_FILTERS_REGISTRY_H
+#define BLOSC_BLOSC2_FILTERS_REGISTRY_H
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -29,3 +32,5 @@ typedef struct {
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* BLOSC_BLOSC2_FILTERS_REGISTRY_H */

--- a/include/blosc2/plugins-utils.h
+++ b/include/blosc2/plugins-utils.h
@@ -8,6 +8,8 @@
   See LICENSE.txt for details about copyright and rights to use.
 **********************************************************************/
 
+#ifndef BLOSC_BLOSC2_PLUGINS_UTILS_H
+#define BLOSC_BLOSC2_PLUGINS_UTILS_H
 
 #include <blosc2.h>
 
@@ -107,3 +109,5 @@ static inline void* load_lib(char *plugin_name, char *libpath) {
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* BLOSC_BLOSC2_PLUGINS_UTILS_H */

--- a/include/blosc2/tuners-registry.h
+++ b/include/blosc2/tuners-registry.h
@@ -8,6 +8,9 @@
   See LICENSE.txt for details about copyright and rights to use.
 **********************************************************************/
 
+#ifndef BLOSC_BLOSC2_TUNERS_UTILS_H
+#define BLOSC_BLOSC2_TUNERS_UTILS_H
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -30,3 +33,5 @@ typedef struct {
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* BLOSC_BLOSC2_TUNERS_UTILS_H */

--- a/plugins/codecs/ndlz/ndlz-private.h
+++ b/plugins/codecs/ndlz/ndlz-private.h
@@ -8,8 +8,6 @@
   See LICENSE.txt for details about copyright and rights to use.
 **********************************************************************/
 
-
-
 #ifndef NDLZ_PRIVATE_H
 #define NDLZ_PRIVATE_H
 

--- a/plugins/codecs/ndlz/ndlz.h
+++ b/plugins/codecs/ndlz/ndlz.h
@@ -8,15 +8,10 @@
   See LICENSE.txt for details about copyright and rights to use.
 **********************************************************************/
 
+#ifndef BLOSC_PLUGINS_CODECS_NDLZ_NDLZ_H
+#define BLOSC_PLUGINS_CODECS_NDLZ_NDLZ_H
 
-
-#ifndef NDLZ_H
-#define NDLZ_H
 #include "context.h"
-
-#if defined (__cplusplus)
-extern "C" {
-#endif
 
 int ndlz_compress(const uint8_t *input, int32_t input_len, uint8_t *output, int32_t output_len,
                   uint8_t meta, blosc2_cparams *cparams, const void* chunk);
@@ -24,8 +19,4 @@ int ndlz_compress(const uint8_t *input, int32_t input_len, uint8_t *output, int3
 int ndlz_decompress(const uint8_t *input, int32_t input_len, uint8_t *output, int32_t output_len,
                     uint8_t meta, blosc2_dparams *dparams, const void* chunk);
 
-#if defined (__cplusplus)
-}
-#endif
-
-#endif /* NDLZ_H */
+#endif /* BLOSC_PLUGINS_CODECS_NDLZ_NDLZ_H */

--- a/plugins/codecs/ndlz/ndlz4x4.h
+++ b/plugins/codecs/ndlz/ndlz4x4.h
@@ -8,24 +8,18 @@
   See LICENSE.txt for details about copyright and rights to use.
 **********************************************************************/
 
+#ifndef BLOSC_PLUGINS_CODECS_NDLZ_NDLZ4X4_H
+#define BLOSC_PLUGINS_CODECS_NDLZ_NDLZ4X4_H
 
-
-#ifndef NDLZ4_H
-#define NDLZ4_H
+#include "ndlz-private.h"
+#include "ndlz.h"
 #include "context.h"
 
-#if defined (__cplusplus)
-extern "C" {
-#endif
-#include "ndlz.h"
-#include "ndlz-private.h"
 /*
 #include <stdio.h>
 #include "blosc2/blosc2-common.h"
 #include "fastcopy.h"
 */
-
-
 
 /**
   Compress a block of data in the input buffer and returns the size of
@@ -65,8 +59,4 @@ int ndlz4_compress(const uint8_t *input, int32_t input_len, uint8_t *output, int
 int ndlz4_decompress(const uint8_t *input, int32_t input_len, uint8_t *output, int32_t output_len,
                      uint8_t meta, blosc2_dparams *dparams);
 
-#if defined (__cplusplus)
-}
-#endif
-
-#endif /* NDLZ4_H */
+#endif /* BLOSC_PLUGINS_CODECS_NDLZ_NDLZ4X4_H */

--- a/plugins/codecs/ndlz/ndlz8x8.h
+++ b/plugins/codecs/ndlz/ndlz8x8.h
@@ -8,17 +8,12 @@
   See LICENSE.txt for details about copyright and rights to use.
 **********************************************************************/
 
-#ifndef NDLZ8_H
-#define NDLZ8_H
+#ifndef BLOSC_PLUGINS_CODECS_NDLZ_NDLZ8X8_H
+#define BLOSC_PLUGINS_CODECS_NDLZ_NDLZ8X8_H
 
-#include "context.h"
-
-#if defined (__cplusplus)
-extern "C" {
-#endif
-
-#include "ndlz.h"
 #include "ndlz-private.h"
+#include "ndlz.h"
+#include "context.h"
 
 /**
   Compress a block of data in the input buffer and returns the size of
@@ -58,8 +53,4 @@ int ndlz8_compress(const uint8_t *input, int32_t input_len, uint8_t *output, int
 int ndlz8_decompress(const uint8_t *input, int32_t input_len, uint8_t *output, int32_t output_len,
                      uint8_t meta, blosc2_dparams *dparams);
 
-#if defined (__cplusplus)
-}
-#endif
-
-#endif /* NDLZ8_H */
+#endif /* BLOSC_PLUGINS_CODECS_NDLZ_NDLZ8X8_H */

--- a/plugins/codecs/zfp/blosc2-zfp.h
+++ b/plugins/codecs/zfp/blosc2-zfp.h
@@ -8,10 +8,8 @@
   See LICENSE.txt for details about copyright and rights to use.
 **********************************************************************/
 
-
-
-#ifndef BLOSC2_ZFP_H
-#define BLOSC2_ZFP_H
+#ifndef BLOSC_PLUGINS_CODECS_ZFP_BLOSC2_ZFP_H
+#define BLOSC_PLUGINS_CODECS_ZFP_BLOSC2_ZFP_H
 
 #include "zfp-private.h"
 #include "../plugins/plugin_utils.h"
@@ -37,4 +35,4 @@ int zfp_rate_decompress(const uint8_t *input, int32_t input_len, uint8_t *output
 
 int zfp_getcell(void *thread_context, const uint8_t *block, int32_t cbytes, uint8_t *dest, int32_t destsize);
 
-#endif /* BLOSC2_ZFP_H */
+#endif /* BLOSC_PLUGINS_CODECS_ZFP_BLOSC2_ZFP_H */

--- a/plugins/codecs/zfp/zfp-private.h
+++ b/plugins/codecs/zfp/zfp-private.h
@@ -8,10 +8,8 @@
   See LICENSE.txt for details about copyright and rights to use.
 **********************************************************************/
 
-
-
-#ifndef ZFP_PRIVATE_H
-#define ZFP_PRIVATE_H
+#ifndef BLOSC_PLUGINS_CODECS_ZFP_ZFP_PRIVATE_H
+#define BLOSC_PLUGINS_CODECS_ZFP_ZFP_PRIVATE_H
 
 #define ZFP_MAX_DIM 4
 #define ZFP_CELL_SHAPE 4
@@ -25,4 +23,4 @@
     }                                \
   } while (0)
 
-#endif /* ZFP_PRIVATE_H */
+#endif /* BLOSC_PLUGINS_CODECS_ZFP_ZFP_PRIVATE_H */

--- a/plugins/filters/bytedelta/bytedelta.h
+++ b/plugins/filters/bytedelta/bytedelta.h
@@ -8,7 +8,9 @@
   See LICENSE.txt for details about copyright and rights to use.
 **********************************************************************/
 
-#pragma once
+#ifndef BLOSC_PLUGINS_FILTERS_BYTEDELTA_BYTEDELTA_H
+#define BLOSC_PLUGINS_FILTERS_BYTEDELTA_BYTEDELTA_H
+
 #include <stdint.h>
 #include <blosc2.h>
 
@@ -17,3 +19,5 @@ int bytedelta_forward(const uint8_t* input, uint8_t* output, int32_t length, uin
 
 int bytedelta_backward(const uint8_t* input, uint8_t* output, int32_t length, uint8_t meta,
                       blosc2_dparams* dparams, uint8_t id);
+
+#endif /* BLOSC_PLUGINS_FILTERS_BYTEDELTA_BYTEDELTA_H*/

--- a/plugins/filters/ndcell/ndcell.h
+++ b/plugins/filters/ndcell/ndcell.h
@@ -8,8 +8,8 @@
   See LICENSE.txt for details about copyright and rights to use.
 **********************************************************************/
 
-#ifndef B2ND_NDCELL_H
-#define B2ND_NDCELL_H
+#ifndef BLOSC_PLUGINS_FILTERS_NDCELL_NDCELL_H
+#define BLOSC_PLUGINS_FILTERS_NDCELL_NDCELL_H
 
 #include <blosc2.h>
 
@@ -20,6 +20,4 @@ int ndcell_forward(const uint8_t* input, uint8_t* output, int32_t length, uint8_
 
 int ndcell_backward(const uint8_t* input, uint8_t* output, int32_t length, uint8_t meta, blosc2_dparams* dparams, uint8_t id);
 
-#endif //B2ND_NDCELL_H
-
-
+#endif /* BLOSC_PLUGINS_FILTERS_NDCELL_NDCELL_H */

--- a/plugins/filters/ndmean/ndmean.h
+++ b/plugins/filters/ndmean/ndmean.h
@@ -8,8 +8,8 @@
   See LICENSE.txt for details about copyright and rights to use.
 **********************************************************************/
 
-#ifndef B2ND_NDMEAN_H
-#define B2ND_NDMEAN_H
+#ifndef BLOSC_PLUGINS_FILTERS_NDMEAN_NDMEAN_H
+#define BLOSC_PLUGINS_FILTERS_NDMEAN_NDMEAN_H
 
 #include "blosc2.h"
 
@@ -20,6 +20,4 @@ int ndmean_forward(const uint8_t* input, uint8_t* output, int32_t length, uint8_
 
 int ndmean_backward(const uint8_t* input, uint8_t* output, int32_t length, uint8_t meta, blosc2_dparams* dparams, uint8_t id);
 
-#endif //B2ND_NDMEAN_H
-
-
+#endif /* BLOSC_PLUGINS_FILTERS_NDMEAN_NDMEAN_H */

--- a/plugins/plugin_utils.h
+++ b/plugins/plugin_utils.h
@@ -4,7 +4,12 @@
   License: BSD 3-Clause (see LICENSE.txt)
 */
 
+#ifndef BLOSC_PLUGINS_PLUGIN_UTILS_H
+#define BLOSC_PLUGINS_PLUGIN_UTILS_H
+
 #include <stdint.h>
 
 int32_t deserialize_meta(uint8_t *smeta, int32_t smeta_len, int8_t *ndim, int64_t *shape,
                          int32_t *chunkshape, int32_t *blockshape);
+
+#endif /* BLOSC_PLUGINS_PLUGIN_UTILS_H */

--- a/tests/b2nd/test_common.h
+++ b/tests/b2nd/test_common.h
@@ -8,8 +8,8 @@
   See LICENSE.txt for details about copyright and rights to use.
 **********************************************************************/
 
-#ifndef B2ND_TEST_COMMON_H
-#define B2ND_TEST_COMMON_H
+#ifndef BLOSC_TESTS_B2ND_TEST_COMMON_H
+#define BLOSC_TESTS_B2ND_TEST_COMMON_H
 
 #include <b2nd.h>
 #include "context.h"
@@ -96,4 +96,4 @@ void b2nd_default_parameters() {
     }
 
 
-#endif //B2ND_TEST_COMMON_H
+#endif /* BLOSC_TESTS_B2ND_TEST_COMMON_H */

--- a/tests/cutest.h
+++ b/tests/cutest.h
@@ -8,8 +8,8 @@
   See LICENSE.txt for details about copyright and rights to use.
 **********************************************************************/
 
-#ifndef CUTEST_CUTEST_H
-#define CUTEST_CUTEST_H
+#ifndef BLOSC_TESTS_CUTEST_H
+#define BLOSC_TESTS_CUTEST_H
 
 #include <stdlib.h>
 #include <stdio.h>
@@ -202,5 +202,4 @@ int _cutest_run(int (*test)(void *), void *test_data, char *name) {
   return cutest_failed;
 }
 
-
-#endif //CUTEST_CUTEST_H
+#endif /* BLOSC_TESTS_CUTEST_H */

--- a/tests/test_common.h
+++ b/tests/test_common.h
@@ -10,8 +10,8 @@
   See LICENSE.txt for details about copyright and rights to use.
 **********************************************************************/
 
-#ifndef BLOSC_TEST_COMMON_H
-#define BLOSC_TEST_COMMON_H
+#ifndef BLOSC_TESTS_TEST_COMMON_H
+#define BLOSC_TESTS_TEST_COMMON_H
 
 #include "blosc2.h"
 
@@ -175,4 +175,4 @@ inline static void install_blosc_callback_test(void)
     blosc2_set_threads_callback(dummy_threads_callback, NULL);
 }
 
-#endif  /* !defined(BLOSC_TEST_COMMON_H) */
+#endif /* BLOSC_TESTS_TEST_COMMON_H */


### PR DESCRIPTION
* Add a `BLOSC_` prefix to all headers to avoid collisions.
* Standardise header guards based on the path of the header file.