### PR TITLE
Fix view

### DIFF
--- a/blosc/b2nd.c
+++ b/blosc/b2nd.c
@@ -1201,7 +1201,7 @@ int view_new(const b2nd_array_t *array, b2nd_array_t **view, b2nd_context_t *ctx
     free((*view)->sc->data[i]);
   }
   free((*view)->sc->data);
-  (*view)->sc->view = true;
+  (*view)->sc->base = (blosc2_schunk*) array->sc; //pointer to original schunk
   (*view)->sc->data = array->sc->data; // point view to the same data
   (*view)->sc->frame = array->sc->frame; // if original array is contiguous, point to frame
   (*view)->sc->nvlmetalayers = array->sc->nvlmetalayers; //

--- a/blosc/schunk.c
+++ b/blosc/schunk.c
@@ -494,8 +494,7 @@ int64_t blosc2_schunk_append_file(blosc2_schunk* schunk, const char* urlpath) {
 int blosc2_schunk_free(blosc2_schunk *schunk) {
   int err = 0;
 
-  // If it is a view, the data belongs to original array and should not be freed
-  if (schunk->data != NULL && !schunk->view) {
+  if (schunk->data != NULL) {
     for (int i = 0; i < schunk->nchunks; i++) {
       free(schunk->data[i]);
     }
@@ -540,8 +539,7 @@ int blosc2_schunk_free(blosc2_schunk *schunk) {
     free(schunk->storage);
   }
 
-  // If it is a view, the frame belongs to original array and should not be freed
-  if (schunk->frame != NULL && !schunk->view) {
+  if (schunk->frame != NULL) {
     frame_free((blosc2_frame_s *) schunk->frame);
   }
 

--- a/blosc/schunk.c
+++ b/blosc/schunk.c
@@ -129,7 +129,7 @@ static bool file_exists (char *filename) {
 blosc2_schunk* blosc2_schunk_new(blosc2_storage *storage) {
   blosc2_schunk* schunk = calloc(1, sizeof(blosc2_schunk));
   schunk->version = 0;     /* pre-first version */
-  schunk->view = false;  /* not a view by default */
+  schunk->base = (blosc2_schunk*) NULL;  /* not a view by default, is its own base */
 
   // Get the storage with proper defaults
   schunk->storage = get_new_storage(storage, &BLOSC2_CPARAMS_DEFAULTS, &BLOSC2_DPARAMS_DEFAULTS, &BLOSC2_IO_DEFAULTS);
@@ -494,7 +494,8 @@ int64_t blosc2_schunk_append_file(blosc2_schunk* schunk, const char* urlpath) {
 int blosc2_schunk_free(blosc2_schunk *schunk) {
   int err = 0;
 
-  if (schunk->data != NULL) {
+  if (schunk->data != NULL && schunk->base != NULL) {
+    // If not a view (and so base points to true array), free all chunks
     for (int i = 0; i < schunk->nchunks; i++) {
       free(schunk->data[i]);
     }
@@ -539,7 +540,8 @@ int blosc2_schunk_free(blosc2_schunk *schunk) {
     free(schunk->storage);
   }
 
-  if (schunk->frame != NULL) {
+  if (schunk->frame != NULL && schunk->base != NULL) {
+    // If not a view (and so base points to true array), free all chunks
     frame_free((blosc2_frame_s *) schunk->frame);
   }
 

--- a/include/b2nd.h
+++ b/include/b2nd.h
@@ -385,6 +385,9 @@ BLOSC_EXPORT int b2nd_squeeze(b2nd_array_t *array);
  * @param final_dims The final number of dimensions. Should be same as the number of elements in @p axis.
  *
  * @return An error code.
+ *
+ * @note This returns a view, so if you free it, pointers to original @param array will be freed too.
+ *
  */
 BLOSC_EXPORT int b2nd_expand_dims(const b2nd_array_t *array, b2nd_array_t **view, const bool *axis,
     const uint8_t final_dims);

--- a/include/blosc2.h
+++ b/include/blosc2.h
@@ -1726,8 +1726,8 @@ typedef struct blosc2_schunk {
   //<! The ndim (mainly for ZFP usage)
   int64_t *blockshape;
   //<! The blockshape (mainly for ZFP usage)
-  bool view;
-  //<! Whether the schunk is a view or not.
+  void *base;
+  //<! If a view then points to the base schunk (if not a view then NULL)
 } blosc2_schunk;
 
 

--- a/tests/b2nd/test_b2nd_expand_dims.c
+++ b/tests/b2nd/test_b2nd_expand_dims.c
@@ -192,7 +192,6 @@ CUTEST_TEST_TEST(expand_dims) {
   free(newbuffer_dest);
   free(buffer);
   B2ND_TEST_ASSERT(b2nd_free(src));
-  B2ND_TEST_ASSERT(b2nd_free(dest));
   B2ND_TEST_ASSERT(b2nd_free(dest2));
   B2ND_TEST_ASSERT(b2nd_free(slice_dest));
   B2ND_TEST_ASSERT(b2nd_free(slice_dest2));


### PR DESCRIPTION
Prior to this fix  `c = blosc2.expand_dims(c, axis=1)` would cause the reference to the original array `c` to disappear, meaning that the original data is garbage collected and the data to which the expanded view points no longer existed. Consequently, `c[0]` for example would fail. 

By including a ``base`` attribute in NDArray objects we ensure views always hold a reference to the array object. When views are garbage collected (created) the reference count for the original array then automatically reduces (increases) by one