### PR TITLE
B2ND concatenate

### DIFF
--- a/bench/b2nd/bench_concatenate.c
+++ b/bench/b2nd/bench_concatenate.c
@@ -1,0 +1,115 @@
+/*********************************************************************
+  Blosc - Blocked Shuffling and Compression Library
+
+  Copyright (c) 2021  Blosc Development Team <blosc@blosc.org>
+  https://blosc.org
+  License: BSD 3-Clause (see LICENSE.txt)
+
+  See LICENSE.txt for details about copyright and rights to use.
+**********************************************************************/
+
+// Benchmark for concatenating b2nd arrays.  This is to check the accelerated path
+// that has been added to b2nd_concat() that allows for faster concatenation of
+// b2nd arrays when there are no partial (or zero-padded) chunks in the arrays being
+// concatenated.
+
+#include <inttypes.h>
+#include "blosc2.h"
+#include "b2nd.h"
+
+
+int main() {
+  blosc2_init();
+  const int width = 512;
+  const int height = 256;
+  const int nimages_inbuf = 10;
+  const int64_t buffershape[] = {nimages_inbuf, height, width};
+  int64_t N_images = 1000;
+  bool copy = false;  // whether to copy the data or expand src1
+
+  // Shapes of the b2nd array
+  // int64_t shape[] = {N_images, height, width};
+  // The initial shape of the array before concatenation
+  int64_t shape[] = {nimages_inbuf, height, width};
+  int32_t chunkshape[] = {nimages_inbuf, height, width};
+  int32_t blockshape[] = {1, height, width};
+
+  // Determine the buffer size of the image (in bytes)
+  const int64_t buffersize = nimages_inbuf * height * width * (int64_t)sizeof(uint16_t);
+  uint16_t* image = malloc(buffersize);
+
+  // Generate data
+  for (int j = 0; j < nimages_inbuf * height * width; j++) {
+    image[j] = j;
+  }
+
+  blosc2_cparams cparams = BLOSC2_CPARAMS_DEFAULTS;
+  cparams.typesize = sizeof(image[0]);
+  blosc2_storage storage = BLOSC2_STORAGE_DEFAULTS;
+  char *urlpath = "bench_concat.b2nd";
+  //storage.urlpath = urlpath;  // for storing in a file
+  storage.cparams = &cparams;
+
+  char *accel_str = "non-accel";
+  for (int accel=1; accel >= 0; accel--) {
+    if (!accel) {
+      chunkshape[0] = chunkshape[0] + 1;  // to avoid the accelerated path
+      accel_str = "non-accel";
+    }
+    else {
+      accel_str = "accel";
+    }
+
+    blosc2_remove_urlpath(urlpath);
+
+    b2nd_context_t *ctx = b2nd_create_ctx(&storage, 3,
+                                          shape, chunkshape, blockshape,
+                                          "|u2", DTYPE_NUMPY_FORMAT,
+                                          NULL, 0);
+    // The first array
+    b2nd_array_t *src1;
+    if (b2nd_empty(ctx, &src1) < 0) {
+      printf("Error in b2nd_empty\n");
+      return -1;
+    }
+
+    // The second array, with the data in buffersize
+    b2nd_array_t *src2;
+    int ret = b2nd_from_cbuffer(ctx, &src2, image, buffersize);
+    if (ret < 0) {
+      printf("Error in b2nd_from_cbuffer\n");
+      return -1;
+    }
+
+    // Concatenate all images
+    b2nd_array_t *array;
+    blosc_timestamp_t t0, t1;
+    blosc_set_timestamp(&t0);
+    for (int i = 1; i < N_images / nimages_inbuf; i++) {
+      if (b2nd_concatenate(ctx, src1, src2, 0, copy, &array) < 0) {
+        printf("Error in b2nd_concatenate\n");
+        return -1;
+      }
+      if (copy) {
+        // If we copy, then we need to free the src1 array
+        b2nd_free(src1);
+      }
+      src1 = array;
+    }
+    blosc_set_timestamp(&t1);
+    printf("Time to append (%s): %.4f s\n", accel_str, blosc_elapsed_secs(t0, t1));
+    printf("Number of chunks: %" PRId64 "\n", array->sc->nchunks);
+    printf("Shape of array: (%" PRId64 ", %" PRId64 ", %" PRId64 ")\n",
+           array->shape[0], array->shape[1], array->shape[2]);
+
+    b2nd_free(src2);
+    if (copy) {
+      b2nd_free(array);
+    }
+    b2nd_free_ctx(ctx);
+  }
+  free(image);
+
+  blosc2_destroy();
+  return 0;
+}

