### PR TITLE
Use _fseeki64/_ftelli64 on win

### DIFF
--- a/blosc/blosc2-stdio.c
+++ b/blosc/blosc2-stdio.c
@@ -24,6 +24,7 @@
 
 #if defined(_WIN32)
   #include <memoryapi.h>
+  #define lseek _lseeki64
 #else
   #include <sys/mman.h>
 #endif

--- a/blosc/blosc2-stdio.c
+++ b/blosc/blosc2-stdio.c
@@ -24,7 +24,8 @@
 
 #if defined(_WIN32)
   #include <memoryapi.h>
-  #define lseek _lseeki64
+  #define fseek _fseeki64
+  #define ftell _ftelli64
 #else
   #include <sys/mman.h>
 #endif


### PR DESCRIPTION
This should fix https://github.com/Blosc/python-blosc2/issues/359.