### PR TITLE
No shuffle repeat

### DIFF
--- a/blosc/blosc2.c
+++ b/blosc/blosc2.c
@@ -970,13 +970,7 @@ uint8_t* pipeline_forward(struct thread_context* thread_context, const int32_t b
     if (filters[i] <= BLOSC2_DEFINED_FILTERS_STOP) {
       switch (filters[i]) {
         case BLOSC_SHUFFLE:
-          for (int j = 0; j <= filters_meta[i]; j++) {
-            shuffle(typesize, bsize, _src, _dest);
-            // Cycle filters when required
-            if (j < filters_meta[i]) {
-              _cycle_buffers(&_src, &_dest, &_tmp);
-            }
-          }
+          shuffle(typesize, bsize, _src, _dest);
           break;
         case BLOSC_BITSHUFFLE:
           if (bitshuffle(typesize, bsize, _src, _dest) < 0) {
@@ -1345,17 +1339,7 @@ int pipeline_backward(struct thread_context* thread_context, const int32_t bsize
     if (filters[i] <= BLOSC2_DEFINED_FILTERS_STOP) {
       switch (filters[i]) {
         case BLOSC_SHUFFLE:
-          for (int j = 0; j <= filters_meta[i]; j++) {
-            unshuffle(typesize, bsize, _src, _dest);
-            // Cycle filters when required
-            if (j < filters_meta[i]) {
-              _cycle_buffers(&_src, &_dest, &_tmp);
-            }
-            // Check whether we have to copy the intermediate _dest buffer to final destination
-            if (last_copy_filter && (filters_meta[i] % 2) == 1 && j == filters_meta[i]) {
-              memcpy(dest + offset, _dest, (unsigned int) bsize);
-            }
-          }
+          unshuffle(typesize, bsize, _src, _dest);
           break;
         case BLOSC_BITSHUFFLE:
           if (bitunshuffle(typesize, bsize, _src, _dest, context->src[BLOSC2_CHUNK_VERSION]) < 0) {

--- a/include/blosc2.h
+++ b/include/blosc2.h
@@ -245,14 +245,22 @@ enum {
  */
 enum {
 #ifndef BLOSC_H
-  BLOSC_NOSHUFFLE = 0,   //!< No shuffle (for compatibility with Blosc1).
-  BLOSC_NOFILTER = 0,    //!< No filter.
-  BLOSC_SHUFFLE = 1,     //!< Byte-wise shuffle.
-  BLOSC_BITSHUFFLE = 2,  //!< Bit-wise shuffle.
+  BLOSC_NOSHUFFLE = 0,
+  //!< No shuffle (for compatibility with Blosc1).
+  BLOSC_NOFILTER = 0,
+  //!< No filter.
+  BLOSC_SHUFFLE = 1,
+  //!< Byte-wise shuffle. `filters_meta` does not have any effect here.
+  BLOSC_BITSHUFFLE = 2,
+  //!< Bit-wise shuffle. `filters_meta` does not have any effect here.
 #endif // BLOSC_H
-  BLOSC_DELTA = 3,       //!< Delta filter.
-  BLOSC_TRUNC_PREC = 4,  //!< Truncate mantissa precision; positive values in `filters_meta` will keep bits; negative values will zero bits.
-  BLOSC_LAST_FILTER = 5, //!< sentinel
+  BLOSC_DELTA = 3,
+  //!< Delta filter. `filters_meta` does not have any effect here.
+  BLOSC_TRUNC_PREC = 4,
+  //!< Truncate mantissa precision.
+  //!< Positive values in `filters_meta` will keep bits; negative values will zero bits.
+  BLOSC_LAST_FILTER = 5,
+  //!< sentinel
   BLOSC_LAST_REGISTERED_FILTER = BLOSC2_GLOBAL_REGISTERED_FILTERS_START + BLOSC2_GLOBAL_REGISTERED_FILTERS - 1,
   //!< Determine the last registered filter. It is used to check if a filter is registered or not.
 };


### PR DESCRIPTION
We introduced the capability of repeating the shuffle filter (and only the shuffle) in C-Blosc2, but we recently discovered issues when using repeat values that are odd (i.e. not even).  This PR removes this capability because:

1) It is buggy
2) It was not documented
3) In our tests, it does not provide any significant advantage in compression ratio
4) It complicates code

As it was not documented (besides than buggy), we don't expect this would break anybody's code.

Also, this PR completes documentation on internal filters (essentially, it explicitly says that `filters_meta` does not have any effect on shuffle, bitshuffle and delta filters).