### PR TITLE
Fix CMake Install: Find*.cmake Modules

### DIFF
--- a/Blosc2Config.cmake.in
+++ b/Blosc2Config.cmake.in
@@ -9,7 +9,7 @@ if(POLICY CMP0074)
 endif()
 
 # locate the installed FindABC.cmake modules
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/Modules")
 
 # this section stores which configuration options were set
 set(HAVE_THREADS @Threads_FOUND@)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -520,6 +520,12 @@ if(BLOSC_INSTALL)
         DESTINATION ${Blosc2_INSTALL_CMAKEDIR}
     )
 
+    # CMake Find*.cmake files used in Blosc2Config.cmake
+    install(
+        DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/cmake/
+        DESTINATION ${Blosc2_INSTALL_CMAKEDIR}/Modules
+    )
+
     # pkg-config .pc file
     configure_file(
          "${CMAKE_CURRENT_SOURCE_DIR}/blosc2.pc.in"


### PR DESCRIPTION
Install the CMake modules in `cmake/` into our install prefix. If we build with external dependencies for LZ4 and ZLIB_NG, then downstream projects will need those Modules to populate our CMake import targets in `Blosc2Config.cmake` during the `find_dependency` calls (which are just wrappers for `find_package`).

Follow-up to #537 and #541.