### PR TITLE
CMake: Static lib Deps are Public

### DIFF
--- a/blosc/CMakeLists.txt
+++ b/blosc/CMakeLists.txt
@@ -304,7 +304,7 @@ if(BUILD_STATIC)
     if(MSVC OR MINGW)
         set_target_properties(blosc2_static PROPERTIES PREFIX lib)
     endif()
-    target_link_libraries(blosc2_static ${LIBS})
+    target_link_libraries(blosc2_static PUBLIC ${LIBS})
     target_include_directories(blosc2_static PUBLIC ${BLOSC_INCLUDE_DIRS})
 endif()
 


### PR DESCRIPTION
In `target_link_libraries`, we need to link dependencies as `PUBLIC` to make sure they are propagated downstream.

Seen when building a static c-blosc2 library, depending on an external, static zlib library and using downstream in ADIOS2.

Follow-up to #529