### PR TITLE
Fix unused parameter warning with dlopen function

### DIFF
--- a/blosc/blosc-private.h
+++ b/blosc/blosc-private.h
@@ -201,6 +201,7 @@ var = {
 };
 
 static inline void *dlopen (const char *filename, int flags) {
+  BLOSC_UNUSED_PARAM(flags);
   HINSTANCE hInst;
   hInst = LoadLibrary(filename);
   if (hInst==NULL) {


### PR DESCRIPTION

    This fixes the following warning with mingw gcc compiler

    blosc-private.h:201:55: warning: unused parameter 'flags' [-Wunused-parameter]
      201 | static inline void *dlopen (const char *filename, int flags) {
          |                                                   ~~~~^~~~~

