### PR TITLE
Use typedef for blosc_timestamp_t

### DIFF
--- a/include/blosc2.h
+++ b/include/blosc2.h
@@ -2306,9 +2306,9 @@ BLOSC_EXPORT int blosc2_vlmeta_get_names(blosc2_schunk *schunk, char **names);
 
 /* The type of timestamp used on this system. */
 #if defined(_WIN32)
-#define blosc_timestamp_t LARGE_INTEGER
+typedef LARGE_INTEGER blosc_timestamp_t;
 #else
-#define blosc_timestamp_t struct timespec
+typedef struct timespec blosc_timestamp_t;
 #endif
 
 /*


### PR DESCRIPTION
Using a `typedef` makes code analysis more efficient as one can see `blosc_timestamp_t` is a type straigth away. In addition tools such as [`bindgen`](https://rust-lang.github.io/rust-bindgen/) are able to generate better bindings.