### PR TITLE
Eagerly register io_cb's to avoid race

### DIFF
--- a/blosc/blosc2.c
+++ b/blosc/blosc2.c
@@ -3818,6 +3818,8 @@ blosc2_io *blosc2_io_global = NULL;
 blosc2_io_cb BLOSC2_IO_CB_DEFAULTS;
 blosc2_io_cb BLOSC2_IO_CB_MMAP;
 
+int _blosc2_register_io_cb(const blosc2_io_cb *io);
+
 void blosc2_init(void) {
   /* Return if Blosc is already initialized */
   if (g_initlib) return;
@@ -3833,6 +3835,8 @@ void blosc2_init(void) {
   BLOSC2_IO_CB_DEFAULTS.truncate = (blosc2_truncate_cb) blosc2_stdio_truncate;
   BLOSC2_IO_CB_DEFAULTS.destroy = (blosc2_destroy_cb) blosc2_stdio_destroy;
 
+  _blosc2_register_io_cb(&BLOSC2_IO_CB_DEFAULTS);
+
   BLOSC2_IO_CB_MMAP.id = BLOSC2_IO_FILESYSTEM_MMAP;
   BLOSC2_IO_CB_MMAP.name = "filesystem_mmap";
   BLOSC2_IO_CB_MMAP.is_allocation_necessary = false;
@@ -3843,6 +3847,8 @@ void blosc2_init(void) {
   BLOSC2_IO_CB_MMAP.write = (blosc2_write_cb) blosc2_stdio_mmap_write;
   BLOSC2_IO_CB_MMAP.truncate = (blosc2_truncate_cb) blosc2_stdio_mmap_truncate;
   BLOSC2_IO_CB_MMAP.destroy = (blosc2_destroy_cb) blosc2_stdio_mmap_destroy;
+
+  _blosc2_register_io_cb(&BLOSC2_IO_CB_MMAP);
 
   g_ncodecs = 0;
   g_nfilters = 0;


### PR DESCRIPTION
I am seeing a crash on darwin/arm64 when calling blosc2 from multiple threads concurrently. I serialize the call to `blosc2_init` but this doesn't prevent a race when multiple threads call _blosc2_register_io_cb simultaneously. See stacktrace of crash below.
```
Thread 13 Crashed:
0   libsystem_platform.dylib 0x1935c31b0 _platform_strcmp$VARIANT$Base + 64
1   pointcloud_sampler       0x10543b218 _blosc2_register_io_cb + 132
2   pointcloud_sampler       0x10543b3ec blosc2_get_io_cb + 188
3   pointcloud_sampler       0x105446ad0 frame_from_schunk + 936
4   pointcloud_sampler       0x10544141c blosc2_schunk_new + 1000
```