### PR TITLE
Restrict overmatching MACH ifdef to only trigger on OSX and Mach

### DIFF
--- a/blosc/timestamp.c
+++ b/blosc/timestamp.c
@@ -35,7 +35,7 @@ double blosc_elapsed_nsecs(blosc_timestamp_t start_time,
 
 #include <time.h>
 
-#if defined(__MACH__) // OS X does not have clock_gettime, use clock_get_time
+#if defined(__MACH__) && defined(__APPLE__) // OS X does not have clock_gettime, use clock_get_time
 
 #include <mach/clock.h>
 

--- a/include/blosc2.h
+++ b/include/blosc2.h
@@ -2272,7 +2272,7 @@ BLOSC_EXPORT int blosc2_vlmeta_get_names(blosc2_schunk *schunk, char **names);
 #if defined(_WIN32)
 /* For QueryPerformanceCounter(), etc. */
   #include <windows.h>
-#elif defined(__MACH__)
+#elif defined(__MACH__) && defined(__APPLE__)
 #include <mach/clock.h>
 #include <mach/mach.h>
 #include <time.h>


### PR DESCRIPTION
Hurd also uses Mach, causing it to hit this ifdef, when it is only intended for OSX.

https://www.gnu.org/software/hurd/hurd/porting/guidelines.html
```
#ifdef __MACH__
Some applications put Apple Darwin-specific code inside #ifdef __MACH__ guards. Such guard is clearly not enough, since not only Apple uses Mach as a kernel. This should be replaced by #if defined(__MACH__) && defined(__APPLE__)
```

Similar to https://github.com/Blosc/c-blosc/pull/183.