### PR TITLE
Suport for typesizes larger than 255 bytes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,10 +1,17 @@
 Release notes for C-Blosc2
 ==========================
 
-Changes from 2.16.0 to 2.16.1
+Changes from 2.16.0 to 2.17.0
 =============================
 
-#XXX version-specific blurb XXX#
+* New b2nd_copy_buffer2() function for copying buffers with typesizes
+  larger than 255.  The previous b2nd_copy_buffer() function is now
+  deprecated and will be removed in a future release.
+
+### Deprecated Functions
+
+- `int b2nd_copy_buffer(...)` is deprecated and will be removed in
+  a future release. Please use `b2nd_copy_buffer2(...)` instead.
 
 
 Changes from 2.15.2 to 2.16.0

--- a/bench/b2nd/bench_get_slice.c
+++ b/bench/b2nd/bench_get_slice.c
@@ -20,7 +20,7 @@ int main() {
   int nslices = 10;
 
   int8_t ndim = 3;
-  uint8_t itemsize = sizeof(DATA_TYPE);
+  int32_t itemsize = sizeof(DATA_TYPE);
 
   int64_t shape[] = {1250, 745, 400};
 

--- a/blosc/b2nd.c
+++ b/blosc/b2nd.c
@@ -355,7 +355,6 @@ int array_new(b2nd_context_t *ctx, int special_value, b2nd_array_t **array) {
   if ((*array)->nitems != 0) {
     int64_t nchunks = (*array)->extnitems / (*array)->chunknitems;
     int64_t nitems = nchunks * (*array)->extchunknitems;
-    // blosc2_schunk_fill_special(sc, nitems, BLOSC2_SPECIAL_ZERO, chunksize);
     BLOSC_ERROR(blosc2_schunk_fill_special(sc, nitems, special_value, chunksize));
   }
   (*array)->sc = sc;

--- a/blosc/b2nd.c
+++ b/blosc/b2nd.c
@@ -775,7 +775,7 @@ int get_set_slice(void *buffer, int64_t buffersize, const int64_t *start, const 
     BLOSC_ERROR(BLOSC2_ERROR_INVALID_PARAM);
   }
 
-  uint8_t *buffer_b = (uint8_t *) buffer;
+  uint8_t *buffer_b = buffer;
   const int64_t *buffer_start = start;
   const int64_t *buffer_stop = stop;
   const int64_t *buffer_shape = shape;
@@ -1069,13 +1069,13 @@ int get_set_slice(void *buffer, int64_t buffersize, const int64_t *start, const 
       }
 
       if (set_slice) {
-        b2nd_copy_buffer(ndim, array->sc->typesize,
-                         src, src_pad_shape, src_start, src_stop,
-                         dst, dst_pad_shape, dst_start);
+        b2nd_copy_buffer2(ndim, array->sc->typesize,
+                          src, src_pad_shape, src_start, src_stop,
+                          dst, dst_pad_shape, dst_start);
       } else {
-        b2nd_copy_buffer(ndim, array->sc->typesize,
-                         dst, dst_pad_shape, dst_start, dst_stop,
-                         src, src_pad_shape, src_start);
+        b2nd_copy_buffer2(ndim, array->sc->typesize,
+                          dst, dst_pad_shape, dst_start, dst_stop,
+                          src, src_pad_shape, src_start);
       }
     }
 
@@ -2103,13 +2103,15 @@ b2nd_create_ctx(const blosc2_storage *b2_storage, int8_t ndim, const int64_t *sh
   }
 
   if (dtype == NULL) {
-    ctx->dtype = strdup(B2ND_DEFAULT_DTYPE);
-    ctx->dtype_format = 0;  // The default is NumPy format
+    // ctx->dtype = strdup(B2ND_DEFAULT_DTYPE);
+    char buf[16] = {0};
+    snprintf(buf, sizeof(buf), "|S%d", cparams->typesize);
+    ctx->dtype = strdup(buf);
   }
   else {
     ctx->dtype = strdup(dtype);
-    ctx->dtype_format = dtype_format;
   }
+  ctx->dtype_format = dtype_format;
 
   params_b2_storage->cparams = cparams;
   ctx->b2_storage = params_b2_storage;

--- a/blosc/b2nd_utils.c
+++ b/blosc/b2nd_utils.c
@@ -332,7 +332,7 @@ int b2nd_copy_buffer(int8_t ndim,
                      const void *src, const int64_t *src_pad_shape,
                      const int64_t *src_start, const int64_t *src_stop,
                      void *dst, const int64_t *dst_pad_shape,
-                     const int64_t *dst_start) __attribute__((deprecated("Use b2nd_copy_buffer2 instead"))) {
+                     const int64_t *dst_start) {
   // Simply cast itemsize to int32_t and delegate
   return b2nd_copy_buffer2(ndim, (int32_t)itemsize, src, src_pad_shape,
                           src_start, src_stop, dst, dst_pad_shape, dst_start);

--- a/blosc/b2nd_utils.c
+++ b/blosc/b2nd_utils.c
@@ -11,7 +11,6 @@
 #include "b2nd.h"
 
 #include <stdint.h>
-#include <string.h>
 
 // copyNdim where N = {2-8} - specializations of copy loops to be used by b2nd_copy_buffer
 // since we don't have c++ templates, substitute manual specializations for up to known B2ND_MAX_DIM (8)
@@ -253,12 +252,12 @@ void copy_ndim_fallback(const int8_t ndim,
   }
 }
 
-int b2nd_copy_buffer(int8_t ndim,
-                     uint8_t itemsize,
-                     const void *src, const int64_t *src_pad_shape,
-                     const int64_t *src_start, const int64_t *src_stop,
-                     void *dst, const int64_t *dst_pad_shape,
-                     const int64_t *dst_start) {
+int b2nd_copy_buffer2(int8_t ndim,
+                      int32_t itemsize,
+                      const void *src, const int64_t *src_pad_shape,
+                      const int64_t *src_start, const int64_t *src_stop,
+                      void *dst, const int64_t *dst_pad_shape,
+                      const int64_t *dst_start) {
   // Compute the shape of the copy
   int64_t copy_shape[B2ND_MAX_DIM] = {0};
   for (int i = 0; i < ndim; ++i) {
@@ -324,4 +323,24 @@ int b2nd_copy_buffer(int8_t ndim,
   }
 
   return BLOSC2_ERROR_SUCCESS;
+}
+
+
+// Keep the old signature for API compatibility
+int b2nd_copy_buffer(int8_t ndim,
+                     uint8_t itemsize,
+                     const void *src, const int64_t *src_pad_shape,
+                     const int64_t *src_start, const int64_t *src_stop,
+                     void *dst, const int64_t *dst_pad_shape,
+                     const int64_t *dst_start) __attribute__((deprecated("Use b2nd_copy_buffer2 instead")));
+
+int b2nd_copy_buffer(int8_t ndim,
+                     uint8_t itemsize,
+                     const void *src, const int64_t *src_pad_shape,
+                     const int64_t *src_start, const int64_t *src_stop,
+                     void *dst, const int64_t *dst_pad_shape,
+                     const int64_t *dst_start) {
+  // Simply cast itemsize to int32_t and delegate
+  return b2nd_copy_buffer2(ndim, (int32_t)itemsize, src, src_pad_shape,
+                          src_start, src_stop, dst, dst_pad_shape, dst_start);
 }

--- a/blosc/b2nd_utils.c
+++ b/blosc/b2nd_utils.c
@@ -15,7 +15,7 @@
 // copyNdim where N = {2-8} - specializations of copy loops to be used by b2nd_copy_buffer
 // since we don't have c++ templates, substitute manual specializations for up to known B2ND_MAX_DIM (8)
 // it's not pretty, but it substantially reduces overhead vs. the generic method
-void copy8dim(const uint8_t itemsize,
+void copy8dim(const int32_t itemsize,
               const int64_t *copy_shape,
               const uint8_t *bsrc, const int64_t *src_strides,
               uint8_t *bdst, const int64_t *dst_strides) {
@@ -57,7 +57,7 @@ void copy8dim(const uint8_t itemsize,
   } while (copy_start[0] < copy_shape[0]);
 }
 
-void copy7dim(const uint8_t itemsize,
+void copy7dim(const int32_t itemsize,
               const int64_t *copy_shape,
               const uint8_t *bsrc, const int64_t *src_strides,
               uint8_t *bdst, const int64_t *dst_strides) {
@@ -95,7 +95,7 @@ void copy7dim(const uint8_t itemsize,
   } while (copy_start[0] < copy_shape[0]);
 }
 
-void copy6dim(const uint8_t itemsize,
+void copy6dim(const int32_t itemsize,
               const int64_t *copy_shape,
               const uint8_t *bsrc, const int64_t *src_strides,
               uint8_t *bdst, const int64_t *dst_strides) {
@@ -129,7 +129,7 @@ void copy6dim(const uint8_t itemsize,
   } while (copy_start[0] < copy_shape[0]);
 }
 
-void copy5dim(const uint8_t itemsize,
+void copy5dim(const int32_t itemsize,
               const int64_t *copy_shape,
               const uint8_t *bsrc, const int64_t *src_strides,
               uint8_t *bdst, const int64_t *dst_strides) {
@@ -159,7 +159,7 @@ void copy5dim(const uint8_t itemsize,
   } while (copy_start[0] < copy_shape[0]);
 }
 
-void copy4dim(const uint8_t itemsize,
+void copy4dim(const int32_t itemsize,
               const int64_t *copy_shape,
               const uint8_t *bsrc, const int64_t *src_strides,
               uint8_t *bdst, const int64_t *dst_strides) {
@@ -185,7 +185,7 @@ void copy4dim(const uint8_t itemsize,
   } while (copy_start[0] < copy_shape[0]);
 }
 
-void copy3dim(const uint8_t itemsize,
+void copy3dim(const int32_t itemsize,
               const int64_t *copy_shape,
               const uint8_t *bsrc, const int64_t *src_strides,
               uint8_t *bdst, const int64_t *dst_strides) {
@@ -207,7 +207,7 @@ void copy3dim(const uint8_t itemsize,
   } while (copy_start[0] < copy_shape[0]);
 }
 
-void copy2dim(const uint8_t itemsize,
+void copy2dim(const int32_t itemsize,
               const int64_t *copy_shape,
               const uint8_t *bsrc, const int64_t *src_strides,
               uint8_t *bdst, const int64_t *dst_strides) {
@@ -223,7 +223,7 @@ void copy2dim(const uint8_t itemsize,
 
 
 void copy_ndim_fallback(const int8_t ndim,
-                        const uint8_t itemsize,
+                        const int32_t itemsize,
                         int64_t *copy_shape,
                         const uint8_t *bsrc, int64_t *src_strides,
                         uint8_t *bdst, int64_t *dst_strides) {
@@ -268,13 +268,13 @@ int b2nd_copy_buffer2(int8_t ndim,
   }
 
   // Compute the strides
-  int64_t src_strides[B2ND_MAX_DIM];
+  int64_t src_strides[B2ND_MAX_DIM] = {0};
   src_strides[ndim - 1] = 1;
   for (int i = ndim - 2; i >= 0; --i) {
     src_strides[i] = src_strides[i + 1] * src_pad_shape[i + 1];
   }
 
-  int64_t dst_strides[B2ND_MAX_DIM];
+  int64_t dst_strides[B2ND_MAX_DIM] = {0};
   dst_strides[ndim - 1] = 1;
   for (int i = ndim - 2; i >= 0; --i) {
     dst_strides[i] = dst_strides[i + 1] * dst_pad_shape[i + 1];
@@ -332,14 +332,7 @@ int b2nd_copy_buffer(int8_t ndim,
                      const void *src, const int64_t *src_pad_shape,
                      const int64_t *src_start, const int64_t *src_stop,
                      void *dst, const int64_t *dst_pad_shape,
-                     const int64_t *dst_start) __attribute__((deprecated("Use b2nd_copy_buffer2 instead")));
-
-int b2nd_copy_buffer(int8_t ndim,
-                     uint8_t itemsize,
-                     const void *src, const int64_t *src_pad_shape,
-                     const int64_t *src_start, const int64_t *src_stop,
-                     void *dst, const int64_t *dst_pad_shape,
-                     const int64_t *dst_start) {
+                     const int64_t *dst_start) __attribute__((deprecated("Use b2nd_copy_buffer2 instead"))) {
   // Simply cast itemsize to int32_t and delegate
   return b2nd_copy_buffer2(ndim, (int32_t)itemsize, src, src_pad_shape,
                           src_start, src_stop, dst, dst_pad_shape, dst_start);

--- a/blosc/blosc2.c
+++ b/blosc/blosc2.c
@@ -728,6 +728,18 @@ int read_chunk_header(const uint8_t* src, int32_t srcsize, bool extended_header,
       if (special_type == BLOSC2_SPECIAL_VALUE) {
         // In this case, the actual type size must be derived from the cbytes
         int32_t typesize = header->cbytes - BLOSC_EXTENDED_HEADER_LENGTH;
+        if (typesize <= 0) {
+          BLOSC_TRACE_ERROR("`typesize` is zero or negative");
+          return BLOSC2_ERROR_INVALID_HEADER;
+        }
+        if (typesize > BLOSC2_MAXTYPESIZE) {
+          BLOSC_TRACE_ERROR("`typesize` is greater than maximum allowed");
+          return BLOSC2_ERROR_INVALID_HEADER;
+        }
+        if (typesize > header->nbytes) {
+          BLOSC_TRACE_ERROR("`typesize` is greater than `nbytes`");
+          return BLOSC2_ERROR_INVALID_HEADER;
+        }
         if (header->nbytes % typesize != 0) {
           BLOSC_TRACE_ERROR("`nbytes` is not a multiple of typesize");
           return BLOSC2_ERROR_INVALID_HEADER;

--- a/blosc/blosc2.c
+++ b/blosc/blosc2.c
@@ -2266,6 +2266,12 @@ static int initialize_context_compression(
   }
 
   /* Check typesize limits */
+  if (context->typesize > BLOSC2_MAXTYPESIZE) {
+    // If typesize is too large for Blosc2, return an error
+    BLOSC_TRACE_ERROR("Typesize cannot exceed %d bytes.", BLOSC2_MAXTYPESIZE);
+    return BLOSC2_ERROR_INVALID_PARAM;
+  }
+  /* Now, cap typesize so that blosc2 split machinery can continue to work */
   if (context->typesize > BLOSC_MAX_TYPESIZE) {
     /* If typesize is too large, treat buffer as an 1-byte stream. */
     context->typesize = 1;

--- a/blosc/blosc2.c
+++ b/blosc/blosc2.c
@@ -2160,7 +2160,7 @@ static int initialize_context_compression(
   context->output_bytes = 0;
   context->destsize = destsize;
   context->sourcesize = srcsize;
-  context->typesize = (int32_t)typesize;
+  context->typesize = typesize;
   context->filter_flags = filters_to_flags(filters);
   for (int i = 0; i < BLOSC2_MAX_FILTERS; i++) {
     context->filters[i] = filters[i];
@@ -4417,8 +4417,7 @@ int blosc2_chunk_nans(blosc2_cparams cparams, const int32_t nbytes, void* dest, 
 /* Create a chunk made of repeated values */
 int blosc2_chunk_repeatval(blosc2_cparams cparams, const int32_t nbytes,
                            void* dest, int32_t destsize, const void* repeatval) {
-  uint8_t typesize = cparams.typesize;
-  if (destsize < BLOSC_EXTENDED_HEADER_LENGTH + typesize) {
+  if (destsize < BLOSC_EXTENDED_HEADER_LENGTH + cparams.typesize) {
     BLOSC_TRACE_ERROR("dest buffer is not long enough");
     return BLOSC2_ERROR_DATA;
   }
@@ -4450,17 +4449,17 @@ int blosc2_chunk_repeatval(blosc2_cparams cparams, const int32_t nbytes,
   header.version = BLOSC2_VERSION_FORMAT;
   header.versionlz = BLOSC_BLOSCLZ_VERSION_FORMAT;
   header.flags = BLOSC_DOSHUFFLE | BLOSC_DOBITSHUFFLE;  // extended header
-  header.typesize = (uint8_t)typesize;
+  header.typesize = context->typesize;
   header.nbytes = (int32_t)nbytes;
   header.blocksize = context->blocksize;
-  header.cbytes = BLOSC_EXTENDED_HEADER_LENGTH + (int32_t)typesize;
+  header.cbytes = BLOSC_EXTENDED_HEADER_LENGTH + cparams.typesize;
   header.blosc2_flags = BLOSC2_SPECIAL_VALUE << 4;  // mark chunk as all repeated value
   memcpy((uint8_t *)dest, &header, sizeof(header));
-  memcpy((uint8_t *)dest + sizeof(header), repeatval, typesize);
+  memcpy((uint8_t *)dest + sizeof(header), repeatval, cparams.typesize);
 
   blosc2_free_ctx(context);
 
-  return BLOSC_EXTENDED_HEADER_LENGTH + (uint8_t)typesize;
+  return BLOSC_EXTENDED_HEADER_LENGTH + cparams.typesize;
 }
 
 

--- a/doc/reference/b2nd.rst
+++ b/doc/reference/b2nd.rst
@@ -109,3 +109,4 @@ Utilities
 These functions may be used for working with plain C buffers representing multidimensional arrays.
 
 .. doxygenfunction:: b2nd_copy_buffer
+.. doxygenfunction:: b2nd_copy_buffer2

--- a/include/b2nd.h
+++ b/include/b2nd.h
@@ -574,7 +574,8 @@ BLOSC_EXPORT int b2nd_copy_buffer(int8_t ndim,
                                   const void *src, const int64_t *src_pad_shape,
                                   const int64_t *src_start, const int64_t *src_stop,
                                   void *dst, const int64_t *dst_pad_shape,
-                                  const int64_t *dst_start);
+                                  const int64_t *dst_start)
+  __attribute__((deprecated("Use b2nd_copy_buffer2 instead")));
 
 
 /**

--- a/include/b2nd.h
+++ b/include/b2nd.h
@@ -562,6 +562,9 @@ BLOSC_EXPORT int b2nd_deserialize_meta(const uint8_t *smeta, int32_t smeta_len, 
  *
  * @return An error code.
  *
+ * @note This is kept for backward compatibility with existing code out there.  New code should use
+ * b2nd_copy_buffer2 instead.
+ *
  * @note Please make sure that slice boundaries fit within the source and
  * destination arrays before using this function, as it does not perform these
  * checks itself.
@@ -572,6 +575,40 @@ BLOSC_EXPORT int b2nd_copy_buffer(int8_t ndim,
                                   const int64_t *src_start, const int64_t *src_stop,
                                   void *dst, const int64_t *dst_pad_shape,
                                   const int64_t *dst_start);
+
+
+/**
+ * @brief Copy a slice of a source array into another array. The arrays have
+ * the same number of dimensions (though their shapes may differ), the same
+ * item size, and they are stored as C buffers with contiguous data (any
+ * padding is considered part of the array).
+ *
+ * @param ndim The number of dimensions in both arrays.
+ * @param itemsize The size of the individual data item in both arrays.
+ * @param src The buffer for getting the data from the source array.
+ * @param src_pad_shape The shape of the source array, including padding.
+ * @param src_start The source coordinates where the slice will begin.
+ * @param src_stop The source coordinates where the slice will end.
+ * @param dst The buffer for setting the data into the destination array.
+ * @param dst_pad_shape The shape of the destination array, including padding.
+ * @param dst_start The destination coordinates where the slice will be placed.
+ *
+ * @return An error code.
+ *
+ * @note This is a version of b2nd_copy_buffer that uses signed 32-bit integers for
+ * copying data. This is useful when the data is stored in a buffer that uses
+ * itemsizes that are larger than 255 bytes.
+ *
+ * @note Please make sure that slice boundaries fit within the source and
+ * destination arrays before using this function, as it does not perform these
+ * checks itself.
+ */
+BLOSC_EXPORT int b2nd_copy_buffer2(int8_t ndim,
+                                   int32_t itemsize,
+                                   const void *src, const int64_t *src_pad_shape,
+                                   const int64_t *src_start, const int64_t *src_stop,
+                                   void *dst, const int64_t *dst_pad_shape,
+                                   const int64_t *dst_start);
 
 
 #ifdef __cplusplus

--- a/include/b2nd.h
+++ b/include/b2nd.h
@@ -35,6 +35,13 @@ extern "C" {
 extern "C" {
 #endif
 
+#if defined(_MSC_VER)
+#define B2ND_DEPRECATED(msg) __declspec(deprecated(msg))
+#elif defined(__GNUC__) || defined(__clang__)
+#define B2ND_DEPRECATED(msg) __attribute__((deprecated(msg)))
+#else
+#define B2ND_DEPRECATED(msg)
+#endif
 
 /* The version for metalayer format; starts from 0 and it must not exceed 127 */
 #define B2ND_METALAYER_VERSION 0
@@ -569,14 +576,13 @@ BLOSC_EXPORT int b2nd_deserialize_meta(const uint8_t *smeta, int32_t smeta_len, 
  * destination arrays before using this function, as it does not perform these
  * checks itself.
  */
+B2ND_DEPRECATED("Use b2nd_copy_buffer2 instead.")
 BLOSC_EXPORT int b2nd_copy_buffer(int8_t ndim,
                                   uint8_t itemsize,
                                   const void *src, const int64_t *src_pad_shape,
                                   const int64_t *src_start, const int64_t *src_stop,
                                   void *dst, const int64_t *dst_pad_shape,
-                                  const int64_t *dst_start)
-  __attribute__((deprecated("Use b2nd_copy_buffer2 instead")));
-
+                                  const int64_t *dst_start);
 
 /**
  * @brief Copy a slice of a source array into another array. The arrays have
@@ -596,9 +602,9 @@ BLOSC_EXPORT int b2nd_copy_buffer(int8_t ndim,
  *
  * @return An error code.
  *
- * @note This is a version of b2nd_copy_buffer that uses signed 32-bit integers for
- * copying data. This is useful when the data is stored in a buffer that uses
- * itemsizes that are larger than 255 bytes.
+ * @note This is a version of (now deprecated) b2nd_copy_buffer() that uses
+ * signed 32-bit integers for copying data. This is useful when data is stored
+ * in a buffer that uses itemsizes that are larger than 255 bytes.
  *
  * @note Please make sure that slice boundaries fit within the source and
  * destination arrays before using this function, as it does not perform these

--- a/include/blosc2.h
+++ b/include/blosc2.h
@@ -429,7 +429,7 @@ enum {
   BLOSC2_NO_SPECIAL = 0x0,       //!< no special value
   BLOSC2_SPECIAL_ZERO = 0x1,     //!< zero special value
   BLOSC2_SPECIAL_NAN = 0x2,      //!< NaN special value
-  BLOSC2_SPECIAL_VALUE = 0x3,    //!< generic special value
+  BLOSC2_SPECIAL_VALUE = 0x3,    //!< repeated special value
   BLOSC2_SPECIAL_UNINIT = 0x4,   //!< non initialized values
   BLOSC2_SPECIAL_LASTID = 0x4,   //!< last valid ID for special value (update this adequately)
   BLOSC2_SPECIAL_MASK = 0x7      //!< special value mask (prev IDs cannot be larger than this)

--- a/include/blosc2.h
+++ b/include/blosc2.h
@@ -291,7 +291,8 @@ enum {
  */
 enum {
   BLOSC2_MAXDICTSIZE = 128 * 1024, //!< maximum size for compression dicts
-  BLOSC2_MAXBLOCKSIZE = 536866816  //!< maximum size for blocks
+  BLOSC2_MAXBLOCKSIZE = 536866816, //!< maximum size for blocks
+  BLOSC2_MAXTYPESIZE = BLOSC2_MAXBLOCKSIZE, //!< maximum size for types
 };
 
 

--- a/tests/b2nd/test_b2nd_copy_buffer.c
+++ b/tests/b2nd/test_b2nd_copy_buffer.c
@@ -64,6 +64,20 @@ CUTEST_TEST_TEST(copy_buffer) {
     CUTEST_ASSERT("Elements are not equal!", a == b);
   }
 
+  int32_t itemsize2 = itemsize;
+  B2ND_TEST_ASSERT(b2nd_copy_buffer2(ndim, itemsize2,
+                                     chunk0x, chunk_shape, chunk0s_start, chunk0s_stop,
+                                     dest, dest_shape, chunk0s_dest));
+  B2ND_TEST_ASSERT(b2nd_copy_buffer2(ndim, itemsize2,
+                                     chunk1x, chunk_shape, chunk1s_start, chunk1s_stop,
+                                     dest, dest_shape, chunk1s_dest));
+
+  for (int i = 0; i < result_length; ++i) {
+    uint8_t a = dest[i];
+    uint8_t b = result[i];
+    CUTEST_ASSERT("Elements are not equal!", a == b);
+  }
+
   return 0;
 }
 

--- a/tests/b2nd/test_b2nd_copy_buffer.c
+++ b/tests/b2nd/test_b2nd_copy_buffer.c
@@ -26,7 +26,7 @@ CUTEST_TEST_SETUP(copy_buffer) {
 
 CUTEST_TEST_TEST(copy_buffer) {
   const int8_t ndim = 3;
-  const uint8_t itemsize = sizeof(uint8_t);
+  const int32_t itemsize = sizeof(uint8_t);
 
   const int64_t chunk_shape[] = {3, 3, 1};
 
@@ -51,24 +51,10 @@ CUTEST_TEST_TEST(copy_buffer) {
                     0, 0};
   const int64_t dest_shape[] = {2, 2, 2};
 
-  B2ND_TEST_ASSERT(b2nd_copy_buffer(ndim, itemsize,
-                                    chunk0x, chunk_shape, chunk0s_start, chunk0s_stop,
-                                    dest, dest_shape, chunk0s_dest));
-  B2ND_TEST_ASSERT(b2nd_copy_buffer(ndim, itemsize,
-                                    chunk1x, chunk_shape, chunk1s_start, chunk1s_stop,
-                                    dest, dest_shape, chunk1s_dest));
-
-  for (int i = 0; i < result_length; ++i) {
-    uint8_t a = dest[i];
-    uint8_t b = result[i];
-    CUTEST_ASSERT("Elements are not equal!", a == b);
-  }
-
-  int32_t itemsize2 = itemsize;
-  B2ND_TEST_ASSERT(b2nd_copy_buffer2(ndim, itemsize2,
+  B2ND_TEST_ASSERT(b2nd_copy_buffer2(ndim, itemsize,
                                      chunk0x, chunk_shape, chunk0s_start, chunk0s_stop,
                                      dest, dest_shape, chunk0s_dest));
-  B2ND_TEST_ASSERT(b2nd_copy_buffer2(ndim, itemsize2,
+  B2ND_TEST_ASSERT(b2nd_copy_buffer2(ndim, itemsize,
                                      chunk1x, chunk_shape, chunk1s_start, chunk1s_stop,
                                      dest, dest_shape, chunk1s_dest));
 

--- a/tests/b2nd/test_b2nd_full.c
+++ b/tests/b2nd/test_b2nd_full.c
@@ -17,34 +17,33 @@ CUTEST_TEST_SETUP(full) {
 
   // Add parametrizations
   CUTEST_PARAMETRIZE(typesize, int32_t, CUTEST_DATA(
-      //1, 2, 4, 8,
-      256, //257, 256 * 256,
-      // 256*256*256, 256*256*256*8,  // these should work for small shapes as well, but are too slow
+      1, 2, 4, 8, 16,
+      255, 256, 257,  // useful to testing typesizes equal or larger than 255
+      // 256 * 256, // this should work for all shapes as well, but is too slow
+      //  256*256*256, 256*256*256*8,  // this should for work small shapes, but is way sloooower
   ));
   CUTEST_PARAMETRIZE(shapes, _test_shapes, CUTEST_DATA(
-    // {0, {0}, {0}, {0}}, // 0-dim
-    // {1, {5}, {3}, {2}}, // 1-idim
-    // {2, {20, 0}, {7, 0}, {3, 0}}, // 0-shape
-    //{2, {20, 10}, {20, 10}, {10, 10}}, // funciona sempre
-    //{2, {20, 10}, {10, 5}, {10, 5}}, // falla
-    //{2, {4, 1}, {2, 1}, {2, 1}}, // falla
-    {2, {1, 3}, {1, 2}, {1, 2}}, // falla
-    //{1, {4}, {2}, {2}}, // funciona sempre
-    //{2, {20, 10}, {8, 6}, {7, 5}}, // falla
-    //{2, {20, 10}, {7, 5}, {3, 5}}, // falla
-    //{2, {14, 10}, {8, 5}, {2, 2}}, // general,
-    //{3, {12, 10, 14}, {3, 5, 9}, {3, 4, 4}}, // general
-    //{3, {10, 21, 20, 5}, {8, 7, 15, 3}, {5, 5, 10, 1}}, // general,
+    {0, {0}, {0}, {0}}, // 0-dim
+    {1, {5}, {3}, {2}}, // 1-idim
+    {2, {20, 0}, {7, 0}, {3, 0}}, // 0-shape
+    {2, {20, 10}, {20, 10}, {10, 10}}, // simple 2-dim
+    {2, {20, 10}, {10, 5}, {10, 5}}, // non-contiguous
+    {2, {4, 1}, {2, 1}, {2, 1}},
+    {2, {1, 3}, {1, 2}, {1, 2}},
+    {2, {20, 10}, {8, 6}, {7, 5}},
+    {2, {20, 10}, {7, 5}, {3, 5}},
+    {2, {14, 10}, {8, 5}, {2, 2}},
+    {3, {12, 10, 14}, {3, 5, 9}, {3, 4, 4}}, // 3-dim
+    {4, {10, 21, 20, 5}, {8, 7, 15, 3}, {5, 5, 10, 1}}, // 4-dim
   ));
   CUTEST_PARAMETRIZE(backend, _test_backend, CUTEST_DATA(
       {false, false},
-      // {true, false},
-      // {true, true},
-      // {false, true},
+      {true, false},
+      {true, true},
+      {false, true},
   ));
   CUTEST_PARAMETRIZE(fill_value, int8_t, CUTEST_DATA(
-      //3, 113, 33, -5
-      3
+      3, 113, 33, -5
   ));
 }
 
@@ -131,9 +130,9 @@ CUTEST_TEST_TEST(full) {
         }
         // Compare buffer_fill with buffer_dest
         is_true = memcmp(buffer_fill, buffer_dest, typesize) == 0;
-        // print the 10 first bytes of buffer_fill and buffer_dest
+        // print the N first bytes of buffer_fill and buffer_dest
         // printf("buffer_fill: ");
-        // for (int j = 0; j < 10; ++j) {
+        // for (int j = 0; j < 3; ++j) {
         //   printf("%d vs %d ", buffer_fill[j], buffer_dest[j]);
         // }
         free(buffer_fill);

--- a/tests/b2nd/test_b2nd_full.c
+++ b/tests/b2nd/test_b2nd_full.c
@@ -18,18 +18,23 @@ CUTEST_TEST_SETUP(full) {
   // Add parametrizations
   CUTEST_PARAMETRIZE(typesize, int32_t, CUTEST_DATA(
       //1, 2, 4, 8,
-      256, // 256, 257, 256 * 256,
-      // 256*256*256, 256*256*256*8  # these should work for small shapes as well, but are too slow
+      256, //257, 256 * 256,
+      // 256*256*256, 256*256*256*8,  // these should work for small shapes as well, but are too slow
   ));
   CUTEST_PARAMETRIZE(shapes, _test_shapes, CUTEST_DATA(
-      {1, {3}, {3}, {3}}, // 1-idim
-      // {0, {0}, {0}, {0}}, // 0-dim
-      //{1, {5}, {3}, {2}}, // 1-idim
-      // {2, {20, 0}, {7, 0}, {3, 0}}, // 0-shape
-      // {2, {20, 10}, {7, 5}, {3, 5}}, // 0-shape
-      // {2, {14, 10}, {8, 5}, {2, 2}}, // general,
-      // {3, {12, 10, 14}, {3, 5, 9}, {3, 4, 4}}, // general
-      // {3, {10, 21, 20, 5}, {8, 7, 15, 3}, {5, 5, 10, 1}}, // general,
+    // {0, {0}, {0}, {0}}, // 0-dim
+    // {1, {5}, {3}, {2}}, // 1-idim
+    // {2, {20, 0}, {7, 0}, {3, 0}}, // 0-shape
+    //{2, {20, 10}, {20, 10}, {10, 10}}, // funciona sempre
+    //{2, {20, 10}, {10, 5}, {10, 5}}, // falla
+    //{2, {4, 1}, {2, 1}, {2, 1}}, // falla
+    {2, {1, 3}, {1, 2}, {1, 2}}, // falla
+    //{1, {4}, {2}, {2}}, // funciona sempre
+    //{2, {20, 10}, {8, 6}, {7, 5}}, // falla
+    //{2, {20, 10}, {7, 5}, {3, 5}}, // falla
+    //{2, {14, 10}, {8, 5}, {2, 2}}, // general,
+    //{3, {12, 10, 14}, {3, 5, 9}, {3, 4, 4}}, // general
+    //{3, {10, 21, 20, 5}, {8, 7, 15, 3}, {5, 5, 10, 1}}, // general,
   ));
   CUTEST_PARAMETRIZE(backend, _test_backend, CUTEST_DATA(
       {false, false},
@@ -47,14 +52,14 @@ CUTEST_TEST_SETUP(full) {
 CUTEST_TEST_TEST(full) {
   CUTEST_GET_PARAMETER(backend, _test_backend);
   CUTEST_GET_PARAMETER(shapes, _test_shapes);
-  CUTEST_GET_PARAMETER(typesize, uint32_t);
+  CUTEST_GET_PARAMETER(typesize, int32_t);
   CUTEST_GET_PARAMETER(fill_value, int8_t);
 
   char *urlpath = "test_full.b2frame";
   blosc2_remove_urlpath(urlpath);
 
   blosc2_cparams cparams = BLOSC2_CPARAMS_DEFAULTS;
-  cparams.nthreads = 2;
+  cparams.nthreads = 1;
   cparams.typesize = typesize;
   blosc2_storage b2_storage = {.cparams=&cparams};
 
@@ -121,16 +126,16 @@ CUTEST_TEST_TEST(full) {
         break;
       default:
         // Fill a buffer with fill_value and compare with buffer_dest
-        for (int j = 0; j < typesize; ++j) {
+        for (uint32_t j = 0; j < typesize; ++j) {
           buffer_fill[j] = fill_value;
         }
         // Compare buffer_fill with buffer_dest
         is_true = memcmp(buffer_fill, buffer_dest, typesize) == 0;
         // print the 10 first bytes of buffer_fill and buffer_dest
-        printf("buffer_fill: ");
-        for (int j = 0; j < 10; ++j) {
-          printf("%d vs %d ", buffer_fill[j], buffer_dest[j]);
-        }
+        // printf("buffer_fill: ");
+        // for (int j = 0; j < 10; ++j) {
+        //   printf("%d vs %d ", buffer_fill[j], buffer_dest[j]);
+        // }
         free(buffer_fill);
         break;
     }

--- a/tests/b2nd/test_b2nd_full.c
+++ b/tests/b2nd/test_b2nd_full.c
@@ -58,7 +58,7 @@ CUTEST_TEST_TEST(full) {
   blosc2_remove_urlpath(urlpath);
 
   blosc2_cparams cparams = BLOSC2_CPARAMS_DEFAULTS;
-  cparams.nthreads = 1;
+  cparams.nthreads = 2;
   cparams.typesize = typesize;
   blosc2_storage b2_storage = {.cparams=&cparams};
 
@@ -125,7 +125,7 @@ CUTEST_TEST_TEST(full) {
         break;
       default:
         // Fill a buffer with fill_value and compare with buffer_dest
-        for (uint32_t j = 0; j < typesize; ++j) {
+        for (int32_t j = 0; j < typesize; ++j) {
           buffer_fill[j] = fill_value;
         }
         // Compare buffer_fill with buffer_dest

--- a/tests/b2nd/test_b2nd_full.c
+++ b/tests/b2nd/test_b2nd_full.c
@@ -16,26 +16,30 @@ CUTEST_TEST_SETUP(full) {
   blosc2_init();
 
   // Add parametrizations
-  CUTEST_PARAMETRIZE(typesize, uint8_t, CUTEST_DATA(
-      1, 2, 4, 8
+  CUTEST_PARAMETRIZE(typesize, int32_t, CUTEST_DATA(
+      //1, 2, 4, 8,
+      256, // 256, 257, 256 * 256,
+      // 256*256*256, 256*256*256*8  # these should work for small shapes as well, but are too slow
   ));
   CUTEST_PARAMETRIZE(shapes, _test_shapes, CUTEST_DATA(
-      {0, {0}, {0}, {0}}, // 0-dim
-      {1, {5}, {3}, {2}}, // 1-idim
-      {2, {20, 0}, {7, 0}, {3, 0}}, // 0-shape
-      {2, {20, 10}, {7, 5}, {3, 5}}, // 0-shape
-      {2, {14, 10}, {8, 5}, {2, 2}}, // general,
-      {3, {12, 10, 14}, {3, 5, 9}, {3, 4, 4}}, // general
-      {3, {10, 21, 20, 5}, {8, 7, 15, 3}, {5, 5, 10, 1}}, // general,
+      {1, {3}, {3}, {3}}, // 1-idim
+      // {0, {0}, {0}, {0}}, // 0-dim
+      //{1, {5}, {3}, {2}}, // 1-idim
+      // {2, {20, 0}, {7, 0}, {3, 0}}, // 0-shape
+      // {2, {20, 10}, {7, 5}, {3, 5}}, // 0-shape
+      // {2, {14, 10}, {8, 5}, {2, 2}}, // general,
+      // {3, {12, 10, 14}, {3, 5, 9}, {3, 4, 4}}, // general
+      // {3, {10, 21, 20, 5}, {8, 7, 15, 3}, {5, 5, 10, 1}}, // general,
   ));
   CUTEST_PARAMETRIZE(backend, _test_backend, CUTEST_DATA(
       {false, false},
-      {true, false},
-      {true, true},
-      {false, true},
+      // {true, false},
+      // {true, true},
+      // {false, true},
   ));
   CUTEST_PARAMETRIZE(fill_value, int8_t, CUTEST_DATA(
-      3, 113, 33, -5
+      //3, 113, 33, -5
+      3
   ));
 }
 
@@ -43,7 +47,7 @@ CUTEST_TEST_SETUP(full) {
 CUTEST_TEST_TEST(full) {
   CUTEST_GET_PARAMETER(backend, _test_backend);
   CUTEST_GET_PARAMETER(shapes, _test_shapes);
-  CUTEST_GET_PARAMETER(typesize, uint8_t);
+  CUTEST_GET_PARAMETER(typesize, uint32_t);
   CUTEST_GET_PARAMETER(fill_value, int8_t);
 
   char *urlpath = "test_full.b2frame";
@@ -85,6 +89,10 @@ CUTEST_TEST_TEST(full) {
       ((int8_t *) value)[0] = fill_value;
       break;
     default:
+      // Fill a buffer with fill_value
+      for (int i = 0; i < typesize; ++i) {
+        value[i] = fill_value;
+      }
       break;
   }
 
@@ -96,6 +104,7 @@ CUTEST_TEST_TEST(full) {
 
   /* Testing */
   for (int i = 0; i < buffersize / typesize; ++i) {
+    uint8_t *buffer_fill = malloc(typesize);
     bool is_true = false;
     switch (typesize) {
       case 8:
@@ -111,9 +120,21 @@ CUTEST_TEST_TEST(full) {
         is_true = ((int8_t *) buffer_dest)[i] == fill_value;
         break;
       default:
+        // Fill a buffer with fill_value and compare with buffer_dest
+        for (int j = 0; j < typesize; ++j) {
+          buffer_fill[j] = fill_value;
+        }
+        // Compare buffer_fill with buffer_dest
+        is_true = memcmp(buffer_fill, buffer_dest, typesize) == 0;
+        // print the 10 first bytes of buffer_fill and buffer_dest
+        printf("buffer_fill: ");
+        for (int j = 0; j < 10; ++j) {
+          printf("%d vs %d ", buffer_fill[j], buffer_dest[j]);
+        }
+        free(buffer_fill);
         break;
     }
-    CUTEST_ASSERT("Elements are not equals", is_true);
+    CUTEST_ASSERT("Elements are not equal", is_true);
   }
 
   /* Free mallocs */


### PR DESCRIPTION
Tests and docs have been updated.

I needed to change the signature of public `b2nd_copy_buffer` for accepting an itemsize > 255, so I have added a new `b2nd_copy_buffer2` for not creating API changes and being backward compatible.  As a consequence, `b2nd_copy_buffer` has been declared deprecated (this should affect upstream projects like PyTables and python-blosc2).  Using `b2nd_copy_buffer2` instead should be straightforward.