### PR TITLE
Fix: CMake Config Version w/o Suffix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -510,7 +510,7 @@ if(BLOSC_INSTALL)
         DESTINATION ${Blosc2_INSTALL_CMAKEDIR}
     )
     write_basic_package_version_file("Blosc2ConfigVersion.cmake"
-        VERSION ${BLOSC2_VERSION_STRING}
+        VERSION ${BLOSC2_VERSION_MAJOR}.${BLOSC2_VERSION_MINOR}.${BLOSC2_VERSION_PATCH}
         COMPATIBILITY SameMajorVersion
     )
     install(


### PR DESCRIPTION
When writing to CMake, we cannot append the suffix string in the version file, i.e., have to omit `.dev`.

The reason for that is that `VERSION_GREATER_EQUAL` is not that flexible: https://cmake.org/cmake/help/latest/variable/CMAKE_VERSION.html and downstream users comparing against the version will get a `FALSE` result comparing things like
```cmake
if (Blosc2_VERSION VERSION_GREATER_EQUAL 2.10.1)
```
if `Blosc2_VERSION` is set to `2.10.2.dev`.

Follow-up to #537