### PR TITLE
Fix SEGV in blosc2_schunk_free()

### DIFF
--- a/blosc/blosc2.c
+++ b/blosc/blosc2.c
@@ -4647,7 +4647,7 @@ int blosc2_register_io_cb(const blosc2_io_cb *io) {
 
 blosc2_io_cb *blosc2_get_io_cb(uint8_t id) {
   // If g_initlib is not set by blosc2_init() this function will try to read
-  // uninitialized memory
+  // uninitialized memory. We should therefore always return NULL in that case
   if (!g_initlib) {
     return NULL;
   }

--- a/blosc/blosc2.c
+++ b/blosc/blosc2.c
@@ -4646,6 +4646,11 @@ int blosc2_register_io_cb(const blosc2_io_cb *io) {
 }
 
 blosc2_io_cb *blosc2_get_io_cb(uint8_t id) {
+  // If g_initlib is not set by blosc2_init() this function will try to read
+  // uninitialized memory
+  if (!g_initlib) {
+    return NULL;
+  }
   for (uint64_t i = 0; i < g_nio; ++i) {
     if (g_ios[i].id == id) {
       return &g_ios[i];

--- a/tests/test_schunk.c
+++ b/tests/test_schunk.c
@@ -168,7 +168,7 @@ static char* test_schunk(void) {
 static char* test_schunk_no_init(void)
 {
   // Test that calling blosc2_schunk without a call to blosc2_init() is valid and works as intended
-  // as this is the recommended route for multithreaded 
+  // as this is the recommended route for multithreaded compression/decompression
   static int32_t data[CHUNKSIZE];
   static int32_t data_dest[CHUNKSIZE];
   int32_t isize = CHUNKSIZE * sizeof(int32_t);

--- a/tests/test_schunk.c
+++ b/tests/test_schunk.c
@@ -173,6 +173,7 @@ static char* test_schunk_no_init(void)
   static int32_t data_dest[CHUNKSIZE];
   int32_t isize = CHUNKSIZE * sizeof(int32_t);
   int dsize;
+  int csize;
   blosc2_cparams cparams = BLOSC2_CPARAMS_DEFAULTS;
   blosc2_dparams dparams = BLOSC2_DPARAMS_DEFAULTS;
   blosc2_schunk* schunk;
@@ -193,7 +194,7 @@ static char* test_schunk_no_init(void)
     uint8_t* chunk = malloc(isize + BLOSC2_MAX_OVERHEAD);
     blosc2_context* ctx = blosc2_create_cctx(cparams);
 
-    blosc2_compress_ctx(ctx, data, isize, chunk, isize + BLOSC2_MAX_OVERHEAD);
+    csize = blosc2_compress_ctx(ctx, data, isize, chunk, isize + BLOSC2_MAX_OVERHEAD);
     int64_t nchunks_ = blosc2_schunk_append_chunk(schunk, chunk, false);
     mu_assert("ERROR: bad append in frame", nchunks_ > 0);
     blosc2_free_ctx(ctx);

--- a/tests/test_schunk.c
+++ b/tests/test_schunk.c
@@ -173,7 +173,6 @@ static char* test_schunk_no_init(void)
   static int32_t data_dest[CHUNKSIZE];
   int32_t isize = CHUNKSIZE * sizeof(int32_t);
   int dsize;
-  int64_t nbytes, cbytes;
   blosc2_cparams cparams = BLOSC2_CPARAMS_DEFAULTS;
   blosc2_dparams dparams = BLOSC2_DPARAMS_DEFAULTS;
   blosc2_schunk* schunk;
@@ -194,7 +193,7 @@ static char* test_schunk_no_init(void)
     uint8_t* chunk = malloc(isize + BLOSC2_MAX_OVERHEAD);
     blosc2_context* ctx = blosc2_create_cctx(cparams);
 
-    int csize = blosc2_compress_ctx(ctx, data, isize, chunk, isize + BLOSC2_MAX_OVERHEAD);
+    blosc2_compress_ctx(ctx, data, isize, chunk, isize + BLOSC2_MAX_OVERHEAD);
     int64_t nchunks_ = blosc2_schunk_append_chunk(schunk, chunk, false);
     mu_assert("ERROR: bad append in frame", nchunks_ > 0);
     blosc2_free_ctx(ctx);
@@ -211,6 +210,8 @@ static char* test_schunk_no_init(void)
   }
 
   blosc2_schunk_free(schunk);
+
+  return EXIT_SUCCESS;
 }
 
 


### PR DESCRIPTION
Apologies for only getting around to it now, this should address the recent regression in 2.15.0 :)

# Context:

#635 I noticed while upgrading to c-blosc2 2.15.0 that calling `blosc2_schunk_free()` without `blosc2_init()` being called first caused a SEGV as it was trying to access uninitialized memory

# Changes

- Added check to `blosc2_get_io_cb()` that returns `NULL` if the library was not initialized yet so we don't try to access a nullptr function in `blosc2_schunk_free()`
- Added test cases for "manual" compression and decompression using `blosc2_compress_ctx` and  `blosc2_decompress_ctx`. This does not in parallel but does trigger a test failure before my changes.

# Considerations

@FrancescAlted I noticed that `blosc2_destroy()` does not actually clean up the IO callbacks (note the order of tests, if it was reversed the tests would pass even without the fix). Is this intended?