### PR TITLE
Fix various UB as well as compiler warnings 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ cmake-build-*
 /blosc/config.h
 /doc/doxygen/xml/
 /doc/xml
+.vs/

--- a/blosc/blosc-private.h
+++ b/blosc/blosc-private.h
@@ -280,7 +280,7 @@ static inline void* load_lib(char *plugin_name, char *libpath) {
         return loaded_lib;
     } else {
 #if defined(_WIN32)
-        BLOSC_TRACE_INFO("Failed to load %s directly, error: %s\n", libpath, GetLastError());
+        BLOSC_TRACE_INFO("Failed to load %s directly, error: %lu\n", libpath, GetLastError());
 #else
         BLOSC_TRACE_INFO("Failed to load %s directly, error: %s\n", libpath, dlerror());
 #endif

--- a/blosc/blosc-private.h
+++ b/blosc/blosc-private.h
@@ -91,7 +91,7 @@ static inline int32_t sw32_(const void* pa) {
 
   bool little_endian = is_little_endian();
   if (little_endian) {
-    idest = *(int32_t *)pa;
+    memcpy(&idest, pa, sizeof(idest));
   }
   else {
 #if defined (__GNUC__)
@@ -116,7 +116,7 @@ static inline void _sw32(void* dest, int32_t a) {
 
   bool little_endian = is_little_endian();
   if (little_endian) {
-    *(int32_t *)dest_ = a;
+    memcpy(dest_, &a, sizeof(a));;
   }
   else {
 #if defined (__GNUC__)

--- a/blosc/blosc2-stdio.c
+++ b/blosc/blosc2-stdio.c
@@ -376,10 +376,11 @@ int64_t blosc2_stdio_mmap_write(const void *ptr, int64_t size, int64_t nitems, i
   }
 
   if (mmap_file->mapping_size < mmap_file->file_size) {
-    int64_t old_mapping_size = mmap_file->mapping_size;
     mmap_file->mapping_size = mmap_file->file_size * 2;
 
 #if defined(__linux__)
+    int64_t old_mapping_size = mmap_file->mapping_size;
+
     /* mremap is the best option as it also ensures that the old data is still available in c mode. Unfortunately, it
     is no POSIX standard and only available on Linux */
     char* new_address = mremap(mmap_file->addr, old_mapping_size, mmap_file->mapping_size, MREMAP_MAYMOVE);

--- a/blosc/directories.c
+++ b/blosc/directories.c
@@ -102,7 +102,12 @@ int blosc2_remove_dir(const char* dir_path) {
   char* fname;
   while ((de = readdir(dr)) != NULL) {
     fname = malloc(strlen(path) + strlen(de->d_name) + 1);
-    sprintf(fname, "%s%s", path, de->d_name);
+    if (path != NULL) {
+      sprintf(fname, "%s%s", path, de->d_name);
+    }
+    else {
+      sprintf(fname, "%s", de->d_name);
+    }
     if (!strcmp(de->d_name, ".") || !strcmp(de->d_name, "..")) {
       free(fname);
       continue;

--- a/blosc/frame.c
+++ b/blosc/frame.c
@@ -3186,8 +3186,8 @@ void* frame_update_chunk(blosc2_frame_s* frame, int64_t nchunk, void* chunk, blo
       return NULL;
     }
   }
-  int32_t cbytes_old;
-  int64_t old_offset;
+  int32_t cbytes_old = 0;
+  int64_t old_offset = 0;
   if (!frame->sframe) {
     // See how big would be the space
     old_offset = offsets[nchunk];

--- a/blosc/shuffle-avx2.c
+++ b/blosc/shuffle-avx2.c
@@ -546,7 +546,7 @@ unshuffle12_avx2(uint8_t* const dest, const uint8_t* const src,
       ymm0[j] = _mm256_loadu_si256((__m256i*)(src_for_ith_element + (j * total_elements)));
     }
     /* Initialize the last 4 registers (128 bytes) to null */
-    for (j = bytesoftype; j < 16 - bytesoftype; j++) {
+    for (j = bytesoftype; j < 16; j++) {
       ymm0[j] = _mm256_setzero_si256();
     }
 

--- a/blosc/shuffle-avx2.c
+++ b/blosc/shuffle-avx2.c
@@ -540,10 +540,14 @@ unshuffle12_avx2(uint8_t* const dest, const uint8_t* const src,
   __m256i store_mask = _mm256_set_epi32(0x0, 0x0, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF);
   int32_t jump = 2*bytesoftype;
   for (i = 0; i < vectorizable_elements; i += sizeof(__m256i)) {
-    /* Fetch 32 elements (512 bytes) into 16 YMM registers. */
+    /* Fetch 24 elements (384 bytes) into 12 YMM registers. */
     const uint8_t* const src_for_ith_element = src + i;
     for (j = 0; j < bytesoftype; j++) {
       ymm0[j] = _mm256_loadu_si256((__m256i*)(src_for_ith_element + (j * total_elements)));
+    }
+    /* Initialize the last 4 registers (128 bytes) to null */
+    for (j = bytesoftype; j < 16 - bytesoftype; j++) {
+      ymm0[j] = _mm256_setzero_si256();
     }
 
     /* Shuffle bytes */

--- a/blosc/shuffle-sse2.c
+++ b/blosc/shuffle-sse2.c
@@ -385,7 +385,7 @@ unshuffle12_sse2(uint8_t* const dest, const uint8_t* const src,
       xmm1[j] = _mm_loadu_si128((__m128i*)(src_for_ith_element + (j * total_elements)));
     }
     /* Initialize the last 4 registers (64 bytes) to null */
-    for (j = bytesoftype; j < 16 - bytesoftype; j++) {
+    for (j = bytesoftype; j < 16; j++) {
       xmm1[j] = _mm_setzero_si128();
     }
     /* Shuffle bytes */

--- a/blosc/shuffle-sse2.c
+++ b/blosc/shuffle-sse2.c
@@ -379,10 +379,14 @@ unshuffle12_sse2(uint8_t* const dest, const uint8_t* const src,
   __m128i mask = _mm_set_epi8( 0x0, 0x0, 0x0, 0x0, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff);
 
   for (i = 0; i < vectorizable_elements; i += sizeof(__m128i)) {
-    /* Load 16 elements (256 bytes) into 16 XMM registers. */
+    /* Load 12 elements (192 bytes) into 12 XMM registers. */
     const uint8_t* const src_for_ith_element = src + i;
     for (j = 0; j < bytesoftype; j++) {
       xmm1[j] = _mm_loadu_si128((__m128i*)(src_for_ith_element + (j * total_elements)));
+    }
+    /* Initialize the last 4 registers (64 bytes) to null */
+    for (j = bytesoftype; j < 16 - bytesoftype; j++) {
+      xmm1[j] = _mm_setzero_si128();
     }
     /* Shuffle bytes */
     for (j = 0; j < 8; j++) {

--- a/blosc/stune.c
+++ b/blosc/stune.c
@@ -56,6 +56,7 @@ int blosc_stune_next_blocksize(blosc2_context *context) {
     return BLOSC2_ERROR_SUCCESS;
   }
 
+  int splitmode = split_block(context, typesize, blocksize);
   if (user_blocksize) {
     blocksize = user_blocksize;
     goto last;
@@ -108,7 +109,6 @@ int blosc_stune_next_blocksize(blosc2_context *context) {
   }
 
   /* Now the blocksize for splittable codecs */
-  int splitmode = split_block(context, typesize, blocksize);
   if (clevel > 0 && splitmode) {
     // For performance reasons, do not exceed 256 KB (it must fit in L2 cache)
     switch (clevel) {

--- a/internal-complibs/zlib-ng-2.0.7/zconf.h
+++ b/internal-complibs/zlib-ng-2.0.7/zconf.h
@@ -135,7 +135,7 @@ typedef void       *voidp;
 
 typedef unsigned int z_crc_t;
 
-#if 0    /* was set to #if 0 by configure/cmake/etc */
+#if 1    /* was set to #if 1 by configure/cmake/etc */
 #  define Z_HAVE_UNISTD_H
 #endif
 

--- a/internal-complibs/zlib-ng-2.0.7/zconf.h
+++ b/internal-complibs/zlib-ng-2.0.7/zconf.h
@@ -135,7 +135,7 @@ typedef void       *voidp;
 
 typedef unsigned int z_crc_t;
 
-#if 1    /* was set to #if 1 by configure/cmake/etc */
+#if 0    /* was set to #if 0 by configure/cmake/etc */
 #  define Z_HAVE_UNISTD_H
 #endif
 


### PR DESCRIPTION
This MR aims to touch on a couple of instances of undefined behaviour in the c-blosc2 library as well as various warnings emitted by compilers 

- Fix uninitialized memory access in newly added `unshuffle12_sse2` and `unshuffle12_avx2` functions
- Fix unaligned access in `_sw32` and `sw32_` I've had a look at where this function is used and it looks like it won't affect performance in any way. I wasnt able to figure out why the access was unaligned but memcpy is safe on unaligned operations
- Fix `DWORD` being printed as `%s` in `sprintf` call
- Fix warning on unused variable (since this variable was only being used in the linux branch)
- `splitmode` variable was uninitialized if goto was triggered

Let me know if you have comments on any of these :)