### PR TITLE
Always take BLOSC_STRICT_ALIGN path

### DIFF
--- a/blosc/blosc-private.h
+++ b/blosc/blosc-private.h
@@ -32,7 +32,14 @@
 
 
 // Return true if platform is little endian; else false
-static bool is_little_endian(void) {
+static inline bool is_little_endian(void) {
+  #if defined(__BYTE_ORDER__)
+  # if (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)
+      return false;
+  # else
+      return true;
+  # endif
+  #else
   static const int i = 1;
   char* p = (char*)&i;
 
@@ -42,6 +49,7 @@ static bool is_little_endian(void) {
   else {
     return false;
   }
+  #endif
 }
 
 

--- a/blosc/blosc2.c
+++ b/blosc/blosc2.c
@@ -1045,11 +1045,7 @@ static bool get_run(const uint8_t* ip, const uint8_t* ip_bound) {
   /* Broadcast the value for every byte in a 64-bit register */
   memset(&value, x, 8);
   while (ip < (ip_bound - 8)) {
-#if defined(BLOSC_STRICT_ALIGN)
     memcpy(&value2, ip, 8);
-#else
-    value2 = *(int64_t*)ip;
-#endif
     if (value != value2) {
       // Values differ.  We don't have a run.
       return false;

--- a/blosc/blosclz.c
+++ b/blosc/blosclz.c
@@ -46,9 +46,6 @@
 #define MAX_DISTANCE 8191
 #define MAX_FARDISTANCE (65535 + MAX_DISTANCE - 1)
 
-#define BLOSCLZ_READU16(p) ((p)[0] | (p)[1]<<8)
-#define BLOSCLZ_READU32(p) ((p)[0] | (p)[1]<<8 | (p)[2]<<16 | (p)[3]<<24)
-
 #define HASH_LOG (14U)
 
 // This is used in LZ4 and seems to work pretty well here too
@@ -56,6 +53,14 @@
   (v) = ((s) * 2654435761U) >> (32U - (h)); \
 }
 
+static inline uint16_t BLOSCLZ_READU16(const unsigned char* src) {
+    return (uint16_t)(src[0] << 0) | (uint16_t)(src[1] << 8);
+}
+
+static inline uint32_t BLOSCLZ_READU32(const unsigned char* src) {
+    return ((uint32_t)src[0] << 0) | ((uint32_t)src[1] << 8) | ((uint32_t)src[2] << 16) |
+           ((uint32_t)src[3] << 24);
+}
 
 #if defined(__AVX2__)
 static uint8_t *get_run_32(uint8_t *ip, const uint8_t *ip_bound, const uint8_t *ref) {

--- a/blosc/blosclz.c
+++ b/blosc/blosclz.c
@@ -16,6 +16,7 @@
 
 #include "blosclz.h"
 #include "fastcopy.h"
+#include "blosc-private.h"
 #include "blosc2/blosc2-common.h"
 
 #include <stdbool.h>
@@ -54,12 +55,19 @@
 }
 
 static inline uint16_t BLOSCLZ_READU16(const unsigned char* src) {
-    return (uint16_t)(src[0] << 0) | (uint16_t)(src[1] << 8);
+    uint16_t result;
+    memcpy(&result, src, 2);
+    if (!is_little_endian())
+      result = __builtin_bswap16(result);
+    return result;
 }
 
 static inline uint32_t BLOSCLZ_READU32(const unsigned char* src) {
-    return ((uint32_t)src[0] << 0) | ((uint32_t)src[1] << 8) | ((uint32_t)src[2] << 16) |
-           ((uint32_t)src[3] << 24);
+    uint32_t result;
+    memcpy(&result, src, 4);
+    if (!is_little_endian())
+      result = __builtin_bswap32(result);
+    return result;
 }
 
 #if defined(__AVX2__)

--- a/blosc/fastcopy.c
+++ b/blosc/fastcopy.c
@@ -22,9 +22,7 @@
 
 #include <assert.h>
 #include <stdint.h>
-#if defined(BLOSC_STRICT_ALIGN)
 #include <string.h>
-#endif
 
 /*
  * Use inlined functions for supported systems.
@@ -40,13 +38,9 @@ static inline unsigned char *copy_1_bytes(unsigned char *out, const unsigned cha
 }
 
 static inline unsigned char *copy_2_bytes(unsigned char *out, const unsigned char *from) {
-#if defined(BLOSC_STRICT_ALIGN)
   uint16_t chunk;
   memcpy(&chunk, from, 2);
   memcpy(out, &chunk, 2);
-#else
-  *(uint16_t *) out = *(uint16_t *) from;
-#endif
   return out + 2;
 }
 
@@ -56,13 +50,9 @@ static inline unsigned char *copy_3_bytes(unsigned char *out, const unsigned cha
 }
 
 static inline unsigned char *copy_4_bytes(unsigned char *out, const unsigned char *from) {
-#if defined(BLOSC_STRICT_ALIGN)
   uint32_t chunk;
   memcpy(&chunk, from, 4);
   memcpy(out, &chunk, 4);
-#else
-  *(uint32_t *) out = *(uint32_t *) from;
-#endif
   return out + 4;
 }
 
@@ -82,13 +72,9 @@ static inline unsigned char *copy_7_bytes(unsigned char *out, const unsigned cha
 }
 
 static inline unsigned char *copy_8_bytes(unsigned char *out, const unsigned char *from) {
-#if defined(BLOSC_STRICT_ALIGN)
   uint64_t chunk;
   memcpy(&chunk, from, 8);
   memcpy(out, &chunk, 8);
-#else
-  *(uint64_t *) out = *(uint64_t *) from;
-#endif
   return out + 8;
 }
 
@@ -99,16 +85,11 @@ static inline unsigned char *copy_16_bytes(unsigned char *out, const unsigned ch
   chunk = _mm_loadu_si128((__m128i*)from);
   _mm_storeu_si128((__m128i*)out, chunk);
   out += 16;
-#elif !defined(BLOSC_STRICT_ALIGN)
-  *(uint64_t*)out = *(uint64_t*)from;
-   from += 8; out += 8;
-   *(uint64_t*)out = *(uint64_t*)from;
-   from += 8; out += 8;
 #else
-   int i;
-   for (i = 0; i < 16; i++) {
-     *out++ = *from++;
-   }
+  int i;
+  for (i = 0; i < 16; i++) {
+    *out++ = *from++;
+  }
 #endif
   return out;
 }
@@ -127,15 +108,6 @@ static inline unsigned char *copy_32_bytes(unsigned char *out, const unsigned ch
   chunk = _mm_loadu_si128((__m128i*)from);
   _mm_storeu_si128((__m128i*)out, chunk);
   out += 16;
-#elif !defined(BLOSC_STRICT_ALIGN)
-  *(uint64_t*)out = *(uint64_t*)from;
-  from += 8; out += 8;
-  *(uint64_t*)out = *(uint64_t*)from;
-  from += 8; out += 8;
-  *(uint64_t*)out = *(uint64_t*)from;
-  from += 8; out += 8;
-  *(uint64_t*)out = *(uint64_t*)from;
-  from += 8; out += 8;
 #else
   int i;
   for (i = 0; i < 32; i++) {
@@ -159,32 +131,9 @@ static inline unsigned char *copy_32_bytes(unsigned char *out, const unsigned ch
 static inline unsigned char *copy_bytes(unsigned char *out, const unsigned char *from, unsigned len) {
   assert(len < 8);
 
-#ifdef BLOSC_STRICT_ALIGN
   while (len--) {
     *out++ = *from++;
   }
-#else
-  switch (len) {
-    case 7:
-      return copy_7_bytes(out, from);
-    case 6:
-      return copy_6_bytes(out, from);
-    case 5:
-      return copy_5_bytes(out, from);
-    case 4:
-      return copy_4_bytes(out, from);
-    case 3:
-      return copy_3_bytes(out, from);
-    case 2:
-      return copy_2_bytes(out, from);
-    case 1:
-      return copy_1_bytes(out, from);
-    case 0:
-      return out;
-    default:
-      assert(0);
-  }
-#endif /* BLOSC_STRICT_ALIGN */
   return out;
 }
 

--- a/include/blosc2/blosc2-common.h
+++ b/include/blosc2/blosc2-common.h
@@ -42,34 +42,6 @@
   #define __SSE2__
 #endif
 
-/*
- * Detect if the architecture is fine with unaligned access.
- */
-#if !defined(BLOSC_STRICT_ALIGN)
-#define BLOSC_STRICT_ALIGN
-#if defined(__i386__) || defined(__386) || defined (__amd64)  /* GNU C, Sun Studio */
-#undef BLOSC_STRICT_ALIGN
-#elif defined(__i486__) || defined(__i586__) || defined(__i686__)  /* GNU C */
-#undef BLOSC_STRICT_ALIGN
-#elif defined(_M_IX86) || defined(_M_X64)   /* Intel, MSVC */
-#undef BLOSC_STRICT_ALIGN
-#elif defined(__386)
-#undef BLOSC_STRICT_ALIGN
-#elif defined(_X86_) /* MinGW */
-#undef BLOSC_STRICT_ALIGN
-#elif defined(__I86__) /* Digital Mars */
-#undef BLOSC_STRICT_ALIGN
-/* Modern ARM systems (like ARM64) should support unaligned access
-   quite efficiently. */
-#elif defined(__ARM_FEATURE_UNALIGNED)   /* ARM, GNU C */
-#undef BLOSC_STRICT_ALIGN
-#elif defined(_ARCH_PPC) || defined(__PPC__)
-/* Modern PowerPC systems (like POWER8) should support unaligned access
-   quite efficiently. */
-#undef BLOSC_STRICT_ALIGN
-#endif
-#endif
-
 #if defined(__SSE2__)
   #include <emmintrin.h>
 #endif

--- a/plugins/codecs/ndlz/ndlz4x4.c
+++ b/plugins/codecs/ndlz/ndlz4x4.c
@@ -44,12 +44,16 @@
 #define MAX_COPY 32U
 #define MAX_DISTANCE 65535
 
-
-#define NDLZ_READU16(p) ((p)[0] | (p)[1]<<8)
-#define NDLZ_READU32(p) ((p)[0] | (p)[1]<<8 | (p)[2]<<16 | (p)[3]<<24)
-
 #define HASH_LOG (12)
 
+static inline uint16_t NDLZ_READU16(const unsigned char* src) {
+  return (uint16_t)(src[0] << 0) | (uint16_t)(src[1] << 8);
+}
+
+static inline uint32_t NDLZ_READU32(const unsigned char* src) {
+  return ((uint32_t)src[0] << 0) | ((uint32_t)src[1] << 8) | ((uint32_t)src[2] << 16) |
+           ((uint32_t)src[3] << 24);
+}
 
 int ndlz4_compress(const uint8_t *input, int32_t input_len, uint8_t *output, int32_t output_len,
                    uint8_t meta, blosc2_cparams *cparams) {

--- a/plugins/codecs/ndlz/ndlz4x4.c
+++ b/plugins/codecs/ndlz/ndlz4x4.c
@@ -45,13 +45,8 @@
 #define MAX_DISTANCE 65535
 
 
-#ifdef BLOSC_STRICT_ALIGN
 #define NDLZ_READU16(p) ((p)[0] | (p)[1]<<8)
 #define NDLZ_READU32(p) ((p)[0] | (p)[1]<<8 | (p)[2]<<16 | (p)[3]<<24)
-#else
-#define NDLZ_READU16(p) *((const uint16_t*)(p))
-#define NDLZ_READU32(p) *((const uint32_t*)(p))
-#endif
 
 #define HASH_LOG (12)
 

--- a/plugins/codecs/ndlz/ndlz4x4.c
+++ b/plugins/codecs/ndlz/ndlz4x4.c
@@ -18,6 +18,7 @@
 #include "ndlz4x4.h"
 #include "ndlz.h"
 #include "xxhash.h"
+#include "blosc-private.h"
 #include "../plugins/plugin_utils.h"
 
 #include <stdlib.h>
@@ -47,12 +48,19 @@
 #define HASH_LOG (12)
 
 static inline uint16_t NDLZ_READU16(const unsigned char* src) {
-  return (uint16_t)(src[0] << 0) | (uint16_t)(src[1] << 8);
+  uint16_t result;
+  memcpy(&result, src, 2);
+  if (!is_little_endian())
+    result = __builtin_bswap16(result);
+  return result;
 }
 
 static inline uint32_t NDLZ_READU32(const unsigned char* src) {
-  return ((uint32_t)src[0] << 0) | ((uint32_t)src[1] << 8) | ((uint32_t)src[2] << 16) |
-           ((uint32_t)src[3] << 24);
+  uint32_t result;
+  memcpy(&result, src, 4);
+  if (!is_little_endian())
+    result = __builtin_bswap32(result);
+  return result;
 }
 
 int ndlz4_compress(const uint8_t *input, int32_t input_len, uint8_t *output, int32_t output_len,

--- a/plugins/codecs/ndlz/ndlz8x8.c
+++ b/plugins/codecs/ndlz/ndlz8x8.c
@@ -44,12 +44,16 @@
 #define MAX_COPY 32U
 #define MAX_DISTANCE 65535
 
-
-#define NDLZ_READU16(p) ((p)[0] | (p)[1]<<8)
-#define NDLZ_READU32(p) ((p)[0] | (p)[1]<<8 | (p)[2]<<16 | (p)[3]<<24)
-
 #define HASH_LOG (12)
 
+static inline uint16_t NDLZ_READU16(const unsigned char* src) {
+  return (uint16_t)(src[0] << 0) | (uint16_t)(src[1] << 8);
+}
+
+static inline uint32_t NDLZ_READU32(const unsigned char* src) {
+  return ((uint32_t)src[0] << 0) | ((uint32_t)src[1] << 8) | ((uint32_t)src[2] << 16) |
+           ((uint32_t)src[3] << 24);
+}
 
 int ndlz8_compress(const uint8_t *input, int32_t input_len, uint8_t *output, int32_t output_len,
                    uint8_t meta, blosc2_cparams *cparams) {

--- a/plugins/codecs/ndlz/ndlz8x8.c
+++ b/plugins/codecs/ndlz/ndlz8x8.c
@@ -45,13 +45,8 @@
 #define MAX_DISTANCE 65535
 
 
-#ifdef BLOSC_STRICT_ALIGN
 #define NDLZ_READU16(p) ((p)[0] | (p)[1]<<8)
 #define NDLZ_READU32(p) ((p)[0] | (p)[1]<<8 | (p)[2]<<16 | (p)[3]<<24)
-#else
-#define NDLZ_READU16(p) *((const uint16_t*)(p))
-#define NDLZ_READU32(p) *((const uint32_t*)(p))
-#endif
 
 #define HASH_LOG (12)
 

--- a/plugins/codecs/ndlz/ndlz8x8.c
+++ b/plugins/codecs/ndlz/ndlz8x8.c
@@ -18,6 +18,7 @@
 #include "ndlz8x8.h"
 #include "ndlz.h"
 #include "xxhash.h"
+#include "blosc-private.h"
 #include "../plugins/plugin_utils.h"
 
 #include <stdlib.h>
@@ -47,12 +48,19 @@
 #define HASH_LOG (12)
 
 static inline uint16_t NDLZ_READU16(const unsigned char* src) {
-  return (uint16_t)(src[0] << 0) | (uint16_t)(src[1] << 8);
+  uint16_t result;
+  memcpy(&result, src, 2);
+  if (!is_little_endian())
+    result = __builtin_bswap16(result);
+  return result;
 }
 
 static inline uint32_t NDLZ_READU32(const unsigned char* src) {
-  return ((uint32_t)src[0] << 0) | ((uint32_t)src[1] << 8) | ((uint32_t)src[2] << 16) |
-           ((uint32_t)src[3] << 24);
+  uint32_t result;
+  memcpy(&result, src, 4);
+  if (!is_little_endian())
+    result = __builtin_bswap32(result);
+  return result;
 }
 
 int ndlz8_compress(const uint8_t *input, int32_t input_len, uint8_t *output, int32_t output_len,


### PR DESCRIPTION
Unaligned access is UB, even on x86. UBsan will also detect this (-fsanitize=undefined or -fsanitize=alignment).

On arm, I hit SIGBUSes in pandas's test suite via pandas->pytables->c-blosc2 because of unaligned loads and stores.

Modern compilers are capable of optimising the "slow" path bitshifts and memcpy into faster alternatives where it is legal.

Bug: https://bugs.gentoo.org/911660
Bug: https://github.com/pandas-dev/pandas/issues/54391
Bug: https://github.com/pandas-dev/pandas/issues/54396