### PR TITLE
Avoid rip-relative addressing for OSX x86_64

### DIFF
--- a/blosc/CMakeLists.txt
+++ b/blosc/CMakeLists.txt
@@ -37,6 +37,7 @@ if(BUILD_SHARED)
         $<INSTALL_INTERFACE:include>)
 endif()
 if(BUILD_STATIC)
+    add_compile_definitions(BUILD_STATIC)
     add_library(blosc2_static STATIC)
     # ALIAS for superbuilds that use Blosc2 as sub-project
     # must be the same as the NAMESPACE in Blosc2Targets

--- a/blosc/shuffle.c
+++ b/blosc/shuffle.c
@@ -52,7 +52,7 @@
 
 // __builtin_cpu_supports() fixed in GCC 8: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=85100
 // Also, clang added support for it in clang 10 at very least (and possibly since 3.8)
-#if (defined(__clang__) && (__clang_major__ >= 10)) || \
+#if (defined(__clang__) && (__clang_major__ >= 10)) && !(defined(__APPLE__) && defined(__x86_64__) && defined(BUILD_STATIC)) || \
     (defined(__GNUC__) && defined(__GNUC_MINOR__) && __GNUC__ >= 8)
 #define HAVE_CPU_FEAT_INTRIN
 #endif


### PR DESCRIPTION
G'day!

As part of [blosc2-rs](https://github.com/milesgranger/blosc2-rs) I find I need to add this caveat otherwise it fails on OSX x86_64 arch, but only when testing with static build of c-blosc2. 

Example failure run: https://github.com/milesgranger/blosc2-rs/actions/runs/10769365090/job/29860415491?pr=29#step:6:3029

> ld: invalid use of rip-relative addressing in '_get_shuffle_implementation' to '___cpu_model'

Maybe there is a proper way to fix this, or I'm doing something silly. 