### PR TITLE
bytedelta: rely on __SSSE3__ macro rather that on architecture macros

### DIFF
--- a/plugins/filters/bytedelta/bytedelta.c
+++ b/plugins/filters/bytedelta/bytedelta.c
@@ -18,7 +18,15 @@
 #include <stdint.h>
 #include <stdio.h>
 
-#if defined __i386__ || defined _M_IX86 || defined __x86_64__ || defined _M_X64
+/* Define the __SSSE3__ symbol if compiling with Visual C++ and
+   targeting the minimum architecture level.
+*/
+#if !defined(__SSSE3__) && defined(_MSC_VER) && \
+    (defined(_M_X64) || (defined(_M_IX86) && _M_IX86_FP >= 2))
+  #define __SSSE3__
+#endif
+
+#if defined(__SSSE3__)
 // SSSE3 code path for x64/x64
 #define CPU_HAS_SIMD 1
 #include <emmintrin.h>


### PR DESCRIPTION
This PR proposes to use the `__SSSE3__` macros to probe SSSE3 availability rather than the architecture macros since this depends on the build options used. From what I have checked the bytedelta code uses only SSSE3 and SSE2 instructions.
For Visual Studio, `__SSSE3__` is defined the same way as for `__SSE2__` in:

https://github.com/Blosc/C-Blosc2/blob/f0183767d73073eb41bbf97bf56554c7a55c7dbf/include/blosc2/blosc2-common.h#L36-L43


Related to #546 and probably fixes it. From what I have tested, it fixes build issues with hdf5plugin.