### PR TITLE
blosc2.h: Avoid C++20 Designated Init

### DIFF
--- a/include/blosc2.h
+++ b/include/blosc2.h
@@ -1053,9 +1053,9 @@ typedef struct {
 } blosc2_io;
 
 static const blosc2_io BLOSC2_IO_DEFAULTS = {
-    .id = BLOSC2_IO_FILESYSTEM,
-    .name = "filesystem",
-    .params = NULL,
+  /* .id = */ BLOSC2_IO_FILESYSTEM,
+  /* .name = */ "filesystem",
+  /* .params = */ NULL,
 };
 
 


### PR DESCRIPTION
See #526.
Designated initializers are in C99 but only in C++20, too.