### PR TITLE
Add functions for c|dparams, storage and io defaults

### DIFF
--- a/blosc/blosc2.c
+++ b/blosc/blosc2.c
@@ -4695,10 +4695,16 @@ int blosc2_get_slice_nchunks(blosc2_schunk* schunk, int64_t *start, int64_t *sto
 
 blosc2_cparams blosc2_get_blosc2_cparams_defaults(void) {
   return BLOSC2_CPARAMS_DEFAULTS;
-}
+};
+
 blosc2_dparams blosc2_get_blosc2_dparams_defaults(void) {
   return BLOSC2_DPARAMS_DEFAULTS;
-}
+};
+
 blosc2_storage blosc2_get_blosc2_storage_defaults(void) {
   return BLOSC2_STORAGE_DEFAULTS;
-}
+};
+
+blosc2_io blosc2_get_blosc2_io_defaults(void) {
+  return BLOSC2_IO_DEFAULTS;
+};

--- a/blosc/blosc2.c
+++ b/blosc/blosc2.c
@@ -4692,3 +4692,13 @@ int blosc2_get_slice_nchunks(blosc2_schunk* schunk, int64_t *start, int64_t *sto
 
   return rc;
 }
+
+blosc2_cparams blosc2_get_blosc2_cparams_defaults(void) {
+  return BLOSC2_CPARAMS_DEFAULTS;
+}
+blosc2_dparams blosc2_get_blosc2_dparams_defaults(void) {
+  return BLOSC2_DPARAMS_DEFAULTS;
+}
+blosc2_storage blosc2_get_blosc2_storage_defaults(void) {
+  return BLOSC2_STORAGE_DEFAULTS;
+}

--- a/include/blosc2.h
+++ b/include/blosc2.h
@@ -1662,6 +1662,10 @@ typedef struct {
     //!< Input/output backend.
 } blosc2_storage;
 
+BLOSC_EXPORT blosc2_cparams blosc2_get_blosc2_cparams_defaults(void);
+BLOSC_EXPORT blosc2_dparams blosc2_get_blosc2_dparams_defaults(void);
+BLOSC_EXPORT blosc2_storage blosc2_get_blosc2_storage_defaults(void);
+
 /**
  * @brief Default struct for #blosc2_storage meant for user initialization.
  */

--- a/include/blosc2.h
+++ b/include/blosc2.h
@@ -1662,14 +1662,30 @@ typedef struct {
     //!< Input/output backend.
 } blosc2_storage;
 
-BLOSC_EXPORT blosc2_cparams blosc2_get_blosc2_cparams_defaults(void);
-BLOSC_EXPORT blosc2_dparams blosc2_get_blosc2_dparams_defaults(void);
-BLOSC_EXPORT blosc2_storage blosc2_get_blosc2_storage_defaults(void);
-
 /**
  * @brief Default struct for #blosc2_storage meant for user initialization.
  */
 static const blosc2_storage BLOSC2_STORAGE_DEFAULTS = {false, NULL, NULL, NULL, NULL};
+
+/**
+ * @brief Get default struct for compression params meant for user initialization.
+ */
+BLOSC_EXPORT blosc2_cparams blosc2_get_blosc2_cparams_defaults(void);
+
+/**
+ * @brief Get default struct for decompression params meant for user initialization.
+ */
+BLOSC_EXPORT blosc2_dparams blosc2_get_blosc2_dparams_defaults(void);
+
+/**
+ * @brief Get default struct for #blosc2_storage meant for user initialization.
+ */
+BLOSC_EXPORT blosc2_storage blosc2_get_blosc2_storage_defaults(void);
+
+/**
+ * @brief Get default struct for #blosc2_io meant for user initialization.
+ */
+BLOSC_EXPORT blosc2_io blosc2_get_blosc2_io_defaults(void);
 
 typedef struct blosc2_frame_s blosc2_frame;   /* opaque type */
 


### PR DESCRIPTION
Hello there,

While working on the rust bindings to c-blosc2 I currently zero initialize the C|DParams and Storage structs and works I think mostly by accident. I do this because the suggested use of `BLOSC2_STORAGE_DEFAULTS` and `BLOSC2_C|DPARAMS_DEFAULTS` doesn't work due to a [different bug in bindgen](https://github.com/rust-lang/rust-bindgen/issues/1888). 

I can understand if you don't want to include this, but it'd help me avoid maintaining a branch for compatibility. :) If you do, I'm happy to add/expand the docs to these functions. 