### PR TITLE
PowerPC: Check for VSX and power8 arch for enabling altivec implementations

### DIFF
--- a/blosc/bitshuffle-altivec.c
+++ b/blosc/bitshuffle-altivec.c
@@ -26,7 +26,7 @@
 #include "bitshuffle-generic.h"
 
 /* Make sure ALTIVEC is available for the compilation target and compiler. */
-#if defined(__ALTIVEC__)
+#if defined(__ALTIVEC__) && defined(__VSX__) && defined(_ARCH_PWR8)
 
 #include "transpose-altivec.h"
 

--- a/blosc/shuffle-altivec.c
+++ b/blosc/shuffle-altivec.c
@@ -12,7 +12,7 @@
 #include "shuffle-generic.h"
 
 /* Make sure ALTIVEC is available for the compilation target and compiler. */
-#if defined(__ALTIVEC__)
+#if defined(__ALTIVEC__) && defined(__VSX__) && defined(_ARCH_PWR8)
 
 #include "transpose-altivec.h"
 

--- a/blosc/shuffle.h
+++ b/blosc/shuffle.h
@@ -39,7 +39,7 @@
 #define SHUFFLE_USE_SSE2
 #endif
 
-#if defined(SHUFFLE_ALTIVEC_ENABLED) && defined(__ALTIVEC__)
+#if defined(SHUFFLE_ALTIVEC_ENABLED) && defined(__ALTIVEC__) && defined(__VSX__) && defined(_ARCH_PWR8)
 #define SHUFFLE_USE_ALTIVEC
 #endif
 


### PR DESCRIPTION
This PR adds more checks of C macro for enabling the altivec implementations of shuffle and bitshuffle.
Indeed checking `__ALTIVEC__` is not enough (see  #592 for details).

I tested this as part of `hdf5plugin` (see https://github.com/silx-kit/hdf5plugin/issues/307#issuecomment-2167946768).
Checking only `__VSX__` was not enough since some features were added over time and I had issue compiling with `-mcpu=power7`. 

Really not sure it is the best approach, but it looks to work for what I tested.


attn @barracuda156  @kif 
