### PR TITLE
Cycle buffers

### DIFF
--- a/tests/test_filters.c
+++ b/tests/test_filters.c
@@ -1,0 +1,45 @@
+#include <stdio.h>
+#include <blosc2.h>
+#include <stdlib.h>
+
+#define NCHUNKS 1
+#define TYPESIZE 2
+#define LEN 39
+#define CHUNKSIZE (TYPESIZE * LEN)
+
+int main(void) {
+  blosc2_init();
+  srandom(0);
+  uint16_t *ref_data = (uint16_t *)malloc(CHUNKSIZE);
+  uint16_t *data_dest = (uint16_t *)malloc(CHUNKSIZE);
+  for (int i = 0; i < LEN; i++) {
+    ref_data[i] = random() % 118;
+  }
+  blosc2_cparams cparams = BLOSC2_CPARAMS_DEFAULTS;
+  cparams.compcode = BLOSC_ZSTD;
+  cparams.filters[BLOSC2_MAX_FILTERS - 2] = BLOSC_BITSHUFFLE;
+  cparams.filters[BLOSC2_MAX_FILTERS - 1] = BLOSC_SHUFFLE;
+
+  blosc2_dparams dparams = BLOSC2_DPARAMS_DEFAULTS;
+
+  cparams.typesize = TYPESIZE;
+  blosc2_storage storage = {.contiguous=false, .urlpath=NULL, .cparams=&cparams, .dparams=&dparams};
+
+  blosc2_schunk* schunk = blosc2_schunk_new(&storage);
+  blosc2_schunk_append_buffer(schunk, ref_data, CHUNKSIZE);
+
+  blosc2_schunk_decompress_chunk(schunk, 0, data_dest, CHUNKSIZE);
+  for (int i = 0; i < LEN; i++) {
+    if (data_dest[i] != ref_data[i]) {
+      printf("Decompressed data differs from original %d, %d, %d!\n",
+          i, ref_data[i], data_dest[i]);
+      return -1;
+    }
+  }
+
+  printf("Successful roundtrip data <-> schunk !\n");
+
+  blosc2_schunk_free(schunk);
+  blosc2_destroy();
+  return 0;
+}


### PR DESCRIPTION
Fix for https://github.com/Blosc/c-blosc2/issues/528

I'm unsure about the correctness of this change but I ran all the unit tests and they all passed. The attached test fails before the addition of `_cycle_buffers`  and passes after adding `_cycle_buffers`. 

My rationale for the fix is that all the sites that were swapping buffers looked like they intended to rotate 3 variables, but actually lose a variable each time:
```
_src = _dest;
_dest = _tmp;
_tmp = _src;
```
is equivalent to 
```
uint8_t *scratch = _dest;
_dest = _tmp;
_src = scratch;
_tmp = scratch;
``` 
So that any filter which writes to the `_tmp` buffer will be corrupting its own input.