### PR TITLE
Unify nchunks offsets bounds checks across frame and schunk

### DIFF
--- a/blosc/blosc-private.h
+++ b/blosc/blosc-private.h
@@ -85,6 +85,25 @@ static inline void endian_handler(bool little, void *dest, const void *pa, int s
   }
 }
 
+/*
+ * Convert a chunk count to the serialized offsets payload size.
+ *
+ * Security rationale: frame metadata can be attacker-controlled, and the offsets payload
+ * eventually flows into APIs that accept int32 byte lengths. This helper enforces a
+ * single overflow-checked conversion so callers cannot accidentally truncate
+ * nchunks * sizeof(int64_t) into a smaller signed length.
+ */
+static inline bool blosc2_nchunks_to_offsets_nbytes(int64_t nchunks, int32_t *off_nbytes) {
+  const int64_t max_nchunks = INT32_MAX / (int64_t)sizeof(int64_t);
+  if (nchunks < 0 || nchunks > max_nchunks) {
+    return false;
+  }
+  if (off_nbytes != NULL) {
+    *off_nbytes = (int32_t)(nchunks * (int64_t)sizeof(int64_t));
+  }
+  return true;
+}
+
 /* Copy 4 bytes from @p *pa to int32_t, changing endianness if necessary. */
 static inline int32_t sw32_(const void* pa) {
   int32_t idest;

--- a/blosc/frame.c
+++ b/blosc/frame.c
@@ -509,10 +509,6 @@ int get_header_info(blosc2_frame_s *frame, int32_t *header_len, int64_t *frame_l
       // We can compute the number of chunks directly when there is a fixed chunk size.
       *nchunks = *nbytes / *chunksize;
       if (*nbytes % *chunksize > 0) {
-        if (*nchunks == INT32_MAX) {
-          BLOSC_TRACE_ERROR("Number of chunks exceeds maximum allowed.");
-          return BLOSC2_ERROR_INVALID_HEADER;
-        }
         *nchunks += 1;
       }
 
@@ -540,6 +536,14 @@ int get_header_info(blosc2_frame_s *frame, int32_t *header_len, int64_t *frame_l
     }
   } else {
     *nchunks = 0;
+  }
+
+  if (*nchunks > 0) {
+    int32_t off_nbytes;
+    if (!blosc2_nchunks_to_offsets_nbytes(*nchunks, &off_nbytes)) {
+      BLOSC_TRACE_ERROR("Invalid number of chunks in frame header.");
+      return BLOSC2_ERROR_INVALID_HEADER;
+    }
   }
 
   return 0;
@@ -1068,8 +1072,18 @@ int64_t frame_from_schunk(blosc2_schunk *schunk, blosc2_frame_s *frame) {
   int32_t chunksize = -1;
   int32_t off_cbytes = 0;
   uint64_t coffset = 0;
-  int32_t off_nbytes = (int32_t) (nchunks * sizeof(int64_t));
-  uint64_t* data_tmp = malloc(off_nbytes);
+  int32_t off_nbytes;
+  if (!blosc2_nchunks_to_offsets_nbytes(nchunks, &off_nbytes)) {
+    BLOSC_TRACE_ERROR("Too many chunks for offsets representation.");
+    free(h2);
+    return BLOSC2_ERROR_DATA;
+  }
+  uint64_t* data_tmp = malloc((size_t)off_nbytes);
+  if (data_tmp == NULL) {
+    BLOSC_TRACE_ERROR("Cannot allocate memory for offset data.");
+    free(h2);
+    return BLOSC2_ERROR_MEMORY_ALLOC;
+  }
   bool needs_free = false;
   for (int i = 0; i < nchunks; i++) {
     uint8_t* data_chunk;
@@ -1253,7 +1267,12 @@ uint8_t* get_coffsets(blosc2_frame_s *frame, int32_t header_len, int64_t cbytes,
         BLOSC_TRACE_ERROR("Cannot read the cbytes outside of frame boundary.");
         return NULL;
       }
-      if (nchunks < 0 || (uint64_t)chunk_nbytes != (uint64_t)nchunks * (uint64_t)sizeof(int64_t)) {
+      int32_t expected_off_nbytes;
+      if (!blosc2_nchunks_to_offsets_nbytes(nchunks, &expected_off_nbytes)) {
+        BLOSC_TRACE_ERROR("Too many chunks for offsets representation.");
+        return NULL;
+      }
+      if (chunk_nbytes != expected_off_nbytes) {
         BLOSC_TRACE_ERROR("The number of chunks in offset idx "
                           "does not match the ones in the header frame.");
         return NULL;
@@ -1270,13 +1289,18 @@ uint8_t* get_coffsets(blosc2_frame_s *frame, int32_t header_len, int64_t cbytes,
     return NULL;
   }
 
-  int32_t coffsets_cbytes;
+  int64_t coffsets_cbytes64;
   if (frame->sframe) {
-    coffsets_cbytes = (int32_t)(trailer_offset - (header_len + 0));
+    coffsets_cbytes64 = trailer_offset - header_len;
   }
   else {
-    coffsets_cbytes = (int32_t)(trailer_offset - (header_len + cbytes));
+    coffsets_cbytes64 = trailer_offset - (header_len + cbytes);
   }
+  if (coffsets_cbytes64 <= 0 || coffsets_cbytes64 > INT32_MAX) {
+    BLOSC_TRACE_ERROR("Offsets chunk size is out of bounds.");
+    return NULL;
+  }
+  int32_t coffsets_cbytes = (int32_t)coffsets_cbytes64;
 
   if (off_cbytes != NULL) {
     *off_cbytes = coffsets_cbytes;
@@ -1354,8 +1378,16 @@ int64_t* blosc2_frame_get_offsets(blosc2_schunk *schunk) {
     return NULL;
   }
 
-  int32_t off_nbytes = (int32_t) (nchunks * sizeof(int64_t));
+  int32_t off_nbytes;
+  if (!blosc2_nchunks_to_offsets_nbytes(nchunks, &off_nbytes)) {
+    BLOSC_TRACE_ERROR("Too many chunks for offsets representation.");
+    return NULL;
+  }
   int64_t* offsets = (int64_t *) malloc((size_t)off_nbytes);
+  if (offsets == NULL) {
+    BLOSC_TRACE_ERROR("Cannot allocate memory for offsets.");
+    return NULL;
+  }
 
   int32_t coffsets_cbytes = 0;
   uint8_t *coffsets = get_coffsets(frame, header_len, cbytes, nchunks, &coffsets_cbytes);
@@ -2002,9 +2034,22 @@ blosc2_schunk* frame_to_schunk(blosc2_frame_s* frame, bool copy, const blosc2_io
     BLOSC_TRACE_ERROR("Error while creating the decompression context");
     return NULL;
   }
-  int64_t* offsets = (int64_t *) malloc((size_t)nchunks * sizeof(int64_t));
+  int32_t offsets_nbytes;
+  if (!blosc2_nchunks_to_offsets_nbytes(nchunks, &offsets_nbytes)) {
+    blosc2_free_ctx(dctx);
+    blosc2_schunk_free(schunk);
+    BLOSC_TRACE_ERROR("Too many chunks for offsets representation.");
+    return NULL;
+  }
+  int64_t* offsets = (int64_t *) malloc((size_t)offsets_nbytes);
+  if (offsets == NULL) {
+    blosc2_free_ctx(dctx);
+    blosc2_schunk_free(schunk);
+    BLOSC_TRACE_ERROR("Cannot allocate memory for offsets.");
+    return NULL;
+  }
   int32_t off_nbytes = blosc2_decompress_ctx(dctx, coffsets, coffsets_cbytes,
-                                             offsets, (int32_t)(nchunks * sizeof(int64_t)));
+                                             offsets, offsets_nbytes);
   blosc2_free_ctx(dctx);
   if (off_nbytes < 0) {
     free(offsets);
@@ -2784,6 +2829,10 @@ int64_t frame_fill_special(blosc2_frame_s* frame, int64_t nitems, int special_va
 
   // Compute the number of chunks and the length of the offsets chunk
   int32_t chunkitems = chunksize / typesize;
+  if (chunkitems <= 0) {
+    BLOSC_TRACE_ERROR("chunksize must be >= typesize for frame special fill.");
+    return BLOSC2_ERROR_FRAME_SPECIAL;
+  }
   nchunks = nitems / chunkitems;
   int32_t leftover_items = (int32_t)(nitems % chunkitems);
   if (leftover_items) {
@@ -2798,6 +2847,13 @@ int64_t frame_fill_special(blosc2_frame_s* frame, int64_t nitems, int special_va
   uint8_t* off_chunk = malloc(new_off_cbytes);
   uint64_t offset_value = ((uint64_t)1 << 63);
   uint8_t* sample_chunk = malloc(BLOSC_EXTENDED_HEADER_LENGTH);
+  if (off_chunk == NULL || sample_chunk == NULL) {
+    free(off_chunk);
+    free(sample_chunk);
+    free(cparams);
+    BLOSC_TRACE_ERROR("Cannot allocate memory for special fill chunks.");
+    return BLOSC2_ERROR_MEMORY_ALLOC;
+  }
   int csize;
   switch (special_value) {
     case BLOSC2_SPECIAL_ZERO:
@@ -2813,10 +2869,16 @@ int64_t frame_fill_special(blosc2_frame_s* frame, int64_t nitems, int special_va
       csize = blosc2_chunk_nans(*cparams, chunksize, sample_chunk, BLOSC_EXTENDED_HEADER_LENGTH);
       break;
     default:
+      free(off_chunk);
+      free(sample_chunk);
+      free(cparams);
       BLOSC_TRACE_ERROR("Only zeros, NaNs or non-initialized values are supported.");
       return BLOSC2_ERROR_FRAME_SPECIAL;
   }
   if (csize < 0) {
+    free(off_chunk);
+    free(sample_chunk);
+    free(cparams);
     BLOSC_TRACE_ERROR("Error creating sample chunk");
     return BLOSC2_ERROR_FRAME_SPECIAL;
   }
@@ -2825,7 +2887,14 @@ int64_t frame_fill_special(blosc2_frame_s* frame, int64_t nitems, int special_va
   cparams->blocksize = 8 * 2 * 1024;  // based on experiments with create_frame.c bench
   cparams->clevel = 5;
   cparams->compcode = BLOSC_BLOSCLZ;
-  int32_t special_nbytes = (int32_t) (nchunks * sizeof(int64_t));
+  int32_t special_nbytes;
+  if (!blosc2_nchunks_to_offsets_nbytes(nchunks, &special_nbytes)) {
+    free(off_chunk);
+    free(sample_chunk);
+    free(cparams);
+    BLOSC_TRACE_ERROR("Too many chunks for offsets representation.");
+    return BLOSC2_ERROR_FRAME_SPECIAL;
+  }
   rc = blosc2_chunk_repeatval(*cparams, special_nbytes, off_chunk, new_off_cbytes, &offset_value);
   free(cparams);
   if (rc < 0) {
@@ -3412,8 +3481,16 @@ void* frame_update_chunk(blosc2_frame_s* frame, int64_t nchunk, void* chunk, blo
   }
 
   // Get the current offsets
-  int32_t off_nbytes = (int32_t) (nchunks * sizeof(int64_t));
+  int32_t off_nbytes;
+  if (!blosc2_nchunks_to_offsets_nbytes(nchunks, &off_nbytes)) {
+    BLOSC_TRACE_ERROR("Too many chunks for offsets representation.");
+    return NULL;
+  }
   int64_t* offsets = (int64_t *) malloc((size_t)off_nbytes);
+  if (offsets == NULL) {
+    BLOSC_TRACE_ERROR("Cannot allocate memory for offsets.");
+    return NULL;
+  }
   if (nchunks > 0) {
     int32_t coffsets_cbytes = 0;
     uint8_t *coffsets = get_coffsets(frame, header_len, cbytes, nchunks, &coffsets_cbytes);
@@ -3733,8 +3810,16 @@ void* frame_delete_chunk(blosc2_frame_s* frame, int64_t nchunk, blosc2_schunk* s
   }
 
   // Get the current offsets
-  int32_t off_nbytes = (int32_t) (nchunks * sizeof(int64_t));
+  int32_t off_nbytes;
+  if (!blosc2_nchunks_to_offsets_nbytes(nchunks, &off_nbytes)) {
+    BLOSC_TRACE_ERROR("Too many chunks for offsets representation.");
+    return NULL;
+  }
   int64_t* offsets = (int64_t *) malloc((size_t)off_nbytes);
+  if (offsets == NULL) {
+    BLOSC_TRACE_ERROR("Cannot allocate memory for offsets.");
+    return NULL;
+  }
   if (nchunks > 0) {
     int32_t coffsets_cbytes = 0;
     uint8_t *coffsets = get_coffsets(frame, header_len, cbytes, nchunks, &coffsets_cbytes);
@@ -3903,8 +3988,16 @@ int frame_reorder_offsets(blosc2_frame_s* frame, const int64_t* offsets_order, b
   }
 
   // Get the current offsets and add one more
-  int32_t off_nbytes = (int32_t) (nchunks * sizeof(int64_t));
+  int32_t off_nbytes;
+  if (!blosc2_nchunks_to_offsets_nbytes(nchunks, &off_nbytes)) {
+    BLOSC_TRACE_ERROR("Too many chunks for offsets representation.");
+    return BLOSC2_ERROR_DATA;
+  }
   int64_t* offsets = (int64_t *) malloc((size_t)off_nbytes);
+  if (offsets == NULL) {
+    BLOSC_TRACE_ERROR("Cannot allocate memory for offsets.");
+    return BLOSC2_ERROR_MEMORY_ALLOC;
+  }
 
   int32_t coffsets_cbytes = 0;
   uint8_t *coffsets = get_coffsets(frame, header_len, cbytes, nchunks, &coffsets_cbytes);

--- a/blosc/frame.c
+++ b/blosc/frame.c
@@ -508,10 +508,6 @@ int get_header_info(blosc2_frame_s *frame, int32_t *header_len, int64_t *frame_l
       // We can compute the number of chunks directly when there is a fixed chunk size.
       *nchunks = *nbytes / *chunksize;
       if (*nbytes % *chunksize > 0) {
-        if (*nchunks == INT32_MAX) {
-          BLOSC_TRACE_ERROR("Number of chunks exceeds maximum allowed.");
-          return BLOSC2_ERROR_INVALID_HEADER;
-        }
         *nchunks += 1;
       }
 
@@ -539,6 +535,14 @@ int get_header_info(blosc2_frame_s *frame, int32_t *header_len, int64_t *frame_l
     }
   } else {
     *nchunks = 0;
+  }
+
+  if (*nchunks > 0) {
+    int32_t off_nbytes;
+    if (!blosc2_nchunks_to_offsets_nbytes(*nchunks, &off_nbytes)) {
+      BLOSC_TRACE_ERROR("Invalid number of chunks in frame header.");
+      return BLOSC2_ERROR_INVALID_HEADER;
+    }
   }
 
   return 0;
@@ -1066,8 +1070,18 @@ int64_t frame_from_schunk(blosc2_schunk *schunk, blosc2_frame_s *frame) {
   int32_t chunksize = -1;
   int32_t off_cbytes = 0;
   uint64_t coffset = 0;
-  int32_t off_nbytes = (int32_t) (nchunks * sizeof(int64_t));
-  uint64_t* data_tmp = malloc(off_nbytes);
+  int32_t off_nbytes;
+  if (!blosc2_nchunks_to_offsets_nbytes(nchunks, &off_nbytes)) {
+    BLOSC_TRACE_ERROR("Too many chunks for offsets representation.");
+    free(h2);
+    return BLOSC2_ERROR_DATA;
+  }
+  uint64_t* data_tmp = malloc((size_t)off_nbytes);
+  if (data_tmp == NULL) {
+    BLOSC_TRACE_ERROR("Cannot allocate memory for offset data.");
+    free(h2);
+    return BLOSC2_ERROR_MEMORY_ALLOC;
+  }
   bool needs_free = false;
   for (int i = 0; i < nchunks; i++) {
     uint8_t* data_chunk;
@@ -1251,7 +1265,12 @@ uint8_t* get_coffsets(blosc2_frame_s *frame, int32_t header_len, int64_t cbytes,
         BLOSC_TRACE_ERROR("Cannot read the cbytes outside of frame boundary.");
         return NULL;
       }
-      if ((uint64_t)chunk_nbytes != nchunks * sizeof(int64_t)) {
+      int32_t expected_off_nbytes;
+      if (!blosc2_nchunks_to_offsets_nbytes(nchunks, &expected_off_nbytes)) {
+        BLOSC_TRACE_ERROR("Too many chunks for offsets representation.");
+        return NULL;
+      }
+      if (chunk_nbytes != expected_off_nbytes) {
         BLOSC_TRACE_ERROR("The number of chunks in offset idx "
                           "does not match the ones in the header frame.");
         return NULL;
@@ -1268,13 +1287,18 @@ uint8_t* get_coffsets(blosc2_frame_s *frame, int32_t header_len, int64_t cbytes,
     return NULL;
   }
 
-  int32_t coffsets_cbytes;
+  int64_t coffsets_cbytes64;
   if (frame->sframe) {
-    coffsets_cbytes = (int32_t)(trailer_offset - (header_len + 0));
+    coffsets_cbytes64 = trailer_offset - header_len;
   }
   else {
-    coffsets_cbytes = (int32_t)(trailer_offset - (header_len + cbytes));
+    coffsets_cbytes64 = trailer_offset - (header_len + cbytes);
   }
+  if (coffsets_cbytes64 <= 0 || coffsets_cbytes64 > INT32_MAX) {
+    BLOSC_TRACE_ERROR("Offsets chunk size is out of bounds.");
+    return NULL;
+  }
+  int32_t coffsets_cbytes = (int32_t)coffsets_cbytes64;
 
   if (off_cbytes != NULL) {
     *off_cbytes = coffsets_cbytes;
@@ -1352,8 +1376,16 @@ int64_t* blosc2_frame_get_offsets(blosc2_schunk *schunk) {
     return NULL;
   }
 
-  int32_t off_nbytes = (int32_t) (nchunks * sizeof(int64_t));
+  int32_t off_nbytes;
+  if (!blosc2_nchunks_to_offsets_nbytes(nchunks, &off_nbytes)) {
+    BLOSC_TRACE_ERROR("Too many chunks for offsets representation.");
+    return NULL;
+  }
   int64_t* offsets = (int64_t *) malloc((size_t)off_nbytes);
+  if (offsets == NULL) {
+    BLOSC_TRACE_ERROR("Cannot allocate memory for offsets.");
+    return NULL;
+  }
 
   int32_t coffsets_cbytes = 0;
   uint8_t *coffsets = get_coffsets(frame, header_len, cbytes, nchunks, &coffsets_cbytes);
@@ -2000,9 +2032,22 @@ blosc2_schunk* frame_to_schunk(blosc2_frame_s* frame, bool copy, const blosc2_io
     BLOSC_TRACE_ERROR("Error while creating the decompression context");
     return NULL;
   }
-  int64_t* offsets = (int64_t *) malloc((size_t)nchunks * sizeof(int64_t));
+  int32_t offsets_nbytes;
+  if (!blosc2_nchunks_to_offsets_nbytes(nchunks, &offsets_nbytes)) {
+    blosc2_free_ctx(dctx);
+    blosc2_schunk_free(schunk);
+    BLOSC_TRACE_ERROR("Too many chunks for offsets representation.");
+    return NULL;
+  }
+  int64_t* offsets = (int64_t *) malloc((size_t)offsets_nbytes);
+  if (offsets == NULL) {
+    blosc2_free_ctx(dctx);
+    blosc2_schunk_free(schunk);
+    BLOSC_TRACE_ERROR("Cannot allocate memory for offsets.");
+    return NULL;
+  }
   int32_t off_nbytes = blosc2_decompress_ctx(dctx, coffsets, coffsets_cbytes,
-                                             offsets, (int32_t)(nchunks * sizeof(int64_t)));
+                                             offsets, offsets_nbytes);
   blosc2_free_ctx(dctx);
   if (off_nbytes < 0) {
     free(offsets);
@@ -2687,6 +2732,10 @@ int64_t frame_fill_special(blosc2_frame_s* frame, int64_t nitems, int special_va
 
   // Compute the number of chunks and the length of the offsets chunk
   int32_t chunkitems = chunksize / typesize;
+  if (chunkitems <= 0) {
+    BLOSC_TRACE_ERROR("chunksize must be >= typesize for frame special fill.");
+    return BLOSC2_ERROR_FRAME_SPECIAL;
+  }
   nchunks = nitems / chunkitems;
   int32_t leftover_items = (int32_t)(nitems % chunkitems);
   if (leftover_items) {
@@ -2701,6 +2750,13 @@ int64_t frame_fill_special(blosc2_frame_s* frame, int64_t nitems, int special_va
   uint8_t* off_chunk = malloc(new_off_cbytes);
   uint64_t offset_value = ((uint64_t)1 << 63);
   uint8_t* sample_chunk = malloc(BLOSC_EXTENDED_HEADER_LENGTH);
+  if (off_chunk == NULL || sample_chunk == NULL) {
+    free(off_chunk);
+    free(sample_chunk);
+    free(cparams);
+    BLOSC_TRACE_ERROR("Cannot allocate memory for special fill chunks.");
+    return BLOSC2_ERROR_MEMORY_ALLOC;
+  }
   int csize;
   switch (special_value) {
     case BLOSC2_SPECIAL_ZERO:
@@ -2716,10 +2772,16 @@ int64_t frame_fill_special(blosc2_frame_s* frame, int64_t nitems, int special_va
       csize = blosc2_chunk_nans(*cparams, chunksize, sample_chunk, BLOSC_EXTENDED_HEADER_LENGTH);
       break;
     default:
+      free(off_chunk);
+      free(sample_chunk);
+      free(cparams);
       BLOSC_TRACE_ERROR("Only zeros, NaNs or non-initialized values are supported.");
       return BLOSC2_ERROR_FRAME_SPECIAL;
   }
   if (csize < 0) {
+    free(off_chunk);
+    free(sample_chunk);
+    free(cparams);
     BLOSC_TRACE_ERROR("Error creating sample chunk");
     return BLOSC2_ERROR_FRAME_SPECIAL;
   }
@@ -2728,7 +2790,14 @@ int64_t frame_fill_special(blosc2_frame_s* frame, int64_t nitems, int special_va
   cparams->blocksize = 8 * 2 * 1024;  // based on experiments with create_frame.c bench
   cparams->clevel = 5;
   cparams->compcode = BLOSC_BLOSCLZ;
-  int32_t special_nbytes = (int32_t) (nchunks * sizeof(int64_t));
+  int32_t special_nbytes;
+  if (!blosc2_nchunks_to_offsets_nbytes(nchunks, &special_nbytes)) {
+    free(off_chunk);
+    free(sample_chunk);
+    free(cparams);
+    BLOSC_TRACE_ERROR("Too many chunks for offsets representation.");
+    return BLOSC2_ERROR_FRAME_SPECIAL;
+  }
   rc = blosc2_chunk_repeatval(*cparams, special_nbytes, off_chunk, new_off_cbytes, &offset_value);
   free(cparams);
   if (rc < 0) {
@@ -3315,8 +3384,16 @@ void* frame_update_chunk(blosc2_frame_s* frame, int64_t nchunk, void* chunk, blo
   }
 
   // Get the current offsets
-  int32_t off_nbytes = (int32_t) (nchunks * sizeof(int64_t));
+  int32_t off_nbytes;
+  if (!blosc2_nchunks_to_offsets_nbytes(nchunks, &off_nbytes)) {
+    BLOSC_TRACE_ERROR("Too many chunks for offsets representation.");
+    return NULL;
+  }
   int64_t* offsets = (int64_t *) malloc((size_t)off_nbytes);
+  if (offsets == NULL) {
+    BLOSC_TRACE_ERROR("Cannot allocate memory for offsets.");
+    return NULL;
+  }
   if (nchunks > 0) {
     int32_t coffsets_cbytes = 0;
     uint8_t *coffsets = get_coffsets(frame, header_len, cbytes, nchunks, &coffsets_cbytes);
@@ -3636,8 +3713,16 @@ void* frame_delete_chunk(blosc2_frame_s* frame, int64_t nchunk, blosc2_schunk* s
   }
 
   // Get the current offsets
-  int32_t off_nbytes = (int32_t) (nchunks * sizeof(int64_t));
+  int32_t off_nbytes;
+  if (!blosc2_nchunks_to_offsets_nbytes(nchunks, &off_nbytes)) {
+    BLOSC_TRACE_ERROR("Too many chunks for offsets representation.");
+    return NULL;
+  }
   int64_t* offsets = (int64_t *) malloc((size_t)off_nbytes);
+  if (offsets == NULL) {
+    BLOSC_TRACE_ERROR("Cannot allocate memory for offsets.");
+    return NULL;
+  }
   if (nchunks > 0) {
     int32_t coffsets_cbytes = 0;
     uint8_t *coffsets = get_coffsets(frame, header_len, cbytes, nchunks, &coffsets_cbytes);
@@ -3806,8 +3891,16 @@ int frame_reorder_offsets(blosc2_frame_s* frame, const int64_t* offsets_order, b
   }
 
   // Get the current offsets and add one more
-  int32_t off_nbytes = (int32_t) (nchunks * sizeof(int64_t));
+  int32_t off_nbytes;
+  if (!blosc2_nchunks_to_offsets_nbytes(nchunks, &off_nbytes)) {
+    BLOSC_TRACE_ERROR("Too many chunks for offsets representation.");
+    return BLOSC2_ERROR_DATA;
+  }
   int64_t* offsets = (int64_t *) malloc((size_t)off_nbytes);
+  if (offsets == NULL) {
+    BLOSC_TRACE_ERROR("Cannot allocate memory for offsets.");
+    return BLOSC2_ERROR_MEMORY_ALLOC;
+  }
 
   int32_t coffsets_cbytes = 0;
   uint8_t *coffsets = get_coffsets(frame, header_len, cbytes, nchunks, &coffsets_cbytes);

--- a/blosc/schunk.c
+++ b/blosc/schunk.c
@@ -610,10 +610,9 @@ int64_t blosc2_schunk_fill_special(blosc2_schunk* schunk, int64_t nitems, int sp
   }
 
   int32_t typesize = schunk->typesize;
-
-  if ((nitems * typesize / chunksize) > INT_MAX) {
-    BLOSC_TRACE_ERROR("nitems is too large.  Try increasing the chunksize.");
-    return BLOSC2_ERROR_SCHUNK_SPECIAL;
+  if (nitems < 0 || chunksize <= 0 || typesize <= 0) {
+    BLOSC_TRACE_ERROR("Invalid special fill parameters.");
+    return BLOSC2_ERROR_INVALID_PARAM;
   }
 
   if ((schunk->nbytes > 0) || (schunk->cbytes > 0)) {
@@ -623,7 +622,19 @@ int64_t blosc2_schunk_fill_special(blosc2_schunk* schunk, int64_t nitems, int sp
 
   // Compute the number of chunks and the length of the offsets chunk
   int32_t chunkitems = chunksize / typesize;
+  if (chunkitems <= 0) {
+    BLOSC_TRACE_ERROR("chunksize must be >= typesize for special fill.");
+    return BLOSC2_ERROR_INVALID_PARAM;
+  }
   int64_t nchunks = nitems / chunkitems;
+  if (nchunks > INT_MAX) {
+    BLOSC_TRACE_ERROR("nitems is too large.  Try increasing the chunksize.");
+    return BLOSC2_ERROR_SCHUNK_SPECIAL;
+  }
+  if (nitems > INT64_MAX / typesize) {
+    BLOSC_TRACE_ERROR("nitems is too large for nbytes accounting.");
+    return BLOSC2_ERROR_SCHUNK_SPECIAL;
+  }
   int32_t leftover_items = (int32_t)(nitems % chunkitems);
 
   if (schunk->frame == NULL) {
@@ -678,6 +689,16 @@ int64_t blosc2_schunk_fill_special(blosc2_schunk* schunk, int64_t nitems, int sp
   else {
     /* Fill an empty frame with special values (fast path). */
     blosc2_frame_s *frame = (blosc2_frame_s *) schunk->frame;
+    int64_t total_chunks = nchunks + (leftover_items ? 1 : 0);
+    if (!blosc2_nchunks_to_offsets_nbytes(total_chunks, NULL)) {
+      BLOSC_TRACE_ERROR("Too many chunks for frame offsets representation.");
+      return BLOSC2_ERROR_FRAME_SPECIAL;
+    }
+
+    int64_t old_nchunks = schunk->nchunks;
+    int64_t old_nbytes = schunk->nbytes;
+    int32_t old_chunksize = schunk->chunksize;
+
     /* Update counters (necessary for the frame_fill_special() logic) */
     if (leftover_items) {
       nchunks += 1;
@@ -687,6 +708,9 @@ int64_t blosc2_schunk_fill_special(blosc2_schunk* schunk, int64_t nitems, int sp
     schunk->nbytes = nitems * typesize;
     int64_t frame_len = frame_fill_special(frame, nitems, special_value, chunksize, schunk);
     if (frame_len < 0) {
+      schunk->chunksize = old_chunksize;
+      schunk->nchunks = old_nchunks;
+      schunk->nbytes = old_nbytes;
       BLOSC_TRACE_ERROR("Error creating special frame.");
       return frame_len;
     }


### PR DESCRIPTION
This PR hardens integer-bounds handling for offsets sizing and unifies the logic across frame and schunk code paths

Added a shared checked conversion helper in `blosc-private.h`

Switched offsets-size calculations in `frame.c` to use the shared helper

Added additional fail-closed checks for trailer-derived offsets sizes in `frame.c`

Hardened special-fill validation and state-consistency handling in `schunk.c`
