### PR TITLE
Generate `blosc/config.h` in binary directory.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@ build*
 .idea
 .*.swp
 cmake-build-*
-/blosc/config.h
 /doc/doxygen/xml/
 /doc/xml
 .vs/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -249,7 +249,7 @@ endif()
 
 # create the config.h file
 configure_file("${PROJECT_SOURCE_DIR}/blosc/config.h.in"
-               "${PROJECT_SOURCE_DIR}/blosc/config.h")
+               "${PROJECT_BINARY_DIR}/blosc/config.h")
 
 # now make sure that you set the build directory on your "Include" path when compiling
 include_directories("${PROJECT_BINARY_DIR}/blosc/")


### PR DESCRIPTION
Fixes failures when configuring from the same source directory in parallel (which vcpkg does by default).