### PR TITLE
Fix trailer_len sizing mismatch

### DIFF
--- a/blosc/frame.c
+++ b/blosc/frame.c
@@ -551,7 +551,7 @@ int frame_update_trailer(blosc2_frame_s* frame, blosc2_schunk* schunk) {
   }
 
   // Create the trailer in msgpack (see the frame format document)
-  int64_t trailer_len = FRAME_TRAILER_MINLEN;
+  uint32_t trailer_len = FRAME_TRAILER_MINLEN;
   uint8_t* trailer = (uint8_t*)calloc((size_t)trailer_len, 1);
   uint8_t* ptrailer = trailer;
   *ptrailer = 0x90 + 4;  // fixarray with 4 elements


### PR DESCRIPTION
In `frame_update_trailer` the trailer len is `int64_t` which when written to the trailer len is expected to be `uint32_t`. On big-endian systems, this causes subsequent reads of cframes to have incorrect sizing as `frame_from_cframe` uses the correct 32bit size.

This will fix https://github.com/milesgranger/blosc2-rs/issues/23 for me, not sure how / if you want this tested on s390x / big endian.

Somewhat related to https://github.com/Blosc/c-blosc2/issues/467, but there as I understand it is when using a file backed schunk.