### PR TITLE
Suppress an use-after-free warning

### DIFF
--- a/blosc/frame.c
+++ b/blosc/frame.c
@@ -1635,11 +1635,12 @@ int frame_get_vlmetalayers(blosc2_frame_s* frame, blosc2_schunk* schunk) {
       char* eframe_name = malloc(strlen(frame->urlpath) + strlen("/chunks.b2frame") + 1);
       sprintf(eframe_name, "%s/chunks.b2frame", frame->urlpath);
       fp = io_cb->open(eframe_name, "rb", frame->schunk->storage->io->params);
-      free(eframe_name);
       if (fp == NULL) {
         BLOSC_TRACE_ERROR("Error opening file in: %s", eframe_name);
+        free(eframe_name);
         return BLOSC2_ERROR_FILE_OPEN;
       }
+      free(eframe_name);
       io_cb->seek(fp, trailer_offset, SEEK_SET);
     }
     else {


### PR DESCRIPTION
    In file included from blosc/frame.h:14,
                     from blosc/frame.c:11:
    blosc/frame.c: In function 'frame_get_vlmetalayers':
    include/blosc2.h:104:9: warning: pointer 'eframe_name' may be used after 'free' [-Wuse-after-free]
      104 |         fprintf(stderr, "[%s] - " msg " (%s:%d)\n", #cat, ##__VA_ARGS__, __FILE__, __LINE__); \
          |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    include/blosc2.h:97:37: note: in expansion of macro 'BLOSC_TRACE'
       97 | #define BLOSC_TRACE_ERROR(msg, ...) BLOSC_TRACE(error, msg, ##__VA_ARGS__)
          |                                     ^~~~~~~~~~~
    blosc/frame.c:1640:9: note: in expansion of macro 'BLOSC_TRACE_ERROR'
     1640 |         BLOSC_TRACE_ERROR("Error opening file in: %s", eframe_name);
          |         ^~~~~~~~~~~~~~~~~
    blosc/frame.c:1638:7: note: call to 'free' here
     1638 |       free(eframe_name);
          |       ^~~~~~~~~~~~~~~~~