--- a/bench/b2nd/bench_concatenate.c
+++ b/bench/b2nd/bench_concatenate.c
@@ -54,10 +54,10 @@ int main() {
     int32_t new_chunkshape[3] = {chunkshape[0], chunkshape[1], chunkshape[2]};
     if (!accel) {
       new_chunkshape[0] = chunkshape[0] + 1;  // to avoid the fast path
-      accel_str = "non-accel";
+      accel_str = "non-fast path";
     }
     else {
-      accel_str = "accel";
+      accel_str = "fast path";
     }
 
     blosc2_remove_urlpath(urlpath);

--- a/blosc/b2nd.c
+++ b/blosc/b2nd.c
@@ -1376,7 +1376,11 @@ int b2nd_concatenate(b2nd_context_t *ctx, const b2nd_array_t *src1,
     for (int8_t i = 0; i < src2->ndim; ++i) {
       chunkshape[i] = src2->chunkshape[i];
     }
-    blosc2_unidim_to_multidim(src2->ndim, chunkshape, nchunk, nchunk_ndim);
+    int64_t chunks_in_dim[B2ND_MAX_DIM] = {0};
+    for (int8_t i = 0; i < src2->ndim; ++i) {
+      chunks_in_dim[i] = (src2->extshape[i] + src2->chunkshape[i] - 1) / src2->chunkshape[i];
+    }
+    blosc2_unidim_to_multidim(src2->ndim, chunks_in_dim, nchunk, nchunk_ndim);
 
     // Set positions for each dimension
     for (int8_t i = 0; i < src2->ndim; ++i) {

--- a/blosc/b2nd.c
+++ b/blosc/b2nd.c
@@ -1330,8 +1330,8 @@ int b2nd_copy(b2nd_context_t *ctx, const b2nd_array_t *src, b2nd_array_t **array
 }
 
 
-int b2nd_concatenate(b2nd_context_t *ctx, b2nd_array_t **array, const b2nd_array_t *src1,
-                     const b2nd_array_t *src2, int axis) {
+int b2nd_concatenate(b2nd_context_t *ctx, const b2nd_array_t *src1,
+                     const b2nd_array_t *src2, b2nd_array_t **array, int8_t axis) {
   BLOSC_ERROR_NULL(src1, BLOSC2_ERROR_NULL_POINTER);
   BLOSC_ERROR_NULL(src2, BLOSC2_ERROR_NULL_POINTER);
   BLOSC_ERROR_NULL(array, BLOSC2_ERROR_NULL_POINTER);
@@ -1346,7 +1346,7 @@ int b2nd_concatenate(b2nd_context_t *ctx, b2nd_array_t **array, const b2nd_array
   }
   // Compute the new shape
   int64_t newshape[B2ND_MAX_DIM];
-  for (int i = 0; i < src1->ndim; ++i) {
+  for (int8_t i = 0; i < src1->ndim; ++i) {
     if (i == axis) {
       newshape[i] = src1->shape[i] + src2->shape[i];
     } else {
@@ -1362,7 +1362,7 @@ int b2nd_concatenate(b2nd_context_t *ctx, b2nd_array_t **array, const b2nd_array
   BLOSC_ERROR(b2nd_resize(*array, newshape, NULL));
 
   // Copy the data from the second array
-  int64_t start[B2ND_MAX_DIM] = {0};
+  int64_t start[B2ND_MAX_DIM];
   int64_t stop[B2ND_MAX_DIM];
   // Copy chunk by chunk
   void *buffer = malloc(src2->sc->typesize * src2->extchunknitems);
@@ -1372,10 +1372,10 @@ int b2nd_concatenate(b2nd_context_t *ctx, b2nd_array_t **array, const b2nd_array
                                                src2->sc->typesize * src2->extchunknitems));
     // Get multidimensional chunk position
     int64_t nchunk_ndim[B2ND_MAX_DIM] = {0};
-    blosc2_unidim_to_multidim(src2->ndim, src2->chunkshape, nchunk, nchunk_ndim);
+    blosc2_unidim_to_multidim(src2->ndim, (int64_t*)(src2->chunkshape), nchunk, nchunk_ndim);
 
     // Set positions for each dimension
-    for (int i = 0; i < src2->ndim; ++i) {
+    for (int8_t i = 0; i < src2->ndim; ++i) {
       start[i] = nchunk_ndim[i] * src2->chunkshape[i];
       stop[i] = start[i] + src2->chunkshape[i];
       if (stop[i] > src2->shape[i]) {
@@ -1390,7 +1390,7 @@ int b2nd_concatenate(b2nd_context_t *ctx, b2nd_array_t **array, const b2nd_array
     }
 
     // Copy the chunk to the correct position
-    BLOSC_ERROR(b2nd_set_slice_cbuffer(buffer, src2->chunkshape,
+    BLOSC_ERROR(b2nd_set_slice_cbuffer(buffer, (int64_t*)(src2->chunkshape),
                                        src2->sc->typesize * src2->extchunknitems,
                                        start, stop, *array));
   }

--- a/blosc/b2nd.c
+++ b/blosc/b2nd.c
@@ -1372,7 +1372,11 @@ int b2nd_concatenate(b2nd_context_t *ctx, const b2nd_array_t *src1,
                                                src2->sc->typesize * src2->extchunknitems));
     // Get multidimensional chunk position
     int64_t nchunk_ndim[B2ND_MAX_DIM] = {0};
-    blosc2_unidim_to_multidim(src2->ndim, (int64_t*)(src2->chunkshape), nchunk, nchunk_ndim);
+    int64_t chunkshape[B2ND_MAX_DIM] = {0};
+    for (int8_t i = 0; i < src2->ndim; ++i) {
+      chunkshape[i] = src2->chunkshape[i];
+    }
+    blosc2_unidim_to_multidim(src2->ndim, chunkshape, nchunk, nchunk_ndim);
 
     // Set positions for each dimension
     for (int8_t i = 0; i < src2->ndim; ++i) {
@@ -1390,7 +1394,7 @@ int b2nd_concatenate(b2nd_context_t *ctx, const b2nd_array_t *src1,
     }
 
     // Copy the chunk to the correct position
-    BLOSC_ERROR(b2nd_set_slice_cbuffer(buffer, (int64_t*)(src2->chunkshape),
+    BLOSC_ERROR(b2nd_set_slice_cbuffer(buffer, chunkshape,
                                        src2->sc->typesize * src2->extchunknitems,
                                        start, stop, *array));
   }

--- a/blosc/b2nd.c
+++ b/blosc/b2nd.c
@@ -1336,91 +1336,65 @@ int b2nd_concatenate(b2nd_context_t *ctx, b2nd_array_t **array, const b2nd_array
   BLOSC_ERROR_NULL(src2, BLOSC2_ERROR_NULL_POINTER);
   BLOSC_ERROR_NULL(array, BLOSC2_ERROR_NULL_POINTER);
 
-  ctx->ndim = src1->ndim;
-  // Compute the new shape while checking that the shapes are compatible with the other axes
+  // For starters, create a copy of src1 array
+  BLOSC_ERROR(b2nd_copy(ctx, src1, array));
+
+  // Check that the shapes are compatible for concatenation
+  if (src1->ndim != src2->ndim) {
+    BLOSC_TRACE_ERROR("The two arrays must have the same number of dimensions");
+    BLOSC_ERROR(BLOSC2_ERROR_INVALID_PARAM);
+  }
+  // Compute the new shape
+  int64_t newshape[B2ND_MAX_DIM];
   for (int i = 0; i < src1->ndim; ++i) {
     if (i == axis) {
-      ctx->shape[i] = src1->shape[i] + src2->shape[i];
+      newshape[i] = src1->shape[i] + src2->shape[i];
     } else {
       if (src1->shape[i] != src2->shape[i]) {
-        BLOSC_TRACE_ERROR("The shapes of the arrays are not compatible in axis %d", i);
+        BLOSC_TRACE_ERROR("The two arrays must have the same shape in all dimensions except the concatenation axis");
         BLOSC_ERROR(BLOSC2_ERROR_INVALID_PARAM);
       }
-      ctx->shape[i] = src1->shape[i];
+      newshape[i] = src1->shape[i];
     }
   }
 
-  // Use the same chunkshape and blockshape as src1
-  for (int i = 0; i < src1->ndim; ++i) {
-    ctx->chunkshape[i] = src1->chunkshape[i];
-    ctx->blockshape[i] = src1->blockshape[i];
-  }
-
-  // Create a container for the new array
-  BLOSC_ERROR(b2nd_empty(ctx, array));
-
-  // Copy the data from the first array
-  int64_t start[B2ND_MAX_DIM] = {0};
-  int64_t stop[B2ND_MAX_DIM];
-  for (int i = 0; i < src1->ndim; ++i) {
-    stop[i] = src1->shape[i];
-  }
-  // Copy src1 data chunk by chunk
-  void *buffer = malloc(src1->sc->typesize * src1->extchunknitems);
-  BLOSC_ERROR_NULL(buffer, BLOSC2_ERROR_MEMORY_ALLOC);
-  for (int64_t nchunk = 0; nchunk < src1->sc->nchunks; ++nchunk) {
-    BLOSC_ERROR(blosc2_schunk_decompress_chunk(src1->sc, nchunk, buffer,
-                                               src1->sc->typesize * src1->extchunknitems));
-    BLOSC_ERROR(b2nd_set_slice_cbuffer(buffer, src1->chunkshape, src1->sc->typesize * src1->extchunknitems,
-                                       start, stop, *array));
-  }
-  free(buffer);
+  // Extend the array, we don't need to specify the start in resize, as we are extending the shape from the end
+  BLOSC_ERROR(b2nd_resize(*array, newshape, NULL));
 
   // Copy the data from the second array
-  for (int i = 0; i < src2->ndim; ++i) {
-    if (i == axis) {
-      start[i] = src1->shape[i];
-      stop[i] = start[i] + src2->shape[i];
-    } else {
-      start[i] = 0;
-      stop[i] = src2->shape[i];
-    }
-  }
-  // Copy src2 data chunk by chunk
-  buffer = malloc(src2->sc->typesize * src2->extchunknitems);
+  int64_t start[B2ND_MAX_DIM] = {0};
+  int64_t stop[B2ND_MAX_DIM];
+  // Copy chunk by chunk
+  void *buffer = malloc(src2->sc->typesize * src2->extchunknitems);
   BLOSC_ERROR_NULL(buffer, BLOSC2_ERROR_MEMORY_ALLOC);
   for (int64_t nchunk = 0; nchunk < src2->sc->nchunks; ++nchunk) {
     BLOSC_ERROR(blosc2_schunk_decompress_chunk(src2->sc, nchunk, buffer,
                                                src2->sc->typesize * src2->extchunknitems));
-    BLOSC_ERROR(b2nd_set_slice_cbuffer(buffer, src2->chunkshape, src2->sc->typesize * src2->extchunknitems,
+    // Get multidimensional chunk position
+    int64_t nchunk_ndim[B2ND_MAX_DIM] = {0};
+    blosc2_unidim_to_multidim(src2->ndim, src2->chunkshape, nchunk, nchunk_ndim);
+
+    // Set positions for each dimension
+    for (int i = 0; i < src2->ndim; ++i) {
+      start[i] = nchunk_ndim[i] * src2->chunkshape[i];
+      stop[i] = start[i] + src2->chunkshape[i];
+      if (stop[i] > src2->shape[i]) {
+        stop[i] = src2->shape[i];  // Handle boundary chunks
+      }
+
+      // Apply offset only for concatenation axis
+      if (i == axis) {
+        start[i] += src1->shape[i];
+        stop[i] += src1->shape[i];
+      }
+    }
+
+    // Copy the chunk to the correct position
+    BLOSC_ERROR(b2nd_set_slice_cbuffer(buffer, src2->chunkshape,
+                                       src2->sc->typesize * src2->extchunknitems,
                                        start, stop, *array));
   }
   free(buffer);
-
-  // Copy the metalayers from src1
-  blosc2_storage *b2_storage = ctx->b2_storage;
-  blosc2_schunk *schunk = src1->sc;
-  blosc2_schunk *new_schunk = (*array)->sc;
-  for (int nmeta = 0; nmeta < schunk->nmetalayers; ++nmeta) {
-    blosc2_metalayer *meta = schunk->metalayers[nmeta];
-    if (blosc2_meta_add(new_schunk, meta->name, meta->content, meta->content_len) < 0) {
-      BLOSC_TRACE_ERROR("Can not add %s `metalayer`.", meta->name);
-      return BLOSC2_ERROR_FAILURE;
-    }
-  }
-
-  // Copy the vlmetalayers from src1
-  for (int nvlmeta = 0; nvlmeta < schunk->nvlmetalayers; ++nvlmeta) {
-    uint8_t *content;
-    int32_t content_len;
-    if (blosc2_vlmeta_get(schunk, schunk->vlmetalayers[nvlmeta]->name, &content,
-                          &content_len) < 0) {
-      BLOSC_ERROR(BLOSC2_ERROR_FAILURE);
-    }
-    BLOSC_ERROR(blosc2_vlmeta_add(new_schunk, schunk->vlmetalayers[nvlmeta]->name, content,
-                                  content_len, b2_storage->cparams));
-    free(content);
-  }
 
   return BLOSC2_ERROR_SUCCESS;
 }

--- a/blosc/b2nd.c
+++ b/blosc/b2nd.c
@@ -1342,11 +1342,10 @@ int b2nd_concatenate(b2nd_context_t *ctx, const b2nd_array_t *src1, const b2nd_a
     src1_shape[i] = src1->shape[i];
   }
 
-  if (copy) {
-    BLOSC_ERROR(b2nd_copy(ctx, src1, array));
-  } else
-  {
-    *array = src1;
+  // Support for 0-dim arrays is not implemented
+  if (src1->ndim == 0 || src2->ndim == 0) {
+    BLOSC_TRACE_ERROR("Concatenation of 0-dim arrays is not supported");
+    BLOSC_ERROR(BLOSC2_ERROR_INVALID_PARAM);
   }
 
   // Check that the shapes are compatible for concatenation
@@ -1366,6 +1365,13 @@ int b2nd_concatenate(b2nd_context_t *ctx, const b2nd_array_t *src1, const b2nd_a
       }
       newshape[i] = src1->shape[i];
     }
+  }
+
+  if (copy) {
+    BLOSC_ERROR(b2nd_copy(ctx, src1, array));
+  }
+  else {
+    *array = (b2nd_array_t *)src1;
   }
 
   // Extend the array, we don't need to specify the start in resize, as we are extending the shape from the end

--- a/blosc/blosc2.c
+++ b/blosc/blosc2.c
@@ -4307,7 +4307,7 @@ int blosc2_chunk_zeros(blosc2_cparams cparams, const int32_t nbytes, void* dest,
     return BLOSC2_ERROR_DATA;
   }
 
-  if (nbytes % cparams.typesize) {
+  if ((nbytes > 0) && (nbytes % cparams.typesize)) {
     BLOSC_TRACE_ERROR("nbytes must be a multiple of typesize");
     return BLOSC2_ERROR_DATA;
   }

--- a/blosc/frame.c
+++ b/blosc/frame.c
@@ -2146,7 +2146,7 @@ int frame_get_chunk(blosc2_frame_s *frame, int64_t nchunk, uint8_t **chunk, bool
     return rc;
   }
 
-  if (nchunk >= nchunks) {
+  if ((nchunks > 0) && (nchunk >= nchunks)) {
     BLOSC_TRACE_ERROR("nchunk ('%" PRId64 "') exceeds the number of chunks "
                     "('%" PRId64 "') in frame.", nchunk, nchunks);
     return BLOSC2_ERROR_INVALID_PARAM;

--- a/include/b2nd.h
+++ b/include/b2nd.h
@@ -410,6 +410,23 @@ BLOSC_EXPORT int b2nd_set_slice_cbuffer(const void *buffer, const int64_t *buffe
 BLOSC_EXPORT int b2nd_copy(b2nd_context_t *ctx, const b2nd_array_t *src, b2nd_array_t **array);
 
 /**
+ * @brief Concatenate arrays. The result is stored in a new b2nd array.
+ *
+ * @param ctx The b2nd context for the new array.
+ * @param src1 The first array from which data is copied.
+ * @param src2 The second array from which data is copied.
+ * @param array The memory pointer where the array will be created.
+ * @param axis The axis along which the arrays will be concatenated.
+ *
+ * @return An error code
+ *
+ * @note The ndim and shape in ctx will be overwritten by the src1 ctx.
+ *
+ */
+BLOSC_EXPORT int b2nd_concatenate(b2nd_context_t *ctx, const b2nd_array_t *src1, const b2nd_array_t *src2,
+                                  b2nd_array_t **array, int8_t axis);
+
+/**
  * @brief Print metalayer parameters.
  *
  * @param array The array where the metalayer is stored.

--- a/include/b2nd.h
+++ b/include/b2nd.h
@@ -418,7 +418,9 @@ BLOSC_EXPORT int b2nd_copy(b2nd_context_t *ctx, const b2nd_array_t *src, b2nd_ar
  * @param axis The axis along which the arrays will be concatenated.
  * @param copy Whether the data should be copied or not. If false, the @p src1 array
  *   will be expanded as needed to keep the result.
- * @param array The memory pointer where the array will be created.
+ * @param array The memory pointer where the array will be created.  It will have the same
+ *   metalayers of @p src1, except for the b2nd metalayer, which will be updated with the
+ *   new shape.
  *
  * @return An error code
  *

--- a/include/b2nd.h
+++ b/include/b2nd.h
@@ -263,7 +263,7 @@ BLOSC_EXPORT int b2nd_to_cframe(const b2nd_array_t *array, uint8_t **cframe,
  *
  * @param cframe The buffer of the in-memory array.
  * @param cframe_len The size (in bytes) of the in-memory array.
- * @param copy Whether b2nd should make a copy of the cframe data or not. The copy will be made to an internal sparse frame.
+ * @param copy Whether b2nd should make a copy of the cframe data or not. The copy will be made to a sparse frame.
  * @param array The memory pointer where the array will be created.
  *
  * @return An error code.
@@ -415,8 +415,10 @@ BLOSC_EXPORT int b2nd_copy(b2nd_context_t *ctx, const b2nd_array_t *src, b2nd_ar
  * @param ctx The b2nd context for the new array.
  * @param src1 The first array from which data is copied.
  * @param src2 The second array from which data is copied.
- * @param array The memory pointer where the array will be created.
  * @param axis The axis along which the arrays will be concatenated.
+ * @param copy Whether the data should be copied or not. If false, the @p src1 array
+ *   will be expanded as needed to keep the result.
+ * @param array The memory pointer where the array will be created.
  *
  * @return An error code
  *
@@ -424,7 +426,7 @@ BLOSC_EXPORT int b2nd_copy(b2nd_context_t *ctx, const b2nd_array_t *src, b2nd_ar
  *
  */
 BLOSC_EXPORT int b2nd_concatenate(b2nd_context_t *ctx, const b2nd_array_t *src1, const b2nd_array_t *src2,
-                                  b2nd_array_t **array, int8_t axis);
+                                  int8_t axis, bool copy, b2nd_array_t **array);
 
 /**
  * @brief Print metalayer parameters.

--- a/tests/b2nd/test_b2nd_concatenate.c
+++ b/tests/b2nd/test_b2nd_concatenate.c
@@ -190,25 +190,9 @@ CUTEST_TEST_TEST(concatenate) {
   /* Create src2 with a value */
   b2nd_array_t *src2;
   uint8_t *value = malloc(typesize);
-  switch (typesize) {
-  case 8:
-    ((int64_t *) value)[0] = (int64_t) fill_value;
-    break;
-  case 4:
-    ((int32_t *) value)[0] = (int32_t) fill_value;
-    break;
-  case 2:
-    ((int16_t *) value)[0] = (int16_t) fill_value;
-    break;
-  case 1:
-    ((int8_t *) value)[0] = fill_value;
-    break;
-  default:
-    // Fill a buffer with fill_value
-    for (int i = 0; i < typesize; ++i) {
-      value[i] = fill_value;
-    }
-    break;
+  // Fill a buffer with fill_value
+  for (int i = 0; i < typesize; ++i) {
+    value[i] = fill_value;
   }
   blosc2_storage b2_storage2 = {.cparams=&cparams};
   if (backend.persistent) {
@@ -290,29 +274,12 @@ CUTEST_TEST_TEST(concatenate) {
   uint8_t *buffer = malloc(buffersize2);
 
   B2ND_TEST_ASSERT(b2nd_get_slice_cbuffer(array, start, stop, buffer, buffershape, buffersize));
-  // Check if the data in the concatenated array matches the helperbuffer
+  // Data in the concatenated array matches the helperbuffer?
   uint8_t *buffer_fill = malloc(typesize);
   for (int64_t i = 0; i < buffersize / typesize; ++i) {
     bool is_true = false;
-    switch (typesize) {
-      case 8:
-        is_true = ((int64_t *) buffer)[i] == ((int64_t *) helperbuffer)[i];
-        break;
-      case 4:
-        is_true = ((int32_t *) buffer)[i] == ((int32_t *) helperbuffer)[i];
-        break;
-      case 2:
-        is_true = ((int16_t *) buffer)[i] == ((int16_t *) helperbuffer)[i];
-        break;
-      case 1:
-        is_true = ((int8_t *) buffer)[i] == ((int8_t *) helperbuffer)[i];
-        break;
-      default:
-        // For default case, don't copy helperbuffer over buffer data
-        memcpy(buffer_fill, &buffer[i * typesize], typesize);
-        is_true = memcmp(buffer_fill, helperbuffer + i * typesize, typesize) == 0;
-        break;
-    }
+    memcpy(buffer_fill, &buffer[i * typesize], typesize);
+    is_true = memcmp(buffer_fill, helperbuffer + i * typesize, typesize) == 0;
     if (!is_true) {
       // Print the raw byte values for better debugging
       fprintf(stderr, "Data mismatch at index %d: buffer bytes = ", (int)i);
@@ -325,8 +292,7 @@ CUTEST_TEST_TEST(concatenate) {
       }
       fprintf(stderr, "\n");
     }
-    CUTEST_ASSERT("Data in the concatenated array does not match the helperbuffer",
-                  is_true);
+    CUTEST_ASSERT("Data in the concatenated array does not match the helperbuffer", is_true);
   }
 
   /* Free mallocs */

--- a/tests/b2nd/test_b2nd_concatenate.c
+++ b/tests/b2nd/test_b2nd_concatenate.c
@@ -1,0 +1,178 @@
+/*********************************************************************
+  Blosc - Blocked Shuffling and Compression Library
+
+  Copyright (c) 2021  Blosc Development Team <blosc@blosc.org>
+  https://blosc.org
+  License: BSD 3-Clause (see LICENSE.txt)
+
+  See LICENSE.txt for details about copyright and rights to use.
+**********************************************************************/
+
+#include "test_common.h"
+
+typedef struct {
+  int8_t ndim;
+  int64_t shape[B2ND_MAX_DIM];
+  int32_t chunkshape[B2ND_MAX_DIM];
+  int32_t blockshape[B2ND_MAX_DIM];
+  int64_t start[B2ND_MAX_DIM];
+  int64_t stop[B2ND_MAX_DIM];
+} test_shapes_t;
+
+
+CUTEST_TEST_SETUP(concatenate) {
+  blosc2_init();
+
+  // Add parametrizations
+  CUTEST_PARAMETRIZE(typesize, uint8_t, CUTEST_DATA(
+      1,
+      2,
+      4,
+      8,
+  ));
+
+  CUTEST_PARAMETRIZE(backend, _test_backend, CUTEST_DATA(
+      {false, false},
+      {true, false},
+      {true, true},
+      {false, true},
+  ));
+
+
+  CUTEST_PARAMETRIZE(shapes, test_shapes_t, CUTEST_DATA(
+      // {0, {0}, {0}, {0}, {0}, {0}}, // 0-dim
+      // {1, {5}, {3}, {2}, {2}, {5}}, // 1-idim
+      // {2, {20, 0}, {7, 0}, {3, 0}, {2, 0}, {8, 0}}, // 0-shape
+      // {2, {20, 10}, {7, 5}, {3, 5}, {2, 0}, {18, 0}}, // 0-shape
+      // {2, {14, 10}, {8, 5}, {2, 2}, {5, 3}, {9, 10}},
+      // {3, {12, 10, 14}, {3, 5, 9}, {3, 4, 4}, {3, 0, 3}, {6, 7, 10}},
+      // {4, {10, 21, 30, 5}, {8, 7, 15, 3}, {5, 5, 10, 1}, {5, 4, 3, 3}, {10, 8, 8, 4}},
+      {2, {50, 50}, {25, 13}, {8, 8}, {0, 0}, {10, 10}},
+      // The case below makes qemu-aarch64 (AARCH64 emulation) in CI (Ubuntu 22.04) to crash with a segfault.
+      // Interestingly, this works perfectly well on both intel64 (native) and in aarch64 (emulated via docker).
+      // Moreover, valgrind does not issue any warning at all when run in the later platforms.
+      // In conclusion, this *may* be revealing a bug in the qemu-aarch64 binaries in Ubuntu 22.04.
+      // {2, {143, 41}, {18, 13}, {7, 7}, {4, 2}, {6, 5}},
+      // Replacing the above line by this one makes qemu-aarch64 happy.
+      // {2, {150, 45}, {15, 15}, {7, 7}, {4, 2}, {6, 5}},
+      // {2, {10, 10}, {5, 7}, {2, 2}, {0, 0}, {5, 5}},
+      // // Checks for fast path in setting a single chunk that is C contiguous
+      // {2, {20, 20}, {10, 10}, {5, 10}, {10, 10}, {20, 20}},
+      // {3, {3, 4, 5}, {1, 4, 5}, {1, 2, 5}, {1, 0, 0}, {2, 4, 5}},
+      // {3, {3, 8, 5}, {1, 4, 5}, {1, 2, 5}, {1, 4, 0}, {2, 8, 5}},
+  ));
+  CUTEST_PARAMETRIZE(fill_value, int8_t, CUTEST_DATA(
+    3, 113, 33, -5
+));
+
+}
+
+CUTEST_TEST_TEST(concatenate) {
+  CUTEST_GET_PARAMETER(backend, _test_backend);
+  CUTEST_GET_PARAMETER(shapes, test_shapes_t);
+  CUTEST_GET_PARAMETER(typesize, uint8_t);
+  CUTEST_GET_PARAMETER(fill_value, int8_t);
+
+  char *urlpath = "test_concatenate.b2frame";
+  blosc2_remove_urlpath(urlpath);
+
+  blosc2_cparams cparams = BLOSC2_CPARAMS_DEFAULTS;
+  cparams.nthreads = 2;
+  cparams.typesize = typesize;
+  blosc2_storage b2_storage = {.cparams=&cparams};
+  if (backend.persistent) {
+    b2_storage.urlpath = urlpath;
+  }
+  b2_storage.contiguous = backend.contiguous;
+
+  b2nd_context_t *ctx = b2nd_create_ctx(&b2_storage, shapes.ndim, shapes.shape,
+                                        shapes.chunkshape, shapes.blockshape, NULL, 0, NULL, 0);
+
+  /* Create dest buffer */
+  int64_t shape[B2ND_MAX_DIM] = {0};
+  int64_t buffersize = typesize;
+  for (int i = 0; i < ctx->ndim; ++i) {
+    shape[i] = shapes.stop[i] - shapes.start[i];
+    buffersize *= shape[i];
+  }
+
+  // uint8_t *buffer = malloc(buffersize);
+  // CUTEST_ASSERT("Buffer filled incorrectly", fill_buf(buffer, typesize, buffersize / typesize));
+
+  /* Create src1 with zeros */
+  b2nd_array_t *src1;
+  BLOSC_ERROR(b2nd_zeros(ctx, &src1));
+  
+  /* Create src2 with ones */
+  b2nd_array_t *src2;
+  uint8_t *value = malloc(typesize);
+  switch (typesize) {
+  case 8:
+    ((int64_t *) value)[0] = (int64_t) fill_value;
+    break;
+  case 4:
+    ((int32_t *) value)[0] = (int32_t) fill_value;
+    break;
+  case 2:
+    ((int16_t *) value)[0] = (int16_t) fill_value;
+    break;
+  case 1:
+    ((int8_t *) value)[0] = fill_value;
+    break;
+  default:
+    // Fill a buffer with fill_value
+    for (int i = 0; i < typesize; ++i) {
+      value[i] = fill_value;
+    }
+    break;
+  }
+  B2ND_TEST_ASSERT(b2nd_full(ctx, &src2, value));
+
+  /* Concatenate src1 and src2 */
+  b2nd_array_t *array = NULL;
+  B2ND_TEST_ASSERT(b2nd_concatenate(ctx, src1, src2, &array, 0));
+
+  // for (uint64_t i = 0; i < (uint64_t) buffersize / typesize; ++i) {
+  //   uint64_t k = i + 1;
+  //   switch (typesize) {
+  //     case 8:
+  //       CUTEST_ASSERT("Elements are not equals!",
+  //                     (uint64_t) k == ((uint64_t *) destbuffer)[i]);
+  //       break;
+  //     case 4:
+  //       CUTEST_ASSERT("Elements are not equals!",
+  //                     (uint32_t) k == ((uint32_t *) destbuffer)[i]);
+  //       break;
+  //     case 2:
+  //       CUTEST_ASSERT("Elements are not equals!",
+  //                     (uint16_t) k == ((uint16_t *) destbuffer)[i]);
+  //       break;
+  //     case 1:
+  //       CUTEST_ASSERT("Elements are not equals!",
+  //                     (uint8_t) k == ((uint8_t *) destbuffer)[i]);
+  //       break;
+  //     default:
+  //       B2ND_TEST_ASSERT(BLOSC2_ERROR_INVALID_PARAM);
+  //   }
+  // }
+
+  /* Free mallocs */
+  // free(buffer);
+  // free(destbuffer);
+  free(value);
+  B2ND_TEST_ASSERT(b2nd_free(src1));
+  B2ND_TEST_ASSERT(b2nd_free(src2));
+  B2ND_TEST_ASSERT(b2nd_free(array));
+  B2ND_TEST_ASSERT(b2nd_free_ctx(ctx));
+  blosc2_remove_urlpath(urlpath);
+
+  return 0;
+}
+
+CUTEST_TEST_TEARDOWN(concatenate) {
+  blosc2_destroy();
+}
+
+int main() {
+  CUTEST_TEST_RUN(concatenate);
+}


### PR DESCRIPTION
This is the low-level implementation of `b2nd_concatenate`, with this signature:

```
/**
 * @brief Concatenate arrays. The result is stored in a new b2nd array.
 *
 * @param ctx The b2nd context for the new array.
 * @param src1 The first array from which data is copied.
 * @param src2 The second array from which data is copied.
 * @param axis The axis along which the arrays will be concatenated.
 * @param copy Whether the data should be copied or not. If false, the @p src1 array
 *   will be expanded as needed to keep the result.
 * @param array The memory pointer where the array will be created.
 *
 * @return An error code
 *
 * @note The ndim and shape in ctx will be overwritten by the src1 ctx.
 *
 */
BLOSC_EXPORT int b2nd_concatenate(b2nd_context_t *ctx, const b2nd_array_t *src1, const b2nd_array_t *src2,
                                  int8_t axis, bool copy, b2nd_array_t **array);
```

This only works for concatenating 2 arrays, but by using the `copy` flag judiciously, this can be used to implement a wrapper in python-blosc2 that would act similarly to `numpy.concatenate()`.

This implementation has an acceleration path for the case where src1 and src2 have the same chunkshape, and for the case that all the dims of the chunk are an exact divisor of the dims in shape for src1 and src2.  We could go further and still accelerate a bit more in this case by not decompressing/compressing the chunks, but that requires more time and can be done later.

This is part of the solution for https://github.com/Blosc/python-blosc2/issues/382