### PR TITLE
CMake: Cleanup Threads Search & Propagation

### DIFF
--- a/Blosc2Config.cmake.in
+++ b/Blosc2Config.cmake.in
@@ -12,7 +12,7 @@ endif()
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/Modules")
 
 # this section stores which configuration options were set
-set(HAVE_THREADS @Threads_FOUND@)
+set(HAVE_THREADS @HAVE_THREADS@)
 set(HAVE_IPP @HAVE_IPP@)
 set(HAVE_ZLIB_NG @HAVE_ZLIB_NG@)
 set(DEACTIVATE_IPP @DEACTIVATE_IPP@)
@@ -26,16 +26,13 @@ set(PREFER_EXTERNAL_ZSTD @PREFER_EXTERNAL_ZSTD@)
 #   additionally, the Blosc2_..._FOUND variables are used to support
 #   find_package(Blosc2 ... COMPONENTS ... ...)
 #   this enables downstream projects to express the need for specific features.
-if(WIN32)
-    if(HAVE_THREADS)
-        find_dependency(Threads)
-        set(Blosc2_THREADS_FOUND TRUE)
-    else()
-        set(Blosc2_THREADS_FOUND FALSE)
-    endif()
-else()
+set(CMAKE_THREAD_PREFER_PTHREAD TRUE) # pre 3.1
+set(THREADS_PREFER_PTHREAD_FLAG TRUE) # CMake 3.1+
+if(HAVE_THREADS)
     find_dependency(Threads)
     set(Blosc2_THREADS_FOUND TRUE)
+else()
+    set(Blosc2_THREADS_FOUND FALSE)
 endif()
 
 if(NOT DEACTIVATE_IPP AND HAVE_IPP)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,6 +151,21 @@ if(BUILD_LITE)
     set(DEACTIVATE_ZSTD ON)
 endif()
 
+# Threads
+set(CMAKE_THREAD_PREFER_PTHREAD TRUE) # pre 3.1
+set(THREADS_PREFER_PTHREAD_FLAG TRUE) # CMake 3.1+
+if(WIN32)
+    # try to use the system library
+    find_package(Threads)
+else()
+    find_package(Threads REQUIRED)
+endif()
+if(Threads_FOUND)
+    set(HAVE_THREADS ON)
+else()
+    set(HAVE_THREADS OFF)
+endif()
+
 if(PREFER_EXTERNAL_LZ4)
     find_package(LZ4)
 else()

--- a/blosc/CMakeLists.txt
+++ b/blosc/CMakeLists.txt
@@ -165,28 +165,22 @@ if(NOT DEACTIVATE_ZSTD)
     endif()
 endif()
 
-set(CMAKE_THREAD_PREFER_PTHREAD TRUE) # pre 3.1
-set(THREADS_PREFER_PTHREAD_FLAG TRUE) # CMake 3.1+
-if(WIN32)
-    # try to use the system library
-    find_package(Threads)
-    if(NOT Threads_FOUND)
-        message(STATUS "using the internal pthread library for win32 systems.")
-        list(APPEND SOURCES blosc/win32/pthread.c)
-    else()
-        if(CMAKE_VERSION VERSION_LESS 3.1)
-            set(LIBS ${LIBS} ${CMAKE_THREAD_LIBS_INIT})
-        else()
-            set(LIBS ${LIBS} Threads::Threads)
-        endif()
-    endif()
-else()
-    find_package(Threads REQUIRED)
+# Threads
+if(HAVE_THREADS)
     if(CMAKE_VERSION VERSION_LESS 3.1)
         set(LIBS ${LIBS} ${CMAKE_THREAD_LIBS_INIT})
     else()
         set(LIBS ${LIBS} Threads::Threads)
     endif()
+elseif(WIN32)
+    message(STATUS "using the internal pthread library for win32 systems.")
+    list(APPEND SOURCES blosc/win32/pthread.c)
+else()
+    message(FATAL_ERROR "Threads required but not found.")
+endif()
+
+# dlopen/dlclose
+if(NOT WIN32)
     set(LIBS ${LIBS} ${CMAKE_DL_LIBS})
 endif()
 


### PR DESCRIPTION
Search Threads upfront, because we configure specific options that are cached and reused by dependencies in superbuilds. This brings all `find_package` calls in the same central file before we start including sub-directories with sub-projects.

Set same options as in `find_package` for the `find_dependency` wrapper in `Blosc2Config.cmake`.

This also solves a dependency propagation issue for all-static builds [that I saw on Windows](https://github.com/openPMD/openPMD-api/pull/1515), when Threads are found.