### PR TITLE
Fixed issue #633 Handle leak in parallel (nThread > 1) zstd decompres…

### DIFF
--- a/blosc/win32/pthread.c
+++ b/blosc/win32/pthread.c
@@ -77,8 +77,10 @@ int win32_pthread_join(pthread_t *thread, void **value_ptr)
 		case WAIT_OBJECT_0:
 			if (value_ptr)
 				*value_ptr = thread->arg;
+			CloseHandle(thread->handle);
 			return 0;
 		case WAIT_ABANDONED:
+			CloseHandle(thread->handle);
 			return EINVAL;
 		default:
 			return GetLastError();


### PR DESCRIPTION
This fix resolves #633.

The bug only affects windows platform in case de-compression is configured to be processed in parallel. Worker threads are not closed due to missing CloseHandle in file win32/pthread.c

Fix has been tested successfully in our windows application.

Note: This fix is inspired by the following commit: https://git.ipfire.org/?p=thirdparty/git.git;a=commit;f=compat/win32/pthread.c;h=238a9dfe86d18214bc0b8be079feee01a2fdc407


 
 