### PR TITLE
Add CMAKE_DL_LIBS to CMakeLists.txt

### DIFF
--- a/blosc/CMakeLists.txt
+++ b/blosc/CMakeLists.txt
@@ -97,6 +97,7 @@ else()
     else()
         set(LIBS ${LIBS} Threads::Threads)
     endif()
+    set(LIBS ${LIBS} ${CMAKE_DL_LIBS})
 endif()
 
 if(LZ4_FOUND)


### PR DESCRIPTION
The plugin infrastructure makes use of dynamic loading of symbols via `dlopen` and connected functions.
These functions have implementations for Windows inside the c-blosc2 source code, but on other platforms are provided by standard libraries. Adding `${CMAKE_DL_LIBS}` to the Cmake target libraries guarantees the availability of the symbols.