### PR TITLE
Fix redefinition of PATH_MAX macro with mingw

### DIFF
--- a/blosc/blosc-private.h
+++ b/blosc/blosc-private.h
@@ -184,7 +184,9 @@ extern int g_ntuners;
 
 #if defined(_WIN32)
 #include <windows.h>
+#ifndef PATH_MAX
 #define PATH_MAX MAX_PATH
+#endif
 #define RTLD_LAZY   0x000
 #define popen _popen
 #define pclose _pclose


### PR DESCRIPTION

    This fixes the following warning with mingw gcc

    blosc-private.h:187: warning: "PATH_MAX" redefined
      187 | #define PATH_MAX MAX_PATH
          |
    limits.h:20: note: this is the location of the previous definition
       20 | #define PATH_MAX        260
          |

