### PR TITLE
Disable visibility attribute for mingw

### DIFF
--- a/include/blosc2/blosc2-export.h
+++ b/include/blosc2/blosc2-export.h
@@ -33,11 +33,11 @@
   #define BLOSC_EXPORT
 #endif  /* defined(BLOSC_SHARED_LIBRARY) */
 
-#if defined(__GNUC__) || defined(__clang__)
+#if (defined(__GNUC__) || defined(__clang__)) && !defined(__MINGW32__)
   #define BLOSC_NO_EXPORT __attribute__((visibility("hidden")))
 #else
   #define BLOSC_NO_EXPORT
-#endif  /* defined(__GNUC__) || defined(__clang__) */
+#endif  /* (defined(__GNUC__) || defined(__clang__)) && !defined(__MINGW32__) */
 
 /* When testing, export everything to make it easier to implement tests. */
 #if defined(BLOSC_TESTING)


### PR DESCRIPTION

    The same thing is done with BLOSC_EXPORT macro also.

    This fixes the following compiler warning with mingw gcc for static build.

    shuffle-generic.c: In function 'shuffle_generic':
    shuffle-generic.c:18:1: warning: visibility attribute not supported
    in this configuration; ignored [-Wattributes]

