### PR TITLE
Harden mmap I/O against integer overflow in size and offset calculations

### DIFF
--- a/blosc/blosc2-stdio.c
+++ b/blosc/blosc2-stdio.c
@@ -87,14 +87,14 @@ int64_t blosc2_stdio_size(void *stream) {
   return size;
 }
 
-int64_t blosc2_stdio_write(const void *ptr, size_t size, size_t nitems, size_t position, void *stream) {
+int64_t blosc2_stdio_write(const void *ptr, int64_t size, int64_t nitems, int64_t position, void *stream) {
   blosc2_stdio_file *my_fp = (blosc2_stdio_file *) stream;
   fseek(my_fp->file, (long)position, SEEK_SET);
   size_t nitems_ = fwrite(ptr, (size_t)size, (size_t)nitems, my_fp->file);
   return (int64_t) nitems_;
 }
 
-int64_t blosc2_stdio_read(void **ptr, size_t size, size_t nitems, size_t position, void *stream) {
+int64_t blosc2_stdio_read(void **ptr, int64_t size, int64_t nitems, int64_t position, void *stream) {
   blosc2_stdio_file *my_fp = (blosc2_stdio_file *) stream;
   fseek(my_fp->file, (long)position, SEEK_SET);
   void* data_ptr = *ptr;
@@ -102,13 +102,13 @@ int64_t blosc2_stdio_read(void **ptr, size_t size, size_t nitems, size_t positio
   return (int64_t) nitems_;
 }
 
-int blosc2_stdio_truncate(void *stream, size_t size) {
+int blosc2_stdio_truncate(void *stream, int64_t size) {
   blosc2_stdio_file *my_fp = (blosc2_stdio_file *) stream;
   int rc;
 #if defined(_MSC_VER)
   rc = _chsize_s(_fileno(my_fp->file), size);
 #else
-  rc = ftruncate(fileno(my_fp->file), (off_t)size);
+  rc = ftruncate(fileno(my_fp->file), size);
 #endif
   return rc;
 }
@@ -306,10 +306,10 @@ void *blosc2_stdio_mmap_open(const char *urlpath, const char *mode, void* params
 #endif
 
   BLOSC_INFO(
-    "Opened memory-mapped file %s in mode %s with a mapping size of %zu bytes.",
+    "Opened memory-mapped file %s in mode %s with an mapping size of %" PRId64 " bytes.",
     mmap_file->urlpath,
     mmap_file->mode,
-    (size_t)mmap_file->mapping_size
+    mmap_file->mapping_size
   );
 
   /* The mmap_file->mode parameter is only available during the opening call and cannot be used in any of the other
@@ -330,7 +330,7 @@ int64_t blosc2_stdio_mmap_size(void *stream) {
   return mmap_file->file_size;
 }
 
-int64_t blosc2_stdio_mmap_write(const void *ptr, size_t size, size_t nitems, size_t position, void *stream) {
+int64_t blosc2_stdio_mmap_write(const void *ptr, int64_t size, int64_t nitems, int64_t position, void *stream) {
   blosc2_stdio_mmap *mmap_file = (blosc2_stdio_mmap *) stream;
 
   if (ptr == NULL) {
@@ -340,7 +340,7 @@ int64_t blosc2_stdio_mmap_write(const void *ptr, size_t size, size_t nitems, siz
 
   size_t n_bytes;
   if (size > 0 && nitems > 0 && size > SIZE_MAX / nitems) {
-    BLOSC_TRACE_ERROR("mmap write size overflow (size=%zu, nitems=%zu).", size, nitems);
+    BLOSC_TRACE_ERROR("mmap write size overflow (size=%" PRId64 ", nitems=%" PRId64 ").", size, nitems);
     return 0;
   }
   n_bytes = size * nitems;
@@ -348,7 +348,7 @@ int64_t blosc2_stdio_mmap_write(const void *ptr, size_t size, size_t nitems, siz
     return 0;
   }
   if (position > SIZE_MAX - n_bytes) {
-    BLOSC_TRACE_ERROR("mmap write position overflow (position=%zu, nbytes=%zu).", position, n_bytes);
+    BLOSC_TRACE_ERROR("mmap write position overflow (position=%" PRId64 ", nbytes=%" PRId64 ").", position, n_bytes);
     return 0;
   }
   size_t position_end = position + n_bytes;
@@ -363,8 +363,8 @@ int64_t blosc2_stdio_mmap_write(const void *ptr, size_t size, size_t nitems, siz
     size_t remap_size;
     if (mmap_file->file_size > SIZE_MAX / 2) {
       BLOSC_TRACE_WARNING(
-        "mmap remap growth capped at file size (%zu bytes) to avoid overflow.",
-        (size_t)mmap_file->file_size
+        "mmap remap growth capped at file size (%" PRId64 " bytes) to avoid overflow.",
+        mmap_file->file_size
       );
       remap_size = mmap_file->file_size;
     }
@@ -373,7 +373,7 @@ int64_t blosc2_stdio_mmap_write(const void *ptr, size_t size, size_t nitems, siz
     }
 
     if ((uint64_t)remap_size > SIZE_MAX) {
-      BLOSC_TRACE_ERROR("mmap mapping size does not fit in size_t (%zu).", (size_t)remap_size);
+      BLOSC_TRACE_ERROR("mmap mapping size does not fit in size_t (%" PRId64 ").", (size_t)remap_size);
       return 0;
     }
 

--- a/blosc/blosc2-stdio.c
+++ b/blosc/blosc2-stdio.c
@@ -21,8 +21,8 @@
 #include <stdint.h>
 #include <errno.h>
 #include <inttypes.h>
-#include <limits.h>
 #include <string.h>
+
 #if defined(_WIN32)
   #include <memoryapi.h>
   // See https://github.com/Blosc/python-blosc2/issues/359
@@ -105,7 +105,7 @@ int64_t blosc2_stdio_write(const void *ptr, int64_t size, int64_t nitems, int64_
 
 int64_t blosc2_stdio_read(void **ptr, int64_t size, int64_t nitems, int64_t position, void *stream) {
   blosc2_stdio_file *my_fp = (blosc2_stdio_file *) stream;
-    int rc = fseek(my_fp->file, position, SEEK_SET);
+  int rc = fseek(my_fp->file, position, SEEK_SET);
   if (rc != 0) {
     BLOSC_TRACE_ERROR("fseek failed at position %" PRId64 " (error: %s).", position, strerror(errno));
     return 0;

--- a/blosc/blosc2-stdio.c
+++ b/blosc/blosc2-stdio.c
@@ -21,7 +21,7 @@
 #include <stdint.h>
 #include <errno.h>
 #include <inttypes.h>
-#include <string.h>
+#include <limits.h>
 
 #if defined(_WIN32)
   #include <memoryapi.h>
@@ -89,34 +89,18 @@ int64_t blosc2_stdio_size(void *stream) {
 
 int64_t blosc2_stdio_write(const void *ptr, int64_t size, int64_t nitems, int64_t position, void *stream) {
   blosc2_stdio_file *my_fp = (blosc2_stdio_file *) stream;
-  int rc = fseek(my_fp->file, position, SEEK_SET);
-  if (rc != 0) {
-    BLOSC_TRACE_ERROR("fseek failed at position %" PRId64 " (error: %s).", position, strerror(errno));
-    return 0;
-  }
+  fseek(my_fp->file, position, SEEK_SET);
 
   size_t nitems_ = fwrite(ptr, (size_t) size, (size_t) nitems, my_fp->file);
-  if ((int64_t)nitems_ != nitems) {
-    BLOSC_TRACE_ERROR("Short write at position %" PRId64 ": requested %" PRId64 " items of size %" PRId64
-                      ", wrote %zu (error: %s).", position, nitems, size, nitems_, strerror(errno));
-  }
   return (int64_t) nitems_;
 }
 
 int64_t blosc2_stdio_read(void **ptr, int64_t size, int64_t nitems, int64_t position, void *stream) {
   blosc2_stdio_file *my_fp = (blosc2_stdio_file *) stream;
-  int rc = fseek(my_fp->file, position, SEEK_SET);
-  if (rc != 0) {
-    BLOSC_TRACE_ERROR("fseek failed at position %" PRId64 " (error: %s).", position, strerror(errno));
-    return 0;
-  }
+  fseek(my_fp->file, position, SEEK_SET);
 
   void* data_ptr = *ptr;
   size_t nitems_ = fread(data_ptr, (size_t) size, (size_t) nitems, my_fp->file);
-  if ((int64_t)nitems_ != nitems) {
-    BLOSC_TRACE_ERROR("Short read at position %" PRId64 ": requested %" PRId64 " items of size %" PRId64
-                      ", read %zu (error: %s).", position, nitems, size, nitems_, strerror(errno));
-  }
   return (int64_t) nitems_;
 }
 
@@ -274,11 +258,6 @@ void *blosc2_stdio_mmap_open(const char *urlpath, const char *mode, void* params
     mmap_file->mapping_size = mmap_file->file_size;
   }
 
-  if ((uint64_t)mmap_file->mapping_size > SIZE_MAX) {
-    BLOSC_TRACE_ERROR("mmap mapping size does not fit in size_t (%zu).", (size_t)mmap_file->mapping_size);
-    return NULL;
-  }
-
 #if defined(_WIN32)
   mmap_file->fd = _fileno(mmap_file->file);
 
@@ -351,49 +330,43 @@ int64_t blosc2_stdio_mmap_size(void *stream) {
 int64_t blosc2_stdio_mmap_write(const void *ptr, int64_t size, int64_t nitems, int64_t position, void *stream) {
   blosc2_stdio_mmap *mmap_file = (blosc2_stdio_mmap *) stream;
 
-  if (ptr == NULL) {
-    BLOSC_TRACE_ERROR("Invalid arguments for mmap write: ptr is NULL.");
+  if (ptr == NULL || size < 0 || nitems < 0 || position < 0) {
+    BLOSC_TRACE_ERROR("Invalid arguments for mmap write.");
     return 0;
   }
 
-  size_t n_bytes;
-  if (size > 0 && nitems > 0 && size > SIZE_MAX / nitems) {
+  int64_t n_bytes;
+  if (!checked_mul_int64_nonneg(size, nitems, &n_bytes)) {
     BLOSC_TRACE_ERROR("mmap write size overflow (size=%" PRId64 ", nitems=%" PRId64 ").", size, nitems);
     return 0;
   }
-  n_bytes = size * nitems;
   if (n_bytes == 0) {
     return 0;
   }
-  size_t position_u = (size_t)position;
-  if (position_u > SIZE_MAX - n_bytes) {
-    BLOSC_TRACE_ERROR("mmap write position overflow (position=%" PRId64 ", nbytes=%zu).", position, n_bytes);
+  if ((uint64_t)n_bytes > SIZE_MAX) {
+    BLOSC_TRACE_ERROR("mmap write size does not fit in size_t (%" PRId64 ").", n_bytes);
     return 0;
   }
-  size_t position_end = position_u + n_bytes;
-  size_t new_size = position_end > (size_t)mmap_file->file_size ? position_end : (size_t)mmap_file->file_size;
+
+  int64_t position_end;
+  if (!checked_add_int64_nonneg(position, n_bytes, &position_end)) {
+    BLOSC_TRACE_ERROR("mmap write position overflow (position=%" PRId64 ", nbytes=%" PRId64 ").", position, n_bytes);
+    return 0;
+  }
+  int64_t new_size = position_end > mmap_file->file_size ? position_end : mmap_file->file_size;
 
 #if defined(_WIN32)
-  if ((size_t)mmap_file->file_size < new_size) {
-    mmap_file->file_size = (int64_t)new_size;
+  if (mmap_file->file_size < new_size) {
+    mmap_file->file_size = new_size;
   }
 
-  if ((size_t)mmap_file->mapping_size < mmap_file->file_size) {
-    size_t remap_size;
-    if (mmap_file->file_size > SIZE_MAX / 2) {
-      BLOSC_TRACE_WARNING(
-        "mmap remap growth capped at file size (%" PRId64 " bytes) to avoid overflow.",
-        mmap_file->file_size
-      );
-      remap_size = mmap_file->file_size;
+  if (mmap_file->mapping_size < mmap_file->file_size) {
+    if (mmap_file->file_size > INT64_MAX / 2) {
+      mmap_file->mapping_size = mmap_file->file_size;
     }
     else {
-      remap_size = mmap_file->file_size * 2;
+      mmap_file->mapping_size = mmap_file->file_size * 2;
     }
-
-    /* remap_size is already size_t, so it always fits — nothing to check here */
-
-    mmap_file->mapping_size = remap_size;
 
     /* We need to remap the file completely and cannot pass the previous used address on Windows */
     if (!UnmapViewOfFile(mmap_file->addr)) {
@@ -448,22 +421,13 @@ int64_t blosc2_stdio_mmap_write(const void *ptr, int64_t size, int64_t nitems, i
   }
 
   if (mmap_file->mapping_size < mmap_file->file_size) {
-    size_t old_mapping_size = mmap_file->mapping_size;
-    size_t remap_size;
+    int64_t old_mapping_size = mmap_file->mapping_size;
     if (mmap_file->file_size > INT64_MAX / 2) {
-      BLOSC_TRACE_WARNING(
-        "mmap remap growth capped at file size (%" PRId64 " bytes) to avoid int64 overflow.",
-        mmap_file->file_size
-      );
-      remap_size = mmap_file->file_size;
+      mmap_file->mapping_size = mmap_file->file_size;
     }
     else {
-      remap_size = mmap_file->file_size * 2;
+      mmap_file->mapping_size = mmap_file->file_size * 2;
     }
-
-    /* remap_size is size_t (unsigned) — no negative / overflow check needed */
-
-    mmap_file->mapping_size = remap_size;
 
 #if defined(__linux__)
     /* mremap is the best option as it also ensures that the old data is still available in c mode. Unfortunately, it
@@ -500,43 +464,40 @@ int64_t blosc2_stdio_mmap_write(const void *ptr, int64_t size, int64_t nitems, i
   }
 #endif
 
-  memcpy(mmap_file->addr + position_u, ptr, n_bytes);
+  memcpy(mmap_file->addr + position, ptr, n_bytes);
   return nitems;
 }
 
 int64_t blosc2_stdio_mmap_read(void **ptr, int64_t size, int64_t nitems, int64_t position, void *stream) {
   blosc2_stdio_mmap *mmap_file = (blosc2_stdio_mmap *) stream;
 
-  if (ptr == NULL) {
-    BLOSC_TRACE_ERROR("Invalid arguments for mmap read: output pointer is NULL.");
-    return 0;
-  }
-
-  if (size < 0 || nitems < 0 || position < 0) {
+  if (ptr == NULL || size < 0 || nitems < 0 || position < 0) {
     BLOSC_TRACE_ERROR("Invalid arguments for mmap read.");
     *ptr = NULL;
     return 0;
   }
 
-  size_t n_bytes;
-  if (size > 0 && nitems > 0 && size > SIZE_MAX / nitems) {
+  int64_t n_bytes;
+  if (!checked_mul_int64_nonneg(size, nitems, &n_bytes)) {
     BLOSC_TRACE_ERROR("mmap read size overflow (size=%" PRId64 ", nitems=%" PRId64 ").", size, nitems);
     *ptr = NULL;
     return 0;
   }
-  n_bytes = size * nitems;
-  if (position > SIZE_MAX - n_bytes) {
-    BLOSC_TRACE_ERROR("mmap read position overflow (position=%" PRId64 ", nbytes=%zu).", position, n_bytes);
+  int64_t position_end;
+  if (!checked_add_int64_nonneg(position, n_bytes, &position_end)) {
+    BLOSC_TRACE_ERROR("mmap read position overflow (position=%" PRId64 ", nbytes=%" PRId64 ").", position, n_bytes);
     *ptr = NULL;
     return 0;
   }
-  size_t position_end = position + n_bytes;
+
   if (position_end > mmap_file->file_size) {
     BLOSC_TRACE_ERROR("Cannot read beyond the end of the memory-mapped file.");
     *ptr = NULL;
     return 0;
   }
+
   *ptr = mmap_file->addr + position;
+
   return nitems;
 }
 

--- a/blosc/blosc2-stdio.c
+++ b/blosc/blosc2-stdio.c
@@ -21,11 +21,8 @@
 #include <stdint.h>
 #include <errno.h>
 #include <inttypes.h>
-<<<<<<< mmap-arithmetic-overflow-hardening
 #include <limits.h>
-=======
 #include <string.h>
->>>>>>> main
 
 #if defined(_WIN32)
   #include <memoryapi.h>

--- a/blosc/blosc2-stdio.c
+++ b/blosc/blosc2-stdio.c
@@ -378,12 +378,19 @@ int64_t blosc2_stdio_mmap_write(const void *ptr, int64_t size, int64_t nitems, i
   }
 
   if (mmap_file->mapping_size < mmap_file->file_size) {
+    int64_t remap_size;
     if (mmap_file->file_size > INT64_MAX / 2) {
-      mmap_file->mapping_size = mmap_file->file_size;
+      BLOSC_TRACE_WARNING("mmap remap growth fallback: cannot double mapping_size near INT64_MAX; using file_size (%" PRId64 ").", mmap_file->file_size);
+      remap_size = mmap_file->file_size;
     }
     else {
-      mmap_file->mapping_size = mmap_file->file_size * 2;
+      remap_size = mmap_file->file_size * 2;
     }
+    if (remap_size < 0 || (uint64_t)remap_size > SIZE_MAX) {
+      BLOSC_TRACE_ERROR("mmap mapping size does not fit in SIZE_T (%" PRId64 ").", remap_size);
+      return 0;
+    }
+    mmap_file->mapping_size = remap_size;
 
     /* We need to remap the file completely and cannot pass the previous used address on Windows */
     if (!UnmapViewOfFile(mmap_file->addr)) {
@@ -440,6 +447,7 @@ int64_t blosc2_stdio_mmap_write(const void *ptr, int64_t size, int64_t nitems, i
   if (mmap_file->mapping_size < mmap_file->file_size) {
     int64_t old_mapping_size = mmap_file->mapping_size;
     if (mmap_file->file_size > INT64_MAX / 2) {
+      BLOSC_TRACE_WARNING("mmap remap growth fallback: cannot double mapping_size near INT64_MAX; using file_size (%" PRId64 ").", mmap_file->file_size);
       mmap_file->mapping_size = mmap_file->file_size;
     }
     else {
@@ -488,7 +496,12 @@ int64_t blosc2_stdio_mmap_write(const void *ptr, int64_t size, int64_t nitems, i
 int64_t blosc2_stdio_mmap_read(void **ptr, int64_t size, int64_t nitems, int64_t position, void *stream) {
   blosc2_stdio_mmap *mmap_file = (blosc2_stdio_mmap *) stream;
 
-  if (ptr == NULL || size < 0 || nitems < 0 || position < 0) {
+  if (ptr == NULL) {
+    BLOSC_TRACE_ERROR("Invalid pointer argument for mmap read.");
+    return 0;
+  }
+
+  if (size < 0 || nitems < 0 || position < 0) {
     BLOSC_TRACE_ERROR("Invalid arguments for mmap read.");
     *ptr = NULL;
     return 0;

--- a/blosc/blosc2-stdio.c
+++ b/blosc/blosc2-stdio.c
@@ -22,7 +22,6 @@
 #include <errno.h>
 #include <inttypes.h>
 #include <string.h>
-#include <limits.h>
 
 #if defined(_WIN32)
   #include <memoryapi.h>

--- a/blosc/blosc2-stdio.c
+++ b/blosc/blosc2-stdio.c
@@ -21,6 +21,7 @@
 #include <stdint.h>
 #include <errno.h>
 #include <inttypes.h>
+#include <limits.h>
 
 #if defined(_WIN32)
   #include <memoryapi.h>
@@ -30,6 +31,33 @@
 #else
   #include <sys/mman.h>
 #endif
+
+
+static bool checked_mul_int64_nonneg(int64_t a, int64_t b, int64_t* out) {
+  if (a < 0 || b < 0) {
+    return false;
+  }
+  if (a == 0 || b == 0) {
+    *out = 0;
+    return true;
+  }
+  if (a > INT64_MAX / b) {
+    return false;
+  }
+  *out = a * b;
+  return true;
+}
+
+static bool checked_add_int64_nonneg(int64_t a, int64_t b, int64_t* out) {
+  if (a < 0 || b < 0) {
+    return false;
+  }
+  if (a > INT64_MAX - b) {
+    return false;
+  }
+  *out = a + b;
+  return true;
+}
 
 
 void *blosc2_stdio_open(const char *urlpath, const char *mode, void *params) {
@@ -302,17 +330,29 @@ int64_t blosc2_stdio_mmap_size(void *stream) {
 int64_t blosc2_stdio_mmap_write(const void *ptr, int64_t size, int64_t nitems, int64_t position, void *stream) {
   blosc2_stdio_mmap *mmap_file = (blosc2_stdio_mmap *) stream;
 
-  if (position < 0) {
-    BLOSC_TRACE_ERROR("Cannot write to a negative position.");
+  if (ptr == NULL || size < 0 || nitems < 0 || position < 0) {
+    BLOSC_TRACE_ERROR("Invalid arguments for mmap write.");
     return 0;
   }
 
-  int64_t n_bytes = size * nitems;
+  int64_t n_bytes;
+  if (!checked_mul_int64_nonneg(size, nitems, &n_bytes)) {
+    BLOSC_TRACE_ERROR("mmap write size overflow (size=%" PRId64 ", nitems=%" PRId64 ").", size, nitems);
+    return 0;
+  }
   if (n_bytes == 0) {
     return 0;
   }
+  if ((uint64_t)n_bytes > SIZE_MAX) {
+    BLOSC_TRACE_ERROR("mmap write size does not fit in size_t (%" PRId64 ").", n_bytes);
+    return 0;
+  }
 
-  int64_t position_end = position + n_bytes;
+  int64_t position_end;
+  if (!checked_add_int64_nonneg(position, n_bytes, &position_end)) {
+    BLOSC_TRACE_ERROR("mmap write position overflow (position=%" PRId64 ", nbytes=%" PRId64 ").", position, n_bytes);
+    return 0;
+  }
   int64_t new_size = position_end > mmap_file->file_size ? position_end : mmap_file->file_size;
 
 #if defined(_WIN32)
@@ -321,7 +361,12 @@ int64_t blosc2_stdio_mmap_write(const void *ptr, int64_t size, int64_t nitems, i
   }
 
   if (mmap_file->mapping_size < mmap_file->file_size) {
-    mmap_file->mapping_size = mmap_file->file_size * 2;
+    if (mmap_file->file_size > INT64_MAX / 2) {
+      mmap_file->mapping_size = mmap_file->file_size;
+    }
+    else {
+      mmap_file->mapping_size = mmap_file->file_size * 2;
+    }
 
     /* We need to remap the file completely and cannot pass the previous used address on Windows */
     if (!UnmapViewOfFile(mmap_file->addr)) {
@@ -376,11 +421,15 @@ int64_t blosc2_stdio_mmap_write(const void *ptr, int64_t size, int64_t nitems, i
   }
 
   if (mmap_file->mapping_size < mmap_file->file_size) {
-    mmap_file->mapping_size = mmap_file->file_size * 2;
+    int64_t old_mapping_size = mmap_file->mapping_size;
+    if (mmap_file->file_size > INT64_MAX / 2) {
+      mmap_file->mapping_size = mmap_file->file_size;
+    }
+    else {
+      mmap_file->mapping_size = mmap_file->file_size * 2;
+    }
 
 #if defined(__linux__)
-    int64_t old_mapping_size = mmap_file->mapping_size;
-
     /* mremap is the best option as it also ensures that the old data is still available in c mode. Unfortunately, it
     is no POSIX standard and only available on Linux */
     char* new_address = mremap(mmap_file->addr, old_mapping_size, mmap_file->mapping_size, MREMAP_MAYMOVE);
@@ -422,13 +471,26 @@ int64_t blosc2_stdio_mmap_write(const void *ptr, int64_t size, int64_t nitems, i
 int64_t blosc2_stdio_mmap_read(void **ptr, int64_t size, int64_t nitems, int64_t position, void *stream) {
   blosc2_stdio_mmap *mmap_file = (blosc2_stdio_mmap *) stream;
 
-  if (position < 0) {
-    BLOSC_TRACE_ERROR("Cannot read from a negative position.");
+  if (ptr == NULL || size < 0 || nitems < 0 || position < 0) {
+    BLOSC_TRACE_ERROR("Invalid arguments for mmap read.");
     *ptr = NULL;
     return 0;
   }
 
-  if (position + size * nitems > mmap_file->file_size) {
+  int64_t n_bytes;
+  if (!checked_mul_int64_nonneg(size, nitems, &n_bytes)) {
+    BLOSC_TRACE_ERROR("mmap read size overflow (size=%" PRId64 ", nitems=%" PRId64 ").", size, nitems);
+    *ptr = NULL;
+    return 0;
+  }
+  int64_t position_end;
+  if (!checked_add_int64_nonneg(position, n_bytes, &position_end)) {
+    BLOSC_TRACE_ERROR("mmap read position overflow (position=%" PRId64 ", nbytes=%" PRId64 ").", position, n_bytes);
+    *ptr = NULL;
+    return 0;
+  }
+
+  if (position_end > mmap_file->file_size) {
     BLOSC_TRACE_ERROR("Cannot read beyond the end of the memory-mapped file.");
     *ptr = NULL;
     return 0;

--- a/blosc/blosc2-stdio.c
+++ b/blosc/blosc2-stdio.c
@@ -90,7 +90,7 @@ int64_t blosc2_stdio_size(void *stream) {
 int64_t blosc2_stdio_write(const void *ptr, size_t size, size_t nitems, size_t position, void *stream) {
   blosc2_stdio_file *my_fp = (blosc2_stdio_file *) stream;
   fseek(my_fp->file, (long)position, SEEK_SET);
-  size_t nitems_ = fwrite(ptr, size, nitems, my_fp->file);
+  size_t nitems_ = fwrite(ptr, (size_t)size, (size_t)nitems, my_fp->file);
   return (int64_t) nitems_;
 }
 
@@ -98,7 +98,7 @@ int64_t blosc2_stdio_read(void **ptr, size_t size, size_t nitems, size_t positio
   blosc2_stdio_file *my_fp = (blosc2_stdio_file *) stream;
   fseek(my_fp->file, (long)position, SEEK_SET);
   void* data_ptr = *ptr;
-  size_t nitems_ = fread(data_ptr, size, nitems, my_fp->file);
+  size_t nitems_ = fread(data_ptr, (size_t)size, (size_t)nitems, my_fp->file);
   return (int64_t) nitems_;
 }
 
@@ -106,7 +106,7 @@ int blosc2_stdio_truncate(void *stream, size_t size) {
   blosc2_stdio_file *my_fp = (blosc2_stdio_file *) stream;
   int rc;
 #if defined(_MSC_VER)
-  rc = _chsize_s(_fileno(my_fp->file), (__int64)size);
+  rc = _chsize_s(_fileno(my_fp->file), size);
 #else
   rc = ftruncate(fileno(my_fp->file), (off_t)size);
 #endif

--- a/blosc/blosc2-stdio.c
+++ b/blosc/blosc2-stdio.c
@@ -87,30 +87,28 @@ int64_t blosc2_stdio_size(void *stream) {
   return size;
 }
 
-int64_t blosc2_stdio_write(const void *ptr, int64_t size, int64_t nitems, int64_t position, void *stream) {
+int64_t blosc2_stdio_write(const void *ptr, size_t size, size_t nitems, size_t position, void *stream) {
   blosc2_stdio_file *my_fp = (blosc2_stdio_file *) stream;
-  fseek(my_fp->file, position, SEEK_SET);
-
-  size_t nitems_ = fwrite(ptr, (size_t) size, (size_t) nitems, my_fp->file);
+  fseek(my_fp->file, (long)position, SEEK_SET);
+  size_t nitems_ = fwrite(ptr, size, nitems, my_fp->file);
   return (int64_t) nitems_;
 }
 
-int64_t blosc2_stdio_read(void **ptr, int64_t size, int64_t nitems, int64_t position, void *stream) {
+int64_t blosc2_stdio_read(void **ptr, size_t size, size_t nitems, size_t position, void *stream) {
   blosc2_stdio_file *my_fp = (blosc2_stdio_file *) stream;
-  fseek(my_fp->file, position, SEEK_SET);
-
+  fseek(my_fp->file, (long)position, SEEK_SET);
   void* data_ptr = *ptr;
-  size_t nitems_ = fread(data_ptr, (size_t) size, (size_t) nitems, my_fp->file);
+  size_t nitems_ = fread(data_ptr, size, nitems, my_fp->file);
   return (int64_t) nitems_;
 }
 
-int blosc2_stdio_truncate(void *stream, int64_t size) {
+int blosc2_stdio_truncate(void *stream, size_t size) {
   blosc2_stdio_file *my_fp = (blosc2_stdio_file *) stream;
   int rc;
 #if defined(_MSC_VER)
-  rc = _chsize_s(_fileno(my_fp->file), size);
+  rc = _chsize_s(_fileno(my_fp->file), (__int64)size);
 #else
-  rc = ftruncate(fileno(my_fp->file), size);
+  rc = ftruncate(fileno(my_fp->file), (off_t)size);
 #endif
   return rc;
 }
@@ -258,6 +256,11 @@ void *blosc2_stdio_mmap_open(const char *urlpath, const char *mode, void* params
     mmap_file->mapping_size = mmap_file->file_size;
   }
 
+  if (mmap_file->mapping_size < 0 || (uint64_t)mmap_file->mapping_size > SIZE_MAX) {
+    BLOSC_TRACE_ERROR("mmap mapping size does not fit in size_t (%" PRId64 ").", mmap_file->mapping_size);
+    return NULL;
+  }
+
 #if defined(_WIN32)
   mmap_file->fd = _fileno(mmap_file->file);
 
@@ -327,33 +330,29 @@ int64_t blosc2_stdio_mmap_size(void *stream) {
   return mmap_file->file_size;
 }
 
-int64_t blosc2_stdio_mmap_write(const void *ptr, int64_t size, int64_t nitems, int64_t position, void *stream) {
+int64_t blosc2_stdio_mmap_write(const void *ptr, size_t size, size_t nitems, size_t position, void *stream) {
   blosc2_stdio_mmap *mmap_file = (blosc2_stdio_mmap *) stream;
 
-  if (ptr == NULL || size < 0 || nitems < 0 || position < 0) {
-    BLOSC_TRACE_ERROR("Invalid arguments for mmap write.");
+  if (ptr == NULL) {
+    BLOSC_TRACE_ERROR("Invalid arguments for mmap write: ptr is NULL.");
     return 0;
   }
 
-  int64_t n_bytes;
-  if (!checked_mul_int64_nonneg(size, nitems, &n_bytes)) {
-    BLOSC_TRACE_ERROR("mmap write size overflow (size=%" PRId64 ", nitems=%" PRId64 ").", size, nitems);
+  size_t n_bytes;
+  if (size > 0 && nitems > 0 && size > SIZE_MAX / nitems) {
+    BLOSC_TRACE_ERROR("mmap write size overflow (size=%zu, nitems=%zu).", size, nitems);
     return 0;
   }
+  n_bytes = size * nitems;
   if (n_bytes == 0) {
     return 0;
   }
-  if ((uint64_t)n_bytes > SIZE_MAX) {
-    BLOSC_TRACE_ERROR("mmap write size does not fit in size_t (%" PRId64 ").", n_bytes);
+  if (position > SIZE_MAX - n_bytes) {
+    BLOSC_TRACE_ERROR("mmap write position overflow (position=%zu, nbytes=%zu).", position, n_bytes);
     return 0;
   }
-
-  int64_t position_end;
-  if (!checked_add_int64_nonneg(position, n_bytes, &position_end)) {
-    BLOSC_TRACE_ERROR("mmap write position overflow (position=%" PRId64 ", nbytes=%" PRId64 ").", position, n_bytes);
-    return 0;
-  }
-  int64_t new_size = position_end > mmap_file->file_size ? position_end : mmap_file->file_size;
+  size_t position_end = position + n_bytes;
+  size_t new_size = position_end > mmap_file->file_size ? position_end : mmap_file->file_size;
 
 #if defined(_WIN32)
   if (mmap_file->file_size < new_size) {
@@ -361,12 +360,24 @@ int64_t blosc2_stdio_mmap_write(const void *ptr, int64_t size, int64_t nitems, i
   }
 
   if (mmap_file->mapping_size < mmap_file->file_size) {
-    if (mmap_file->file_size > INT64_MAX / 2) {
-      mmap_file->mapping_size = mmap_file->file_size;
+    size_t remap_size;
+    if (mmap_file->file_size > SIZE_MAX / 2) {
+      BLOSC_TRACE_WARNING(
+        "mmap remap growth capped at file size (%" PRId64 " bytes) to avoid int64 overflow.",
+        mmap_file->file_size
+      );
+      remap_size = mmap_file->file_size;
     }
     else {
-      mmap_file->mapping_size = mmap_file->file_size * 2;
+      remap_size = mmap_file->file_size * 2;
     }
+
+    if (remap_size < 0 || (uint64_t)remap_size > SIZE_MAX) {
+      BLOSC_TRACE_ERROR("mmap mapping size does not fit in size_t (%" PRId64 ").", remap_size);
+      return 0;
+    }
+
+    mmap_file->mapping_size = remap_size;
 
     /* We need to remap the file completely and cannot pass the previous used address on Windows */
     if (!UnmapViewOfFile(mmap_file->addr)) {
@@ -421,13 +432,25 @@ int64_t blosc2_stdio_mmap_write(const void *ptr, int64_t size, int64_t nitems, i
   }
 
   if (mmap_file->mapping_size < mmap_file->file_size) {
-    int64_t old_mapping_size = mmap_file->mapping_size;
+    size_t old_mapping_size = mmap_file->mapping_size;
+    size_t remap_size;
     if (mmap_file->file_size > INT64_MAX / 2) {
-      mmap_file->mapping_size = mmap_file->file_size;
+      BLOSC_TRACE_WARNING(
+        "mmap remap growth capped at file size (%" PRId64 " bytes) to avoid int64 overflow.",
+        mmap_file->file_size
+      );
+      remap_size = mmap_file->file_size;
     }
     else {
-      mmap_file->mapping_size = mmap_file->file_size * 2;
+      remap_size = mmap_file->file_size * 2;
     }
+
+    if (remap_size < 0 || (uint64_t)remap_size > SIZE_MAX) {
+      BLOSC_TRACE_ERROR("mmap mapping size does not fit in size_t (%" PRId64 ").", remap_size);
+      return 0;
+    }
+
+    mmap_file->mapping_size = remap_size;
 
 #if defined(__linux__)
     /* mremap is the best option as it also ensures that the old data is still available in c mode. Unfortunately, it
@@ -471,33 +494,36 @@ int64_t blosc2_stdio_mmap_write(const void *ptr, int64_t size, int64_t nitems, i
 int64_t blosc2_stdio_mmap_read(void **ptr, int64_t size, int64_t nitems, int64_t position, void *stream) {
   blosc2_stdio_mmap *mmap_file = (blosc2_stdio_mmap *) stream;
 
-  if (ptr == NULL || size < 0 || nitems < 0 || position < 0) {
+  if (ptr == NULL) {
+    BLOSC_TRACE_ERROR("Invalid arguments for mmap read: output pointer is NULL.");
+    return 0;
+  }
+
+  if (size < 0 || nitems < 0 || position < 0) {
     BLOSC_TRACE_ERROR("Invalid arguments for mmap read.");
     *ptr = NULL;
     return 0;
   }
 
-  int64_t n_bytes;
-  if (!checked_mul_int64_nonneg(size, nitems, &n_bytes)) {
-    BLOSC_TRACE_ERROR("mmap read size overflow (size=%" PRId64 ", nitems=%" PRId64 ").", size, nitems);
+  size_t n_bytes;
+  if (size > 0 && nitems > 0 && size > SIZE_MAX / nitems) {
+    BLOSC_TRACE_ERROR("mmap read size overflow (size=%zu, nitems=%zu).", size, nitems);
     *ptr = NULL;
     return 0;
   }
-  int64_t position_end;
-  if (!checked_add_int64_nonneg(position, n_bytes, &position_end)) {
-    BLOSC_TRACE_ERROR("mmap read position overflow (position=%" PRId64 ", nbytes=%" PRId64 ").", position, n_bytes);
+  n_bytes = size * nitems;
+  if (position > SIZE_MAX - n_bytes) {
+    BLOSC_TRACE_ERROR("mmap read position overflow (position=%zu, nbytes=%zu).", position, n_bytes);
     *ptr = NULL;
     return 0;
   }
-
+  size_t position_end = position + n_bytes;
   if (position_end > mmap_file->file_size) {
     BLOSC_TRACE_ERROR("Cannot read beyond the end of the memory-mapped file.");
     *ptr = NULL;
     return 0;
   }
-
   *ptr = mmap_file->addr + position;
-
   return nitems;
 }
 

--- a/blosc/blosc2-stdio.c
+++ b/blosc/blosc2-stdio.c
@@ -256,8 +256,8 @@ void *blosc2_stdio_mmap_open(const char *urlpath, const char *mode, void* params
     mmap_file->mapping_size = mmap_file->file_size;
   }
 
-  if (mmap_file->mapping_size < 0 || (uint64_t)mmap_file->mapping_size > SIZE_MAX) {
-    BLOSC_TRACE_ERROR("mmap mapping size does not fit in size_t (%" PRId64 ").", mmap_file->mapping_size);
+  if ((uint64_t)mmap_file->mapping_size > SIZE_MAX) {
+    BLOSC_TRACE_ERROR("mmap mapping size does not fit in size_t (%zu).", (size_t)mmap_file->mapping_size);
     return NULL;
   }
 
@@ -306,10 +306,10 @@ void *blosc2_stdio_mmap_open(const char *urlpath, const char *mode, void* params
 #endif
 
   BLOSC_INFO(
-    "Opened memory-mapped file %s in mode %s with an mapping size of %" PRId64 " bytes.",
+    "Opened memory-mapped file %s in mode %s with a mapping size of %zu bytes.",
     mmap_file->urlpath,
     mmap_file->mode,
-    mmap_file->mapping_size
+    (size_t)mmap_file->mapping_size
   );
 
   /* The mmap_file->mode parameter is only available during the opening call and cannot be used in any of the other
@@ -363,8 +363,8 @@ int64_t blosc2_stdio_mmap_write(const void *ptr, size_t size, size_t nitems, siz
     size_t remap_size;
     if (mmap_file->file_size > SIZE_MAX / 2) {
       BLOSC_TRACE_WARNING(
-        "mmap remap growth capped at file size (%" PRId64 " bytes) to avoid int64 overflow.",
-        mmap_file->file_size
+        "mmap remap growth capped at file size (%zu bytes) to avoid overflow.",
+        (size_t)mmap_file->file_size
       );
       remap_size = mmap_file->file_size;
     }
@@ -372,8 +372,8 @@ int64_t blosc2_stdio_mmap_write(const void *ptr, size_t size, size_t nitems, siz
       remap_size = mmap_file->file_size * 2;
     }
 
-    if (remap_size < 0 || (uint64_t)remap_size > SIZE_MAX) {
-      BLOSC_TRACE_ERROR("mmap mapping size does not fit in size_t (%" PRId64 ").", remap_size);
+    if ((uint64_t)remap_size > SIZE_MAX) {
+      BLOSC_TRACE_ERROR("mmap mapping size does not fit in size_t (%zu).", (size_t)remap_size);
       return 0;
     }
 

--- a/blosc/blosc2-stdio.c
+++ b/blosc/blosc2-stdio.c
@@ -22,7 +22,7 @@
 #include <errno.h>
 #include <inttypes.h>
 #include <limits.h>
-
+#include <string.h>
 #if defined(_WIN32)
   #include <memoryapi.h>
   // See https://github.com/Blosc/python-blosc2/issues/359
@@ -89,16 +89,34 @@ int64_t blosc2_stdio_size(void *stream) {
 
 int64_t blosc2_stdio_write(const void *ptr, int64_t size, int64_t nitems, int64_t position, void *stream) {
   blosc2_stdio_file *my_fp = (blosc2_stdio_file *) stream;
-  fseek(my_fp->file, (long)position, SEEK_SET);
-  size_t nitems_ = fwrite(ptr, (size_t)size, (size_t)nitems, my_fp->file);
+  int rc = fseek(my_fp->file, position, SEEK_SET);
+  if (rc != 0) {
+    BLOSC_TRACE_ERROR("fseek failed at position %" PRId64 " (error: %s).", position, strerror(errno));
+    return 0;
+  }
+
+  size_t nitems_ = fwrite(ptr, (size_t) size, (size_t) nitems, my_fp->file);
+  if ((int64_t)nitems_ != nitems) {
+    BLOSC_TRACE_ERROR("Short write at position %" PRId64 ": requested %" PRId64 " items of size %" PRId64
+                      ", wrote %zu (error: %s).", position, nitems, size, nitems_, strerror(errno));
+  }
   return (int64_t) nitems_;
 }
 
 int64_t blosc2_stdio_read(void **ptr, int64_t size, int64_t nitems, int64_t position, void *stream) {
   blosc2_stdio_file *my_fp = (blosc2_stdio_file *) stream;
-  fseek(my_fp->file, (long)position, SEEK_SET);
+    int rc = fseek(my_fp->file, position, SEEK_SET);
+  if (rc != 0) {
+    BLOSC_TRACE_ERROR("fseek failed at position %" PRId64 " (error: %s).", position, strerror(errno));
+    return 0;
+  }
+
   void* data_ptr = *ptr;
-  size_t nitems_ = fread(data_ptr, (size_t)size, (size_t)nitems, my_fp->file);
+  size_t nitems_ = fread(data_ptr, (size_t) size, (size_t) nitems, my_fp->file);
+  if ((int64_t)nitems_ != nitems) {
+    BLOSC_TRACE_ERROR("Short read at position %" PRId64 ": requested %" PRId64 " items of size %" PRId64
+                      ", read %zu (error: %s).", position, nitems, size, nitems_, strerror(errno));
+  }
   return (int64_t) nitems_;
 }
 

--- a/blosc/blosc2-stdio.c
+++ b/blosc/blosc2-stdio.c
@@ -22,6 +22,7 @@
 #include <errno.h>
 #include <inttypes.h>
 #include <string.h>
+#include <limits.h>
 
 #if defined(_WIN32)
   #include <memoryapi.h>
@@ -365,19 +366,20 @@ int64_t blosc2_stdio_mmap_write(const void *ptr, int64_t size, int64_t nitems, i
   if (n_bytes == 0) {
     return 0;
   }
-  if (position > SIZE_MAX - n_bytes) {
-    BLOSC_TRACE_ERROR("mmap write position overflow (position=%" PRId64 ", nbytes=%" PRId64 ").", position, n_bytes);
+  size_t position_u = (size_t)position;
+  if (position_u > SIZE_MAX - n_bytes) {
+    BLOSC_TRACE_ERROR("mmap write position overflow (position=%" PRId64 ", nbytes=%zu).", position, n_bytes);
     return 0;
   }
-  size_t position_end = position + n_bytes;
-  size_t new_size = position_end > mmap_file->file_size ? position_end : mmap_file->file_size;
+  size_t position_end = position_u + n_bytes;
+  size_t new_size = position_end > (size_t)mmap_file->file_size ? position_end : (size_t)mmap_file->file_size;
 
 #if defined(_WIN32)
-  if (mmap_file->file_size < new_size) {
-    mmap_file->file_size = new_size;
+  if ((size_t)mmap_file->file_size < new_size) {
+    mmap_file->file_size = (int64_t)new_size;
   }
 
-  if (mmap_file->mapping_size < mmap_file->file_size) {
+  if ((size_t)mmap_file->mapping_size < mmap_file->file_size) {
     size_t remap_size;
     if (mmap_file->file_size > SIZE_MAX / 2) {
       BLOSC_TRACE_WARNING(
@@ -390,10 +392,7 @@ int64_t blosc2_stdio_mmap_write(const void *ptr, int64_t size, int64_t nitems, i
       remap_size = mmap_file->file_size * 2;
     }
 
-    if ((uint64_t)remap_size > SIZE_MAX) {
-      BLOSC_TRACE_ERROR("mmap mapping size does not fit in size_t (%" PRId64 ").", (size_t)remap_size);
-      return 0;
-    }
+    /* remap_size is already size_t, so it always fits — nothing to check here */
 
     mmap_file->mapping_size = remap_size;
 
@@ -463,10 +462,7 @@ int64_t blosc2_stdio_mmap_write(const void *ptr, int64_t size, int64_t nitems, i
       remap_size = mmap_file->file_size * 2;
     }
 
-    if (remap_size < 0 || (uint64_t)remap_size > SIZE_MAX) {
-      BLOSC_TRACE_ERROR("mmap mapping size does not fit in size_t (%" PRId64 ").", remap_size);
-      return 0;
-    }
+    /* remap_size is size_t (unsigned) — no negative / overflow check needed */
 
     mmap_file->mapping_size = remap_size;
 
@@ -505,7 +501,7 @@ int64_t blosc2_stdio_mmap_write(const void *ptr, int64_t size, int64_t nitems, i
   }
 #endif
 
-  memcpy(mmap_file->addr + position, ptr, n_bytes);
+  memcpy(mmap_file->addr + position_u, ptr, n_bytes);
   return nitems;
 }
 
@@ -525,13 +521,13 @@ int64_t blosc2_stdio_mmap_read(void **ptr, int64_t size, int64_t nitems, int64_t
 
   size_t n_bytes;
   if (size > 0 && nitems > 0 && size > SIZE_MAX / nitems) {
-    BLOSC_TRACE_ERROR("mmap read size overflow (size=%zu, nitems=%zu).", size, nitems);
+    BLOSC_TRACE_ERROR("mmap read size overflow (size=%" PRId64 ", nitems=%" PRId64 ").", size, nitems);
     *ptr = NULL;
     return 0;
   }
   n_bytes = size * nitems;
   if (position > SIZE_MAX - n_bytes) {
-    BLOSC_TRACE_ERROR("mmap read position overflow (position=%zu, nbytes=%zu).", position, n_bytes);
+    BLOSC_TRACE_ERROR("mmap read position overflow (position=%" PRId64 ", nbytes=%zu).", position, n_bytes);
     *ptr = NULL;
     return 0;
   }

--- a/include/blosc2/blosc2-stdio.h
+++ b/include/blosc2/blosc2-stdio.h
@@ -71,9 +71,9 @@ typedef struct {
   //!< The starting address of the mapping.
   char* urlpath;
   //!< The path to the file which is associated with this object.
-    size_t file_size;
+    int64_t file_size;
     //!< The size of the file.
-    size_t mapping_size;
+    int64_t mapping_size;
     //!< The size of the mapping (mapping_size >= file_size).
   bool is_memory_only;
   //!< Whether the mapping is only in-memory and changes are not reflected to the file on disk (c mode).
@@ -92,8 +92,9 @@ typedef struct {
 } blosc2_stdio_mmap;
 
 /**
- * @brief Default struct for memory-mapped I/O for user initialization.
- */
+  BLOSC_EXPORT int64_t blosc2_stdio_write(const void *ptr, int64_t size, int64_t nitems, int64_t position, void *stream);
+  BLOSC_EXPORT int64_t blosc2_stdio_read(void **ptr, int64_t size, int64_t nitems, int64_t position, void *stream);
+  BLOSC_EXPORT int blosc2_stdio_truncate(void *stream, int64_t size);
 static const blosc2_stdio_mmap BLOSC2_STDIO_MMAP_DEFAULTS = {
   "r", (1 << 30), false, NULL, NULL, -1, -1, false, NULL, -1, -1, -1
 #if defined(_WIN32)
@@ -105,9 +106,10 @@ BLOSC_EXPORT void *blosc2_stdio_mmap_open(const char *urlpath, const char *mode,
 BLOSC_EXPORT int blosc2_stdio_mmap_close(void *stream);
 BLOSC_EXPORT int64_t blosc2_stdio_mmap_size(void *stream);
 BLOSC_EXPORT int64_t blosc2_stdio_mmap_write(
-  const void *ptr, size_t size, size_t nitems, size_t position, void *stream);
-BLOSC_EXPORT int64_t blosc2_stdio_mmap_read(void **ptr, size_t size, size_t nitems, size_t position, void *stream);
-BLOSC_EXPORT int blosc2_stdio_mmap_truncate(void *stream, size_t size);
+BLOSC_EXPORT int64_t blosc2_stdio_mmap_write(
+  const void *ptr, int64_t size, int64_t nitems, int64_t position, void *stream);
+BLOSC_EXPORT int64_t blosc2_stdio_mmap_read(void **ptr, int64_t size, int64_t nitems, int64_t position, void *stream);
+BLOSC_EXPORT int blosc2_stdio_mmap_truncate(void *stream, int64_t size);
 BLOSC_EXPORT int blosc2_stdio_mmap_destroy(void* params);
 
 #ifdef __cplusplus

--- a/include/blosc2/blosc2-stdio.h
+++ b/include/blosc2/blosc2-stdio.h
@@ -39,9 +39,9 @@ typedef struct {
 BLOSC_EXPORT void *blosc2_stdio_open(const char *urlpath, const char *mode, void* params);
 BLOSC_EXPORT int blosc2_stdio_close(void *stream);
 BLOSC_EXPORT int64_t blosc2_stdio_size(void *stream);
-BLOSC_EXPORT int64_t blosc2_stdio_write(const void *ptr, int64_t size, int64_t nitems, int64_t position, void *stream);
-BLOSC_EXPORT int64_t blosc2_stdio_read(void **ptr, int64_t size, int64_t nitems, int64_t position, void *stream);
-BLOSC_EXPORT int blosc2_stdio_truncate(void *stream, int64_t size);
+BLOSC_EXPORT int64_t blosc2_stdio_write(const void *ptr, size_t size, size_t nitems, size_t position, void *stream);
+BLOSC_EXPORT int64_t blosc2_stdio_read(void **ptr, size_t size, size_t nitems, size_t position, void *stream);
+BLOSC_EXPORT int blosc2_stdio_truncate(void *stream, size_t size);
 BLOSC_EXPORT int blosc2_stdio_destroy(void* params);
 
 
@@ -71,10 +71,10 @@ typedef struct {
   //!< The starting address of the mapping.
   char* urlpath;
   //!< The path to the file which is associated with this object.
-  int64_t file_size;
-  //!< The size of the file.
-  int64_t mapping_size;
-  //!< The size of the mapping (mapping_size >= file_size).
+    size_t file_size;
+    //!< The size of the file.
+    size_t mapping_size;
+    //!< The size of the mapping (mapping_size >= file_size).
   bool is_memory_only;
   //!< Whether the mapping is only in-memory and changes are not reflected to the file on disk (c mode).
   FILE* file;
@@ -105,9 +105,9 @@ BLOSC_EXPORT void *blosc2_stdio_mmap_open(const char *urlpath, const char *mode,
 BLOSC_EXPORT int blosc2_stdio_mmap_close(void *stream);
 BLOSC_EXPORT int64_t blosc2_stdio_mmap_size(void *stream);
 BLOSC_EXPORT int64_t blosc2_stdio_mmap_write(
-  const void *ptr, int64_t size, int64_t nitems, int64_t position, void *stream);
-BLOSC_EXPORT int64_t blosc2_stdio_mmap_read(void **ptr, int64_t size, int64_t nitems, int64_t position, void *stream);
-BLOSC_EXPORT int blosc2_stdio_mmap_truncate(void *stream, int64_t size);
+  const void *ptr, size_t size, size_t nitems, size_t position, void *stream);
+BLOSC_EXPORT int64_t blosc2_stdio_mmap_read(void **ptr, size_t size, size_t nitems, size_t position, void *stream);
+BLOSC_EXPORT int blosc2_stdio_mmap_truncate(void *stream, size_t size);
 BLOSC_EXPORT int blosc2_stdio_mmap_destroy(void* params);
 
 #ifdef __cplusplus

--- a/include/blosc2/blosc2-stdio.h
+++ b/include/blosc2/blosc2-stdio.h
@@ -105,7 +105,7 @@ BLOSC_EXPORT void *blosc2_stdio_mmap_open(const char *urlpath, const char *mode,
 BLOSC_EXPORT int blosc2_stdio_mmap_close(void *stream);
 BLOSC_EXPORT int64_t blosc2_stdio_mmap_size(void *stream);
 BLOSC_EXPORT int64_t blosc2_stdio_mmap_write(
-const void *ptr, int64_t size, int64_t nitems, int64_t position, void *stream);
+  const void *ptr, int64_t size, int64_t nitems, int64_t position, void *stream);
 BLOSC_EXPORT int64_t blosc2_stdio_mmap_read(void **ptr, int64_t size, int64_t nitems, int64_t position, void *stream);
 BLOSC_EXPORT int blosc2_stdio_mmap_truncate(void *stream, int64_t size);
 BLOSC_EXPORT int blosc2_stdio_mmap_destroy(void* params);

--- a/include/blosc2/blosc2-stdio.h
+++ b/include/blosc2/blosc2-stdio.h
@@ -105,7 +105,6 @@ BLOSC_EXPORT void *blosc2_stdio_mmap_open(const char *urlpath, const char *mode,
 BLOSC_EXPORT int blosc2_stdio_mmap_close(void *stream);
 BLOSC_EXPORT int64_t blosc2_stdio_mmap_size(void *stream);
 BLOSC_EXPORT int64_t blosc2_stdio_mmap_write(
-BLOSC_EXPORT int64_t blosc2_stdio_mmap_write(
 const void *ptr, int64_t size, int64_t nitems, int64_t position, void *stream);
 BLOSC_EXPORT int64_t blosc2_stdio_mmap_read(void **ptr, int64_t size, int64_t nitems, int64_t position, void *stream);
 BLOSC_EXPORT int blosc2_stdio_mmap_truncate(void *stream, int64_t size);

--- a/include/blosc2/blosc2-stdio.h
+++ b/include/blosc2/blosc2-stdio.h
@@ -39,9 +39,9 @@ typedef struct {
 BLOSC_EXPORT void *blosc2_stdio_open(const char *urlpath, const char *mode, void* params);
 BLOSC_EXPORT int blosc2_stdio_close(void *stream);
 BLOSC_EXPORT int64_t blosc2_stdio_size(void *stream);
-BLOSC_EXPORT int64_t blosc2_stdio_write(const void *ptr, size_t size, size_t nitems, size_t position, void *stream);
-BLOSC_EXPORT int64_t blosc2_stdio_read(void **ptr, size_t size, size_t nitems, size_t position, void *stream);
-BLOSC_EXPORT int blosc2_stdio_truncate(void *stream, size_t size);
+BLOSC_EXPORT int64_t blosc2_stdio_write(const void *ptr, int64_t size, int64_t nitems, int64_t position, void *stream);
+BLOSC_EXPORT int64_t blosc2_stdio_read(void **ptr, int64_t size, int64_t nitems, int64_t position, void *stream);
+BLOSC_EXPORT int blosc2_stdio_truncate(void *stream, int64_t size);
 BLOSC_EXPORT int blosc2_stdio_destroy(void* params);
 
 
@@ -71,10 +71,10 @@ typedef struct {
   //!< The starting address of the mapping.
   char* urlpath;
   //!< The path to the file which is associated with this object.
-    int64_t file_size;
-    //!< The size of the file.
-    int64_t mapping_size;
-    //!< The size of the mapping (mapping_size >= file_size).
+  int64_t file_size;
+  //!< The size of the file.
+  int64_t mapping_size;
+  //!< The size of the mapping (mapping_size >= file_size).
   bool is_memory_only;
   //!< Whether the mapping is only in-memory and changes are not reflected to the file on disk (c mode).
   FILE* file;
@@ -92,9 +92,8 @@ typedef struct {
 } blosc2_stdio_mmap;
 
 /**
-  BLOSC_EXPORT int64_t blosc2_stdio_write(const void *ptr, int64_t size, int64_t nitems, int64_t position, void *stream);
-  BLOSC_EXPORT int64_t blosc2_stdio_read(void **ptr, int64_t size, int64_t nitems, int64_t position, void *stream);
-  BLOSC_EXPORT int blosc2_stdio_truncate(void *stream, int64_t size);
+ * @brief Default struct for memory-mapped I/O for user initialization.
+ */
 static const blosc2_stdio_mmap BLOSC2_STDIO_MMAP_DEFAULTS = {
   "r", (1 << 30), false, NULL, NULL, -1, -1, false, NULL, -1, -1, -1
 #if defined(_WIN32)
@@ -107,7 +106,7 @@ BLOSC_EXPORT int blosc2_stdio_mmap_close(void *stream);
 BLOSC_EXPORT int64_t blosc2_stdio_mmap_size(void *stream);
 BLOSC_EXPORT int64_t blosc2_stdio_mmap_write(
 BLOSC_EXPORT int64_t blosc2_stdio_mmap_write(
-  const void *ptr, int64_t size, int64_t nitems, int64_t position, void *stream);
+const void *ptr, int64_t size, int64_t nitems, int64_t position, void *stream);
 BLOSC_EXPORT int64_t blosc2_stdio_mmap_read(void **ptr, int64_t size, int64_t nitems, int64_t position, void *stream);
 BLOSC_EXPORT int blosc2_stdio_mmap_truncate(void *stream, int64_t size);
 BLOSC_EXPORT int blosc2_stdio_mmap_destroy(void* params);

--- a/tests/test_mmap_arithmetic.c
+++ b/tests/test_mmap_arithmetic.c
@@ -26,8 +26,8 @@ CUTEST_TEST_TEST(mmap_arithmetic) {
 
   blosc2_stdio_mmap mmap_file = BLOSC2_STDIO_MMAP_DEFAULTS;
   mmap_file.addr = (char*)backing;
-  mmap_file.file_size = (int64_t)sizeof(backing);
-  mmap_file.mapping_size = (int64_t)sizeof(backing);
+  mmap_file.file_size = (size_t)sizeof(backing);
+  mmap_file.mapping_size = (size_t)sizeof(backing);
 
   uint8_t src_ok[4] = {1, 2, 3, 4};
   int64_t nwritten = blosc2_stdio_mmap_write(src_ok, 1, 4, 8, &mmap_file);
@@ -35,33 +35,41 @@ CUTEST_TEST_TEST(mmap_arithmetic) {
   CUTEST_ASSERT("Valid mmap write should copy bytes", memcmp(backing + 8, src_ok, 4) == 0);
 
   uint8_t src_guard[4] = {7, 7, 7, 7};
-  nwritten = blosc2_stdio_mmap_write(src_guard, INT64_MAX, 2, 0, &mmap_file);
+  nwritten = blosc2_stdio_mmap_write(src_guard, SIZE_MAX, 2, 0, &mmap_file);
   CUTEST_ASSERT("mmap write must reject multiplication overflow", nwritten == 0);
 
-  nwritten = blosc2_stdio_mmap_write(src_guard, 1, 1, INT64_MAX, &mmap_file);
+  nwritten = blosc2_stdio_mmap_write(src_guard, 1, 1, SIZE_MAX, &mmap_file);
   CUTEST_ASSERT("mmap write must reject addition overflow", nwritten == 0);
 
-  nwritten = blosc2_stdio_mmap_write(src_guard, -1, 1, 0, &mmap_file);
-  CUTEST_ASSERT("mmap write must reject negative size", nwritten == 0);
+  nwritten = blosc2_stdio_mmap_write(src_guard, (size_t)-1, 1, 0, &mmap_file);
+  CUTEST_ASSERT("mmap write must reject negative size (now wraps)", nwritten == 0);
 
   void* read_ptr = NULL;
   int64_t nread = blosc2_stdio_mmap_read(&read_ptr, 1, 4, 8, &mmap_file);
   CUTEST_ASSERT("Valid mmap read should succeed", nread == 4);
   CUTEST_ASSERT("Valid mmap read should return mapped pointer", read_ptr == (void*)(backing + 8));
 
+  nread = blosc2_stdio_mmap_read(NULL, 1, 4, 8, &mmap_file);
+  CUTEST_ASSERT("mmap read must reject NULL output pointer", nread == 0);
+
   read_ptr = (void*)0x1;
-  nread = blosc2_stdio_mmap_read(&read_ptr, INT64_MAX, 2, 0, &mmap_file);
+  nread = blosc2_stdio_mmap_read(&read_ptr, 4, 8, 1, &mmap_file);
+  CUTEST_ASSERT("mmap read must reject out-of-range read", nread == 0);
+  CUTEST_ASSERT("mmap read must null pointer on out-of-range read", read_ptr == NULL);
+
+  read_ptr = (void*)0x1;
+  nread = blosc2_stdio_mmap_read(&read_ptr, SIZE_MAX, 2, 0, &mmap_file);
   CUTEST_ASSERT("mmap read must reject multiplication overflow", nread == 0);
   CUTEST_ASSERT("mmap read must null pointer on invalid args", read_ptr == NULL);
 
   read_ptr = (void*)0x1;
-  nread = blosc2_stdio_mmap_read(&read_ptr, 1, 1, INT64_MAX, &mmap_file);
+  nread = blosc2_stdio_mmap_read(&read_ptr, 1, 1, SIZE_MAX, &mmap_file);
   CUTEST_ASSERT("mmap read must reject addition overflow", nread == 0);
   CUTEST_ASSERT("mmap read must null pointer on overflow", read_ptr == NULL);
 
   read_ptr = (void*)0x1;
-  nread = blosc2_stdio_mmap_read(&read_ptr, -1, 1, 0, &mmap_file);
-  CUTEST_ASSERT("mmap read must reject negative size", nread == 0);
+  nread = blosc2_stdio_mmap_read(&read_ptr, (size_t)-1, 1, 0, &mmap_file);
+  CUTEST_ASSERT("mmap read must reject negative size (now wraps)", nread == 0);
   CUTEST_ASSERT("mmap read must null pointer on negative args", read_ptr == NULL);
 
   return 0;

--- a/tests/test_mmap_arithmetic.c
+++ b/tests/test_mmap_arithmetic.c
@@ -35,41 +35,33 @@ CUTEST_TEST_TEST(mmap_arithmetic) {
   CUTEST_ASSERT("Valid mmap write should copy bytes", memcmp(backing + 8, src_ok, 4) == 0);
 
   uint8_t src_guard[4] = {7, 7, 7, 7};
-  nwritten = blosc2_stdio_mmap_write(src_guard, (int64_t)SIZE_MAX, 2, 0, &mmap_file);
+  nwritten = blosc2_stdio_mmap_write(src_guard, INT64_MAX, 2, 0, &mmap_file);
   CUTEST_ASSERT("mmap write must reject multiplication overflow", nwritten == 0);
 
-  nwritten = blosc2_stdio_mmap_write(src_guard, 1, 1, (int64_t)SIZE_MAX, &mmap_file);
+  nwritten = blosc2_stdio_mmap_write(src_guard, 1, 1, INT64_MAX, &mmap_file);
   CUTEST_ASSERT("mmap write must reject addition overflow", nwritten == 0);
 
-  nwritten = blosc2_stdio_mmap_write(src_guard, (int64_t)-1, 1, 0, &mmap_file);
-  CUTEST_ASSERT("mmap write must reject negative size (now wraps)", nwritten == 0);
+  nwritten = blosc2_stdio_mmap_write(src_guard, -1, 1, 0, &mmap_file);
+  CUTEST_ASSERT("mmap write must reject negative size", nwritten == 0);
 
   void* read_ptr = NULL;
   int64_t nread = blosc2_stdio_mmap_read(&read_ptr, 1, 4, 8, &mmap_file);
   CUTEST_ASSERT("Valid mmap read should succeed", nread == 4);
   CUTEST_ASSERT("Valid mmap read should return mapped pointer", read_ptr == (void*)(backing + 8));
 
-  nread = blosc2_stdio_mmap_read(NULL, 1, 4, 8, &mmap_file);
-  CUTEST_ASSERT("mmap read must reject NULL output pointer", nread == 0);
-
   read_ptr = (void*)0x1;
-  nread = blosc2_stdio_mmap_read(&read_ptr, 4, 8, 1, &mmap_file);
-  CUTEST_ASSERT("mmap read must reject out-of-range read", nread == 0);
-  CUTEST_ASSERT("mmap read must null pointer on out-of-range read", read_ptr == NULL);
-
-  read_ptr = (void*)0x1;
-  nread = blosc2_stdio_mmap_read(&read_ptr, (int64_t)SIZE_MAX, 2, 0, &mmap_file);
+  nread = blosc2_stdio_mmap_read(&read_ptr, INT64_MAX, 2, 0, &mmap_file);
   CUTEST_ASSERT("mmap read must reject multiplication overflow", nread == 0);
   CUTEST_ASSERT("mmap read must null pointer on invalid args", read_ptr == NULL);
 
   read_ptr = (void*)0x1;
-  nread = blosc2_stdio_mmap_read(&read_ptr, 1, 1, (int64_t)SIZE_MAX, &mmap_file);
+  nread = blosc2_stdio_mmap_read(&read_ptr, 1, 1, INT64_MAX, &mmap_file);
   CUTEST_ASSERT("mmap read must reject addition overflow", nread == 0);
   CUTEST_ASSERT("mmap read must null pointer on overflow", read_ptr == NULL);
 
   read_ptr = (void*)0x1;
-  nread = blosc2_stdio_mmap_read(&read_ptr, (int64_t)-1, 1, 0, &mmap_file);
-  CUTEST_ASSERT("mmap read must reject negative size (now wraps)", nread == 0);
+  nread = blosc2_stdio_mmap_read(&read_ptr, -1, 1, 0, &mmap_file);
+  CUTEST_ASSERT("mmap read must reject negative size", nread == 0);
   CUTEST_ASSERT("mmap read must null pointer on negative args", read_ptr == NULL);
 
   return 0;

--- a/tests/test_mmap_arithmetic.c
+++ b/tests/test_mmap_arithmetic.c
@@ -26,8 +26,8 @@ CUTEST_TEST_TEST(mmap_arithmetic) {
 
   blosc2_stdio_mmap mmap_file = BLOSC2_STDIO_MMAP_DEFAULTS;
   mmap_file.addr = (char*)backing;
-  mmap_file.file_size = (size_t)sizeof(backing);
-  mmap_file.mapping_size = (size_t)sizeof(backing);
+  mmap_file.file_size = (int64_t)sizeof(backing);
+  mmap_file.mapping_size = (int64_t)sizeof(backing);
 
   uint8_t src_ok[4] = {1, 2, 3, 4};
   int64_t nwritten = blosc2_stdio_mmap_write(src_ok, 1, 4, 8, &mmap_file);
@@ -35,13 +35,13 @@ CUTEST_TEST_TEST(mmap_arithmetic) {
   CUTEST_ASSERT("Valid mmap write should copy bytes", memcmp(backing + 8, src_ok, 4) == 0);
 
   uint8_t src_guard[4] = {7, 7, 7, 7};
-  nwritten = blosc2_stdio_mmap_write(src_guard, SIZE_MAX, 2, 0, &mmap_file);
+  nwritten = blosc2_stdio_mmap_write(src_guard, (int64_t)SIZE_MAX, 2, 0, &mmap_file);
   CUTEST_ASSERT("mmap write must reject multiplication overflow", nwritten == 0);
 
-  nwritten = blosc2_stdio_mmap_write(src_guard, 1, 1, SIZE_MAX, &mmap_file);
+  nwritten = blosc2_stdio_mmap_write(src_guard, 1, 1, (int64_t)SIZE_MAX, &mmap_file);
   CUTEST_ASSERT("mmap write must reject addition overflow", nwritten == 0);
 
-  nwritten = blosc2_stdio_mmap_write(src_guard, (size_t)-1, 1, 0, &mmap_file);
+  nwritten = blosc2_stdio_mmap_write(src_guard, (int64_t)-1, 1, 0, &mmap_file);
   CUTEST_ASSERT("mmap write must reject negative size (now wraps)", nwritten == 0);
 
   void* read_ptr = NULL;
@@ -58,17 +58,17 @@ CUTEST_TEST_TEST(mmap_arithmetic) {
   CUTEST_ASSERT("mmap read must null pointer on out-of-range read", read_ptr == NULL);
 
   read_ptr = (void*)0x1;
-  nread = blosc2_stdio_mmap_read(&read_ptr, SIZE_MAX, 2, 0, &mmap_file);
+  nread = blosc2_stdio_mmap_read(&read_ptr, (int64_t)SIZE_MAX, 2, 0, &mmap_file);
   CUTEST_ASSERT("mmap read must reject multiplication overflow", nread == 0);
   CUTEST_ASSERT("mmap read must null pointer on invalid args", read_ptr == NULL);
 
   read_ptr = (void*)0x1;
-  nread = blosc2_stdio_mmap_read(&read_ptr, 1, 1, SIZE_MAX, &mmap_file);
+  nread = blosc2_stdio_mmap_read(&read_ptr, 1, 1, (int64_t)SIZE_MAX, &mmap_file);
   CUTEST_ASSERT("mmap read must reject addition overflow", nread == 0);
   CUTEST_ASSERT("mmap read must null pointer on overflow", read_ptr == NULL);
 
   read_ptr = (void*)0x1;
-  nread = blosc2_stdio_mmap_read(&read_ptr, (size_t)-1, 1, 0, &mmap_file);
+  nread = blosc2_stdio_mmap_read(&read_ptr, (int64_t)-1, 1, 0, &mmap_file);
   CUTEST_ASSERT("mmap read must reject negative size (now wraps)", nread == 0);
   CUTEST_ASSERT("mmap read must null pointer on negative args", read_ptr == NULL);
 

--- a/tests/test_mmap_arithmetic.c
+++ b/tests/test_mmap_arithmetic.c
@@ -1,0 +1,78 @@
+/*
+  Copyright (c) 2021  Blosc Development Team <blosc@blosc.org>
+  https://blosc.org
+  License: BSD 3-Clause (see LICENSE.txt)
+*/
+
+#include "test_common.h"
+#include "cutest.h"
+
+#include <limits.h>
+#include <stdint.h>
+#include <string.h>
+
+
+CUTEST_TEST_DATA(mmap_arithmetic) {
+  bool placeholder;
+};
+
+CUTEST_TEST_SETUP(mmap_arithmetic) {
+  blosc2_init();
+}
+
+CUTEST_TEST_TEST(mmap_arithmetic) {
+  uint8_t backing[32];
+  memset(backing, 0, sizeof(backing));
+
+  blosc2_stdio_mmap mmap_file = BLOSC2_STDIO_MMAP_DEFAULTS;
+  mmap_file.addr = (char*)backing;
+  mmap_file.file_size = (int64_t)sizeof(backing);
+  mmap_file.mapping_size = (int64_t)sizeof(backing);
+
+  uint8_t src_ok[4] = {1, 2, 3, 4};
+  int64_t nwritten = blosc2_stdio_mmap_write(src_ok, 1, 4, 8, &mmap_file);
+  CUTEST_ASSERT("Valid mmap write should succeed", nwritten == 4);
+  CUTEST_ASSERT("Valid mmap write should copy bytes", memcmp(backing + 8, src_ok, 4) == 0);
+
+  uint8_t src_guard[4] = {7, 7, 7, 7};
+  nwritten = blosc2_stdio_mmap_write(src_guard, INT64_MAX, 2, 0, &mmap_file);
+  CUTEST_ASSERT("mmap write must reject multiplication overflow", nwritten == 0);
+
+  nwritten = blosc2_stdio_mmap_write(src_guard, 1, 1, INT64_MAX, &mmap_file);
+  CUTEST_ASSERT("mmap write must reject addition overflow", nwritten == 0);
+
+  nwritten = blosc2_stdio_mmap_write(src_guard, -1, 1, 0, &mmap_file);
+  CUTEST_ASSERT("mmap write must reject negative size", nwritten == 0);
+
+  void* read_ptr = NULL;
+  int64_t nread = blosc2_stdio_mmap_read(&read_ptr, 1, 4, 8, &mmap_file);
+  CUTEST_ASSERT("Valid mmap read should succeed", nread == 4);
+  CUTEST_ASSERT("Valid mmap read should return mapped pointer", read_ptr == (void*)(backing + 8));
+
+  read_ptr = (void*)0x1;
+  nread = blosc2_stdio_mmap_read(&read_ptr, INT64_MAX, 2, 0, &mmap_file);
+  CUTEST_ASSERT("mmap read must reject multiplication overflow", nread == 0);
+  CUTEST_ASSERT("mmap read must null pointer on invalid args", read_ptr == NULL);
+
+  read_ptr = (void*)0x1;
+  nread = blosc2_stdio_mmap_read(&read_ptr, 1, 1, INT64_MAX, &mmap_file);
+  CUTEST_ASSERT("mmap read must reject addition overflow", nread == 0);
+  CUTEST_ASSERT("mmap read must null pointer on overflow", read_ptr == NULL);
+
+  read_ptr = (void*)0x1;
+  nread = blosc2_stdio_mmap_read(&read_ptr, -1, 1, 0, &mmap_file);
+  CUTEST_ASSERT("mmap read must reject negative size", nread == 0);
+  CUTEST_ASSERT("mmap read must null pointer on negative args", read_ptr == NULL);
+
+  return 0;
+}
+
+CUTEST_TEST_TEARDOWN(mmap_arithmetic) {
+  BLOSC_UNUSED_PARAM(data);
+  blosc2_destroy();
+}
+
+
+int main(void) {
+  CUTEST_TEST_RUN(mmap_arithmetic);
+}


### PR DESCRIPTION
This adds overflow-safe arithmetic checks to mmap-based I/O paths in `blosc2-stdio.c` to prevent incorrect bounds validation and potential out-of-bounds memory access.

-Added checked arithmetic helpers:
  - checked_mul_int64_nonneg
  - checked_add_int64_nonneg

-Validated inputs 
-Prevented multiplication and addition overflow before use
-nsured computed sizes fit in size_t before memory operations
-Hardened mapping growth logic to avoid overflow

Added a new regression test `test_mmap_arithmetic.c` covering:

- Valid mmap read/write behavior
- Rejection of multiplication overflow
- Rejection of addition overflow
- Rejection of negative inputs
- Safe handling of invalid reads (null pointer return)
- Out-of-bounds access prevention

All new and existing tests pass.