### PR TITLE
Optimizing zstd, specially when using dicts

### DIFF
--- a/blosc/stune.c
+++ b/blosc/stune.c
@@ -198,8 +198,11 @@ int split_block(blosc2_context *context, int32_t typesize, int32_t blocksize) {
 
   int compcode = context->compcode;
   return (
-          // Fast codecs like blosclz and lz4 always prefer to always split
-          ((compcode == BLOSC_BLOSCLZ) || (compcode == BLOSC_LZ4)) &&
+          // Fast codecs like blosclz, lz4 seems to prefer to split
+          ((compcode == BLOSC_BLOSCLZ) || (compcode == BLOSC_LZ4)
+            // and low levels of zstd too
+            || ((compcode == BLOSC_ZSTD) && (context->clevel <= 5))
+            ) &&
           // ...but split seems to harm cratio too much when not using shuffle
           (context->filter_flags & BLOSC_DOSHUFFLE) &&
           (typesize <= MAX_STREAMS) &&

--- a/tests/test_compressor.c
+++ b/tests/test_compressor.c
@@ -152,8 +152,8 @@ static char *test_bitshuffle(void) {
   int cbytes2;
 
   /* Get a compressed buffer */
-  if (blosc1_set_compressor("zstd") == -1) {
-    /* If zstd is not here, just skip the test */
+  if (blosc1_set_compressor("zlib") == -1) {
+    /* If zlib is not here, just skip the test */
     return 0;
   };
   cbytes = blosc1_compress(clevel, doshuffle, typesize, size, src,

--- a/tests/test_dict_schunk.c
+++ b/tests/test_dict_schunk.c
@@ -39,6 +39,7 @@ static char* test_dict(void) {
   cparams.clevel = 5;
   cparams.nthreads = NTHREADS;
   cparams.blocksize = blocksize;
+  cparams.splitmode = BLOSC_FORWARD_COMPAT_SPLIT;
   dparams.nthreads = NTHREADS;
   blosc2_storage storage = {.cparams=&cparams, .dparams=&dparams};
   schunk = blosc2_schunk_new(&storage);


### PR DESCRIPTION
This is an effort to optimize the dictionaries for Zstd inside Blosc2.

The tuning here is mainly based on experiments done with `test_dict_schunk.c`, but that is probably very dependent on data.

Also, during testing, I detected that splitting is also beneficial for low compression levels in Zstd, so it has been enable for it when using SHUFFLE and clevel <= 5.