### PR TITLE
Fix conflicting types in Altivec code

### DIFF
--- a/blosc/bitshuffle-altivec.h
+++ b/blosc/bitshuffle-altivec.h
@@ -35,13 +35,13 @@ BLOSC_NO_EXPORT int64_t
 */
 BLOSC_NO_EXPORT int64_t
     bshuf_trans_bit_elem_altivec(void* in, void* out, const size_t size,
-                              const size_t elem_size, void* tmp_buf);
+                              const size_t elem_size);
 
 /**
   ALTIVEC-accelerated bitunshuffle routine.
 */
 BLOSC_NO_EXPORT int64_t
     bshuf_untrans_bit_elem_altivec(void* in, void* out, const size_t size,
-                                const size_t elem_size, void* tmp_buf);
+                                const size_t elem_size);
 
 #endif /* BLOSC_BITSHUFFLE_ALTIVEC_H */


### PR DESCRIPTION
Spack's CI caught the following errors:
```
error: conflicting types for 'bshuf_trans_bit_elem_altivec'
error: conflicting types for 'bshuf_untrans_bit_elem_altivec'
```
For more details, see https://gitlab.spack.io/spack/spack/-/jobs/8976601