### PR TITLE
Change blosc2.c:set_values to always call memcpy if BLOSC_STRICT_ALIGN

### DIFF
--- a/blosc/blosc2.c
+++ b/blosc/blosc2.c
@@ -1494,6 +1494,18 @@ static int32_t set_nans(int32_t typesize, uint8_t* dest, int32_t destsize) {
 
 
 static int32_t set_values(int32_t typesize, const uint8_t* src, uint8_t* dest, int32_t destsize) {
+#if defined(BLOSC_STRICT_ALIGN)
+  if (destsize % typesize != 0) {
+    BLOSC_ERROR(BLOSC2_ERROR_FAILURE);
+  }
+  int32_t nitems = destsize / typesize;
+  if (nitems == 0) {
+    return 0;
+  }
+  for (int i = 0; i < nitems; i++) {
+    memcpy(dest + i * typesize, src + BLOSC_EXTENDED_HEADER_LENGTH, typesize);
+  }
+#else
   // destsize can only be a multiple of typesize
   int64_t val8;
   int64_t* dest8;
@@ -1546,6 +1558,7 @@ static int32_t set_values(int32_t typesize, const uint8_t* src, uint8_t* dest, i
         memcpy(dest + i * typesize, src + BLOSC_EXTENDED_HEADER_LENGTH, typesize);
       }
   }
+#endif
 
   return nitems;
 }


### PR DESCRIPTION
While I have some sympathy with the argument in #550 that all this code depending on unaligned access should go away in favour of letting the compiler put it back when it makes sense, this particular instance of it is all that is making the test suite fail on 32-bit ARM on the current Ubuntu devel series.