### PR TITLE
 harden metadata deserialization with bounds and length validation

### DIFF
--- a/blosc/b2nd.c
+++ b/blosc/b2nd.c
@@ -188,6 +188,10 @@ int b2nd_deserialize_meta(const uint8_t *smeta, int32_t smeta_len, int8_t *ndim,
     // dtype info is here
     B2ND_REQUIRE_META_NBYTES(1 + 1 + sizeof(int32_t));
     *dtype_format = (int8_t) *(pmeta++);
+    if (*pmeta != 0xdb) {
+      BLOSC_TRACE_ERROR("Malformed b2nd metalayer: invalid dtype MsgPack marker");
+      return BLOSC2_ERROR_FAILURE;
+    }
     pmeta += 1;
     int32_t dtype_len;
     swap_store(&dtype_len, pmeta, sizeof(int32_t));
@@ -665,7 +669,7 @@ int b2nd_get_slice_nchunks(const b2nd_array_t *array, const int64_t *start, cons
 
   int8_t ndim = array->ndim;
 
-  if (array->nitems == 0){
+  if (array->nitems == 0) {
     *chunks_idx = NULL;
     return 0;
   }

--- a/blosc/b2nd.c
+++ b/blosc/b2nd.c
@@ -102,6 +102,12 @@ int b2nd_deserialize_meta(const uint8_t *smeta, int32_t smeta_len, int8_t *ndim,
   BLOSC_ERROR_NULL(shape, BLOSC2_ERROR_NULL_POINTER);
   BLOSC_ERROR_NULL(chunkshape, BLOSC2_ERROR_NULL_POINTER);
   BLOSC_ERROR_NULL(blockshape, BLOSC2_ERROR_NULL_POINTER);
+  if (dtype != NULL) {
+    *dtype = NULL;
+  }
+  if (dtype_format != NULL) {
+    *dtype_format = 0;
+  }
   if (smeta_len <= 0) {
     BLOSC_TRACE_ERROR("Malformed b2nd metalayer: empty metadata");
     return BLOSC2_ERROR_FAILURE;
@@ -178,7 +184,6 @@ int b2nd_deserialize_meta(const uint8_t *smeta, int32_t smeta_len, int8_t *ndim,
   if (dtype_format == NULL || dtype == NULL) {
     return (int32_t)(pmeta - smeta);
   }
-  *dtype = NULL;
   if (pmeta - smeta < smeta_len) {
     // dtype info is here
     B2ND_REQUIRE_META_NBYTES(1 + 1 + sizeof(int32_t));

--- a/blosc/b2nd.c
+++ b/blosc/b2nd.c
@@ -97,16 +97,38 @@ int b2nd_serialize_meta(int8_t ndim, const int64_t *shape, const int32_t *chunks
 
 int b2nd_deserialize_meta(const uint8_t *smeta, int32_t smeta_len, int8_t *ndim, int64_t *shape,
                           int32_t *chunkshape, int32_t *blockshape, char **dtype, int8_t *dtype_format) {
+  BLOSC_ERROR_NULL(smeta, BLOSC2_ERROR_NULL_POINTER);
+  BLOSC_ERROR_NULL(ndim, BLOSC2_ERROR_NULL_POINTER);
+  BLOSC_ERROR_NULL(shape, BLOSC2_ERROR_NULL_POINTER);
+  BLOSC_ERROR_NULL(chunkshape, BLOSC2_ERROR_NULL_POINTER);
+  BLOSC_ERROR_NULL(blockshape, BLOSC2_ERROR_NULL_POINTER);
+  if (smeta_len <= 0) {
+    BLOSC_TRACE_ERROR("Malformed b2nd metalayer: empty metadata");
+    return BLOSC2_ERROR_FAILURE;
+  }
+
   const uint8_t *pmeta = smeta;
+  const uint8_t *smeta_end = smeta + smeta_len;
+
+#define B2ND_REQUIRE_META_NBYTES(nbytes)                                             \
+  do {                                                                                \
+    if ((size_t)(smeta_end - pmeta) < (size_t)(nbytes)) {                            \
+      BLOSC_TRACE_ERROR("Malformed b2nd metalayer: truncated metadata");            \
+      return BLOSC2_ERROR_FAILURE;                                                    \
+    }                                                                                 \
+  } while (0)
 
   // Check that we have an array with 7 entries (version, ndim, shape, chunkshape, blockshape, dtype_format, dtype)
+  B2ND_REQUIRE_META_NBYTES(1);
   pmeta += 1;
 
   // version entry
   // int8_t version = (int8_t)pmeta[0];  // positive fixnum (7-bit positive integer) commented to avoid warning
+  B2ND_REQUIRE_META_NBYTES(1);
   pmeta += 1;
 
   // ndim entry
+  B2ND_REQUIRE_META_NBYTES(1);
   *ndim = (int8_t) pmeta[0];
   int8_t ndim_aux = *ndim;  // positive fixnum (7-bit positive integer)
   if (ndim_aux < 0 || ndim_aux > B2ND_MAX_DIM) {
@@ -118,8 +140,10 @@ int b2nd_deserialize_meta(const uint8_t *smeta, int32_t smeta_len, int8_t *ndim,
   // shape entry
   // Initialize to ones, as required by b2nd
   for (int i = 0; i < ndim_aux; i++) shape[i] = 1;
+  B2ND_REQUIRE_META_NBYTES(1);
   pmeta += 1;
   for (int8_t i = 0; i < ndim_aux; i++) {
+    B2ND_REQUIRE_META_NBYTES(1 + sizeof(int64_t));
     pmeta += 1;
     swap_store(shape + i, pmeta, sizeof(int64_t));
     pmeta += sizeof(int64_t);
@@ -128,8 +152,10 @@ int b2nd_deserialize_meta(const uint8_t *smeta, int32_t smeta_len, int8_t *ndim,
   // chunkshape entry
   // Initialize to ones, as required by b2nd
   for (int i = 0; i < ndim_aux; i++) chunkshape[i] = 1;
+  B2ND_REQUIRE_META_NBYTES(1);
   pmeta += 1;
   for (int8_t i = 0; i < ndim_aux; i++) {
+    B2ND_REQUIRE_META_NBYTES(1 + sizeof(int32_t));
     pmeta += 1;
     swap_store(chunkshape + i, pmeta, sizeof(int32_t));
     pmeta += sizeof(int32_t);
@@ -138,8 +164,10 @@ int b2nd_deserialize_meta(const uint8_t *smeta, int32_t smeta_len, int8_t *ndim,
   // blockshape entry
   // Initialize to ones, as required by b2nd
   for (int i = 0; i < ndim_aux; i++) blockshape[i] = 1;
+  B2ND_REQUIRE_META_NBYTES(1);
   pmeta += 1;
   for (int8_t i = 0; i < ndim_aux; i++) {
+    B2ND_REQUIRE_META_NBYTES(1 + sizeof(int32_t));
     pmeta += 1;
     swap_store(blockshape + i, pmeta, sizeof(int32_t));
     pmeta += sizeof(int32_t);
@@ -149,18 +177,27 @@ int b2nd_deserialize_meta(const uint8_t *smeta, int32_t smeta_len, int8_t *ndim,
   if (dtype_format == NULL || dtype == NULL) {
     return (int32_t)(pmeta - smeta);
   }
+  *dtype = NULL;
   if (pmeta - smeta < smeta_len) {
     // dtype info is here
+    B2ND_REQUIRE_META_NBYTES(1 + 1 + sizeof(int32_t));
     *dtype_format = (int8_t) *(pmeta++);
     pmeta += 1;
     int dtype_len;
     swap_store(&dtype_len, pmeta, sizeof(int32_t));
     pmeta += sizeof(int32_t);
-    *dtype = (char*)malloc(dtype_len + 1);
+    if (dtype_len < 0) {
+      BLOSC_TRACE_ERROR("Malformed b2nd metalayer: negative dtype length");
+      return BLOSC2_ERROR_FAILURE;
+    }
+    B2ND_REQUIRE_META_NBYTES(dtype_len);
+    size_t dtype_len_ = (size_t)dtype_len;
+    *dtype = (char*)malloc(dtype_len_ + 1);
+    BLOSC_ERROR_NULL(*dtype, BLOSC2_ERROR_MEMORY_ALLOC);
     char* dtype_ = *dtype;
-    memcpy(dtype_, (char*)pmeta, dtype_len);
-    dtype_[dtype_len] = '\0';
-    pmeta += dtype_len;
+    memcpy(dtype_, (char*)pmeta, dtype_len_);
+    dtype_[dtype_len_] = '\0';
+    pmeta += dtype_len_;
   }
   else {
     // dtype is mandatory in b2nd metalayer, but this is mainly meant as
@@ -168,6 +205,8 @@ int b2nd_deserialize_meta(const uint8_t *smeta, int32_t smeta_len, int8_t *ndim,
     *dtype = NULL;
     *dtype_format = 0;
   }
+
+#undef B2ND_REQUIRE_META_NBYTES
 
   int32_t slen = (int32_t) (pmeta - smeta);
   return (int)slen;
@@ -620,7 +659,7 @@ int b2nd_get_slice_nchunks(const b2nd_array_t *array, const int64_t *start, cons
 
   int8_t ndim = array->ndim;
 
-  if (array->nitems == 0){  
+  if (array->nitems == 0){
     *chunks_idx = NULL;
     return 0;
   }

--- a/blosc/b2nd.c
+++ b/blosc/b2nd.c
@@ -108,11 +108,12 @@ int b2nd_deserialize_meta(const uint8_t *smeta, int32_t smeta_len, int8_t *ndim,
   }
 
   const uint8_t *pmeta = smeta;
-  const uint8_t *smeta_end = smeta + smeta_len;
 
 #define B2ND_REQUIRE_META_NBYTES(nbytes)                                             \
   do {                                                                                \
-    if ((size_t)(smeta_end - pmeta) < (size_t)(nbytes)) {                            \
+    size_t consumed = (size_t)(pmeta - smeta);                                        \
+    size_t total = (size_t)smeta_len;                                                 \
+    if (consumed > total || (total - consumed) < (size_t)(nbytes)) {                 \
       BLOSC_TRACE_ERROR("Malformed b2nd metalayer: truncated metadata");            \
       return BLOSC2_ERROR_FAILURE;                                                    \
     }                                                                                 \
@@ -183,7 +184,7 @@ int b2nd_deserialize_meta(const uint8_t *smeta, int32_t smeta_len, int8_t *ndim,
     B2ND_REQUIRE_META_NBYTES(1 + 1 + sizeof(int32_t));
     *dtype_format = (int8_t) *(pmeta++);
     pmeta += 1;
-    int dtype_len;
+    int32_t dtype_len;
     swap_store(&dtype_len, pmeta, sizeof(int32_t));
     pmeta += sizeof(int32_t);
     if (dtype_len < 0) {

--- a/blosc/b2nd.c
+++ b/blosc/b2nd.c
@@ -127,11 +127,21 @@ int b2nd_deserialize_meta(const uint8_t *smeta, int32_t smeta_len, int8_t *ndim,
 
   // Check that we have an array with 7 entries (version, ndim, shape, chunkshape, blockshape, dtype_format, dtype)
   B2ND_REQUIRE_META_NBYTES(1);
+  uint8_t array_marker = *pmeta;
+  if ((array_marker & 0xf0u) != 0x90u) {
+    BLOSC_TRACE_ERROR("Malformed b2nd metalayer: invalid top-level MsgPack marker");
+    return BLOSC2_ERROR_FAILURE;
+  }
+  // Be compatibility-friendly: validate fixarray type, but do not enforce exact entry count.
   pmeta += 1;
 
   // version entry
-  // int8_t version = (int8_t)pmeta[0];  // positive fixnum (7-bit positive integer) commented to avoid warning
   B2ND_REQUIRE_META_NBYTES(1);
+  int8_t version = (int8_t)pmeta[0];  // positive fixnum (7-bit positive integer)
+  if (version <= 0 || version > B2ND_METALAYER_VERSION) {
+    BLOSC_TRACE_ERROR("Malformed b2nd metalayer: unsupported version (%d)", version);
+    return BLOSC2_ERROR_FAILURE;
+  }
   pmeta += 1;
 
   // ndim entry

--- a/blosc/b2nd.c
+++ b/blosc/b2nd.c
@@ -125,13 +125,37 @@ int b2nd_deserialize_meta(const uint8_t *smeta, int32_t smeta_len, int8_t *ndim,
     }                                                                                 \
   } while (0)
 
+#define B2ND_REQUIRE_META_MARKER(expected, what)                                      \
+  do {                                                                                \
+    B2ND_REQUIRE_META_NBYTES(1);                                                      \
+    if (*pmeta != (uint8_t)(expected)) {                                              \
+      BLOSC_TRACE_ERROR("Malformed b2nd metalayer: invalid " what " marker");      \
+      return BLOSC2_ERROR_FAILURE;                                                    \
+    }                                                                                 \
+    pmeta += 1;                                                                       \
+  } while (0)
+
   // Check that we have an array with 7 entries (version, ndim, shape, chunkshape, blockshape, dtype_format, dtype)
   B2ND_REQUIRE_META_NBYTES(1);
-  pmeta += 1;
+  uint8_t top_array_marker = *pmeta++;
+  if ((top_array_marker & 0xf0u) != 0x90u) {
+    BLOSC_TRACE_ERROR("Malformed b2nd metalayer: invalid top-level array marker");
+    return BLOSC2_ERROR_FAILURE;
+  }
+  // Legacy caterva metadata can have fewer entries than current b2nd metadata.
+  uint8_t top_array_entries = (uint8_t)(top_array_marker & 0x0fu);
+  if (top_array_entries != 5 && top_array_entries != 7) {
+    BLOSC_TRACE_ERROR("Malformed b2nd metalayer: unsupported top-level array size (%u)", top_array_entries);
+    return BLOSC2_ERROR_FAILURE;
+  }
 
   // version entry
-  // int8_t version = (int8_t)pmeta[0];  // positive fixnum (7-bit positive integer) commented to avoid warning
   B2ND_REQUIRE_META_NBYTES(1);
+  int8_t version = (int8_t)pmeta[0];  // positive fixnum (7-bit positive integer)
+  if (version <= 0 || version > B2ND_METALAYER_VERSION) {
+    BLOSC_TRACE_ERROR("Malformed b2nd metalayer: unsupported version (%d)", version);
+    return BLOSC2_ERROR_FAILURE;
+  }
   pmeta += 1;
 
   // ndim entry
@@ -148,10 +172,14 @@ int b2nd_deserialize_meta(const uint8_t *smeta, int32_t smeta_len, int8_t *ndim,
   // Initialize to ones, as required by b2nd
   for (int i = 0; i < ndim_aux; i++) shape[i] = 1;
   B2ND_REQUIRE_META_NBYTES(1);
-  pmeta += 1;
+  uint8_t shape_array_marker = *pmeta++;
+  if ((shape_array_marker & 0xf0u) != 0x90u || (shape_array_marker & 0x0fu) != (uint8_t)ndim_aux) {
+    BLOSC_TRACE_ERROR("Malformed b2nd metalayer: invalid shape array marker");
+    return BLOSC2_ERROR_FAILURE;
+  }
   for (int8_t i = 0; i < ndim_aux; i++) {
     B2ND_REQUIRE_META_NBYTES(1 + sizeof(int64_t));
-    pmeta += 1;
+    B2ND_REQUIRE_META_MARKER(0xd3, "shape dtype");
     swap_store(shape + i, pmeta, sizeof(int64_t));
     pmeta += sizeof(int64_t);
   }
@@ -160,10 +188,14 @@ int b2nd_deserialize_meta(const uint8_t *smeta, int32_t smeta_len, int8_t *ndim,
   // Initialize to ones, as required by b2nd
   for (int i = 0; i < ndim_aux; i++) chunkshape[i] = 1;
   B2ND_REQUIRE_META_NBYTES(1);
-  pmeta += 1;
+  uint8_t chunkshape_array_marker = *pmeta++;
+  if ((chunkshape_array_marker & 0xf0u) != 0x90u || (chunkshape_array_marker & 0x0fu) != (uint8_t)ndim_aux) {
+    BLOSC_TRACE_ERROR("Malformed b2nd metalayer: invalid chunkshape array marker");
+    return BLOSC2_ERROR_FAILURE;
+  }
   for (int8_t i = 0; i < ndim_aux; i++) {
     B2ND_REQUIRE_META_NBYTES(1 + sizeof(int32_t));
-    pmeta += 1;
+    B2ND_REQUIRE_META_MARKER(0xd2, "chunkshape dtype");
     swap_store(chunkshape + i, pmeta, sizeof(int32_t));
     pmeta += sizeof(int32_t);
   }
@@ -172,10 +204,14 @@ int b2nd_deserialize_meta(const uint8_t *smeta, int32_t smeta_len, int8_t *ndim,
   // Initialize to ones, as required by b2nd
   for (int i = 0; i < ndim_aux; i++) blockshape[i] = 1;
   B2ND_REQUIRE_META_NBYTES(1);
-  pmeta += 1;
+  uint8_t blockshape_array_marker = *pmeta++;
+  if ((blockshape_array_marker & 0xf0u) != 0x90u || (blockshape_array_marker & 0x0fu) != (uint8_t)ndim_aux) {
+    BLOSC_TRACE_ERROR("Malformed b2nd metalayer: invalid blockshape array marker");
+    return BLOSC2_ERROR_FAILURE;
+  }
   for (int8_t i = 0; i < ndim_aux; i++) {
     B2ND_REQUIRE_META_NBYTES(1 + sizeof(int32_t));
-    pmeta += 1;
+    B2ND_REQUIRE_META_MARKER(0xd2, "blockshape dtype");
     swap_store(blockshape + i, pmeta, sizeof(int32_t));
     pmeta += sizeof(int32_t);
   }
@@ -188,7 +224,7 @@ int b2nd_deserialize_meta(const uint8_t *smeta, int32_t smeta_len, int8_t *ndim,
     // dtype info is here
     B2ND_REQUIRE_META_NBYTES(1 + 1 + sizeof(int32_t));
     *dtype_format = (int8_t) *(pmeta++);
-    pmeta += 1;
+    B2ND_REQUIRE_META_MARKER(0xdb, "dtype string");
     int32_t dtype_len;
     swap_store(&dtype_len, pmeta, sizeof(int32_t));
     pmeta += sizeof(int32_t);
@@ -212,6 +248,7 @@ int b2nd_deserialize_meta(const uint8_t *smeta, int32_t smeta_len, int8_t *ndim,
     *dtype_format = 0;
   }
 
+#undef B2ND_REQUIRE_META_MARKER
 #undef B2ND_REQUIRE_META_NBYTES
 
   int32_t slen = (int32_t) (pmeta - smeta);
@@ -665,7 +702,7 @@ int b2nd_get_slice_nchunks(const b2nd_array_t *array, const int64_t *start, cons
 
   int8_t ndim = array->ndim;
 
-  if (array->nitems == 0){
+  if (array->nitems == 0) {
     *chunks_idx = NULL;
     return 0;
   }

--- a/blosc/b2nd.c
+++ b/blosc/b2nd.c
@@ -127,21 +127,11 @@ int b2nd_deserialize_meta(const uint8_t *smeta, int32_t smeta_len, int8_t *ndim,
 
   // Check that we have an array with 7 entries (version, ndim, shape, chunkshape, blockshape, dtype_format, dtype)
   B2ND_REQUIRE_META_NBYTES(1);
-  uint8_t array_marker = *pmeta;
-  if ((array_marker & 0xf0u) != 0x90u) {
-    BLOSC_TRACE_ERROR("Malformed b2nd metalayer: invalid top-level MsgPack marker");
-    return BLOSC2_ERROR_FAILURE;
-  }
-  // Be compatibility-friendly: validate fixarray type, but do not enforce exact entry count.
   pmeta += 1;
 
   // version entry
+  // int8_t version = (int8_t)pmeta[0];  // positive fixnum (7-bit positive integer) commented to avoid warning
   B2ND_REQUIRE_META_NBYTES(1);
-  int8_t version = (int8_t)pmeta[0];  // positive fixnum (7-bit positive integer)
-  if (version <= 0 || version > B2ND_METALAYER_VERSION) {
-    BLOSC_TRACE_ERROR("Malformed b2nd metalayer: unsupported version (%d)", version);
-    return BLOSC2_ERROR_FAILURE;
-  }
   pmeta += 1;
 
   // ndim entry

--- a/blosc/b2nd.c
+++ b/blosc/b2nd.c
@@ -125,37 +125,13 @@ int b2nd_deserialize_meta(const uint8_t *smeta, int32_t smeta_len, int8_t *ndim,
     }                                                                                 \
   } while (0)
 
-#define B2ND_REQUIRE_META_MARKER(expected, what)                                      \
-  do {                                                                                \
-    B2ND_REQUIRE_META_NBYTES(1);                                                      \
-    if (*pmeta != (uint8_t)(expected)) {                                              \
-      BLOSC_TRACE_ERROR("Malformed b2nd metalayer: invalid " what " marker");      \
-      return BLOSC2_ERROR_FAILURE;                                                    \
-    }                                                                                 \
-    pmeta += 1;                                                                       \
-  } while (0)
-
   // Check that we have an array with 7 entries (version, ndim, shape, chunkshape, blockshape, dtype_format, dtype)
   B2ND_REQUIRE_META_NBYTES(1);
-  uint8_t top_array_marker = *pmeta++;
-  if ((top_array_marker & 0xf0u) != 0x90u) {
-    BLOSC_TRACE_ERROR("Malformed b2nd metalayer: invalid top-level array marker");
-    return BLOSC2_ERROR_FAILURE;
-  }
-  // Legacy caterva metadata can have fewer entries than current b2nd metadata.
-  uint8_t top_array_entries = (uint8_t)(top_array_marker & 0x0fu);
-  if (top_array_entries != 5 && top_array_entries != 7) {
-    BLOSC_TRACE_ERROR("Malformed b2nd metalayer: unsupported top-level array size (%u)", top_array_entries);
-    return BLOSC2_ERROR_FAILURE;
-  }
+  pmeta += 1;
 
   // version entry
+  // int8_t version = (int8_t)pmeta[0];  // positive fixnum (7-bit positive integer) commented to avoid warning
   B2ND_REQUIRE_META_NBYTES(1);
-  int8_t version = (int8_t)pmeta[0];  // positive fixnum (7-bit positive integer)
-  if (version <= 0 || version > B2ND_METALAYER_VERSION) {
-    BLOSC_TRACE_ERROR("Malformed b2nd metalayer: unsupported version (%d)", version);
-    return BLOSC2_ERROR_FAILURE;
-  }
   pmeta += 1;
 
   // ndim entry
@@ -172,14 +148,10 @@ int b2nd_deserialize_meta(const uint8_t *smeta, int32_t smeta_len, int8_t *ndim,
   // Initialize to ones, as required by b2nd
   for (int i = 0; i < ndim_aux; i++) shape[i] = 1;
   B2ND_REQUIRE_META_NBYTES(1);
-  uint8_t shape_array_marker = *pmeta++;
-  if ((shape_array_marker & 0xf0u) != 0x90u || (shape_array_marker & 0x0fu) != (uint8_t)ndim_aux) {
-    BLOSC_TRACE_ERROR("Malformed b2nd metalayer: invalid shape array marker");
-    return BLOSC2_ERROR_FAILURE;
-  }
+  pmeta += 1;
   for (int8_t i = 0; i < ndim_aux; i++) {
     B2ND_REQUIRE_META_NBYTES(1 + sizeof(int64_t));
-    B2ND_REQUIRE_META_MARKER(0xd3, "shape dtype");
+    pmeta += 1;
     swap_store(shape + i, pmeta, sizeof(int64_t));
     pmeta += sizeof(int64_t);
   }
@@ -188,14 +160,10 @@ int b2nd_deserialize_meta(const uint8_t *smeta, int32_t smeta_len, int8_t *ndim,
   // Initialize to ones, as required by b2nd
   for (int i = 0; i < ndim_aux; i++) chunkshape[i] = 1;
   B2ND_REQUIRE_META_NBYTES(1);
-  uint8_t chunkshape_array_marker = *pmeta++;
-  if ((chunkshape_array_marker & 0xf0u) != 0x90u || (chunkshape_array_marker & 0x0fu) != (uint8_t)ndim_aux) {
-    BLOSC_TRACE_ERROR("Malformed b2nd metalayer: invalid chunkshape array marker");
-    return BLOSC2_ERROR_FAILURE;
-  }
+  pmeta += 1;
   for (int8_t i = 0; i < ndim_aux; i++) {
     B2ND_REQUIRE_META_NBYTES(1 + sizeof(int32_t));
-    B2ND_REQUIRE_META_MARKER(0xd2, "chunkshape dtype");
+    pmeta += 1;
     swap_store(chunkshape + i, pmeta, sizeof(int32_t));
     pmeta += sizeof(int32_t);
   }
@@ -204,14 +172,10 @@ int b2nd_deserialize_meta(const uint8_t *smeta, int32_t smeta_len, int8_t *ndim,
   // Initialize to ones, as required by b2nd
   for (int i = 0; i < ndim_aux; i++) blockshape[i] = 1;
   B2ND_REQUIRE_META_NBYTES(1);
-  uint8_t blockshape_array_marker = *pmeta++;
-  if ((blockshape_array_marker & 0xf0u) != 0x90u || (blockshape_array_marker & 0x0fu) != (uint8_t)ndim_aux) {
-    BLOSC_TRACE_ERROR("Malformed b2nd metalayer: invalid blockshape array marker");
-    return BLOSC2_ERROR_FAILURE;
-  }
+  pmeta += 1;
   for (int8_t i = 0; i < ndim_aux; i++) {
     B2ND_REQUIRE_META_NBYTES(1 + sizeof(int32_t));
-    B2ND_REQUIRE_META_MARKER(0xd2, "blockshape dtype");
+    pmeta += 1;
     swap_store(blockshape + i, pmeta, sizeof(int32_t));
     pmeta += sizeof(int32_t);
   }
@@ -224,7 +188,7 @@ int b2nd_deserialize_meta(const uint8_t *smeta, int32_t smeta_len, int8_t *ndim,
     // dtype info is here
     B2ND_REQUIRE_META_NBYTES(1 + 1 + sizeof(int32_t));
     *dtype_format = (int8_t) *(pmeta++);
-    B2ND_REQUIRE_META_MARKER(0xdb, "dtype string");
+    pmeta += 1;
     int32_t dtype_len;
     swap_store(&dtype_len, pmeta, sizeof(int32_t));
     pmeta += sizeof(int32_t);
@@ -248,7 +212,6 @@ int b2nd_deserialize_meta(const uint8_t *smeta, int32_t smeta_len, int8_t *ndim,
     *dtype_format = 0;
   }
 
-#undef B2ND_REQUIRE_META_MARKER
 #undef B2ND_REQUIRE_META_NBYTES
 
   int32_t slen = (int32_t) (pmeta - smeta);
@@ -702,7 +665,7 @@ int b2nd_get_slice_nchunks(const b2nd_array_t *array, const int64_t *start, cons
 
   int8_t ndim = array->ndim;
 
-  if (array->nitems == 0) {
+  if (array->nitems == 0){
     *chunks_idx = NULL;
     return 0;
   }

--- a/tests/b2nd/test_b2nd_deserialize_meta_security.c
+++ b/tests/b2nd/test_b2nd_deserialize_meta_security.c
@@ -60,16 +60,6 @@ CUTEST_TEST_TEST(deserialize_meta_security) {
   CUTEST_ASSERT("negative dtype length should fail", rc < 0);
   CUTEST_ASSERT("dtype must remain NULL on malformed metadata", dtype == NULL);
 
-  // Corrupt top-level marker; parser must reject non-fixarray metadata.
-  memcpy(smeta_bad, smeta, (size_t)smeta_len);
-  smeta_bad[0] = 0x80;  // fixmap marker (invalid for b2nd top-level)
-
-  dtype = NULL;
-  rc = b2nd_deserialize_meta(smeta_bad, smeta_len, &parsed_ndim, parsed_shape,
-                             parsed_chunkshape, parsed_blockshape, &dtype, &dtype_format);
-  CUTEST_ASSERT("invalid top-level marker should fail", rc < 0);
-  CUTEST_ASSERT("dtype must remain NULL on malformed metadata", dtype == NULL);
-
   free(smeta_bad);
   free(smeta);
 

--- a/tests/b2nd/test_b2nd_deserialize_meta_security.c
+++ b/tests/b2nd/test_b2nd_deserialize_meta_security.c
@@ -60,6 +60,16 @@ CUTEST_TEST_TEST(deserialize_meta_security) {
   CUTEST_ASSERT("negative dtype length should fail", rc < 0);
   CUTEST_ASSERT("dtype must remain NULL on malformed metadata", dtype == NULL);
 
+  // Corrupt top-level marker; parser must reject non-fixarray metadata.
+  memcpy(smeta_bad, smeta, (size_t)smeta_len);
+  smeta_bad[0] = 0x80;  // fixmap marker (invalid for b2nd top-level)
+
+  dtype = NULL;
+  rc = b2nd_deserialize_meta(smeta_bad, smeta_len, &parsed_ndim, parsed_shape,
+                             parsed_chunkshape, parsed_blockshape, &dtype, &dtype_format);
+  CUTEST_ASSERT("invalid top-level marker should fail", rc < 0);
+  CUTEST_ASSERT("dtype must remain NULL on malformed metadata", dtype == NULL);
+
   free(smeta_bad);
   free(smeta);
 

--- a/tests/b2nd/test_b2nd_deserialize_meta_security.c
+++ b/tests/b2nd/test_b2nd_deserialize_meta_security.c
@@ -60,27 +60,6 @@ CUTEST_TEST_TEST(deserialize_meta_security) {
   CUTEST_ASSERT("negative dtype length should fail", rc < 0);
   CUTEST_ASSERT("dtype must remain NULL on malformed metadata", dtype == NULL);
 
-  // Corrupt top-level marker; parser must reject non-fixarray metadata.
-  memcpy(smeta_bad, smeta, (size_t)smeta_len);
-  smeta_bad[0] = 0x80;  // fixmap marker (invalid for b2nd top-level)
-
-  dtype = NULL;
-  rc = b2nd_deserialize_meta(smeta_bad, smeta_len, &parsed_ndim, parsed_shape,
-                             parsed_chunkshape, parsed_blockshape, &dtype, &dtype_format);
-  CUTEST_ASSERT("invalid top-level marker should fail", rc < 0);
-  CUTEST_ASSERT("dtype must remain NULL on malformed metadata", dtype == NULL);
-
-  // Corrupt dtype MsgPack marker; parser must reject non-str32 marker.
-  memcpy(smeta_bad, smeta, (size_t)smeta_len);
-  CUTEST_ASSERT("dtype marker out of bounds", dtype_offset + 1 < (size_t)smeta_len);
-  smeta_bad[dtype_offset + 1] = 0xda;  // str16 marker (unexpected in this format)
-
-  dtype = NULL;
-  rc = b2nd_deserialize_meta(smeta_bad, smeta_len, &parsed_ndim, parsed_shape,
-                             parsed_chunkshape, parsed_blockshape, &dtype, &dtype_format);
-  CUTEST_ASSERT("invalid dtype marker should fail", rc < 0);
-  CUTEST_ASSERT("dtype must remain NULL on malformed metadata", dtype == NULL);
-
   free(smeta_bad);
   free(smeta);
 

--- a/tests/b2nd/test_b2nd_deserialize_meta_security.c
+++ b/tests/b2nd/test_b2nd_deserialize_meta_security.c
@@ -1,0 +1,77 @@
+/*********************************************************************
+  Blosc - Blocked Shuffling and Compression Library
+
+  Copyright (c) 2021  Blosc Development Team <blosc@blosc.org>
+  https://blosc.org
+  License: BSD 3-Clause (see LICENSE.txt)
+
+  See LICENSE.txt for details about copyright and rights to use.
+*********************************************************************/
+
+#include "test_common.h"
+
+
+CUTEST_TEST_SETUP(deserialize_meta_security) {
+  blosc2_init();
+}
+
+
+CUTEST_TEST_TEST(deserialize_meta_security) {
+  int8_t ndim = 2;
+  int64_t shape[B2ND_MAX_DIM] = {4, 5};
+  int32_t chunkshape[B2ND_MAX_DIM] = {2, 5};
+  int32_t blockshape[B2ND_MAX_DIM] = {1, 5};
+
+  uint8_t *smeta = NULL;
+  int32_t smeta_len = b2nd_serialize_meta(ndim, shape, chunkshape, blockshape,
+                                          "|u1", DTYPE_NUMPY_FORMAT, &smeta);
+  B2ND_TEST_ASSERT(smeta_len);
+
+  // Truncated metadata must be rejected instead of being over-read.
+  int8_t parsed_ndim = 0;
+  int64_t parsed_shape[B2ND_MAX_DIM];
+  int32_t parsed_chunkshape[B2ND_MAX_DIM];
+  int32_t parsed_blockshape[B2ND_MAX_DIM];
+  char *dtype = NULL;
+  int8_t dtype_format = 0;
+  int rc = b2nd_deserialize_meta(smeta, smeta_len - 1, &parsed_ndim, parsed_shape,
+                                 parsed_chunkshape, parsed_blockshape, &dtype, &dtype_format);
+  CUTEST_ASSERT("truncated metadata should fail", rc < 0);
+  CUTEST_ASSERT("dtype must remain NULL on failure", dtype == NULL);
+
+  // Corrupt dtype length to negative; parser must fail before allocating/copying.
+  uint8_t *smeta_bad = malloc((size_t)smeta_len);
+  CUTEST_ASSERT("cannot allocate test buffer", smeta_bad != NULL);
+  memcpy(smeta_bad, smeta, (size_t)smeta_len);
+
+  size_t dtype_offset = 3;
+  dtype_offset += 1 + (size_t)ndim * (1 + sizeof(int64_t));
+  dtype_offset += 1 + (size_t)ndim * (1 + sizeof(int32_t));
+  dtype_offset += 1 + (size_t)ndim * (1 + sizeof(int32_t));
+  size_t dtype_len_offset = dtype_offset + 2;
+  CUTEST_ASSERT("dtype length field out of bounds", dtype_len_offset + sizeof(int32_t) <= (size_t)smeta_len);
+
+  int32_t negative_dtype_len = -1;
+  swap_store(&smeta_bad[dtype_len_offset], &negative_dtype_len, sizeof(int32_t));
+
+  dtype = NULL;
+  rc = b2nd_deserialize_meta(smeta_bad, smeta_len, &parsed_ndim, parsed_shape,
+                             parsed_chunkshape, parsed_blockshape, &dtype, &dtype_format);
+  CUTEST_ASSERT("negative dtype length should fail", rc < 0);
+  CUTEST_ASSERT("dtype must remain NULL on malformed metadata", dtype == NULL);
+
+  free(smeta_bad);
+  free(smeta);
+
+  return 0;
+}
+
+
+CUTEST_TEST_TEARDOWN(deserialize_meta_security) {
+  blosc2_destroy();
+}
+
+
+int main() {
+  CUTEST_TEST_RUN(deserialize_meta_security);
+}

--- a/tests/b2nd/test_b2nd_deserialize_meta_security.c
+++ b/tests/b2nd/test_b2nd_deserialize_meta_security.c
@@ -60,6 +60,27 @@ CUTEST_TEST_TEST(deserialize_meta_security) {
   CUTEST_ASSERT("negative dtype length should fail", rc < 0);
   CUTEST_ASSERT("dtype must remain NULL on malformed metadata", dtype == NULL);
 
+  // Corrupt top-level marker; parser must reject non-fixarray metadata.
+  memcpy(smeta_bad, smeta, (size_t)smeta_len);
+  smeta_bad[0] = 0x80;  // fixmap marker (invalid for b2nd top-level)
+
+  dtype = NULL;
+  rc = b2nd_deserialize_meta(smeta_bad, smeta_len, &parsed_ndim, parsed_shape,
+                             parsed_chunkshape, parsed_blockshape, &dtype, &dtype_format);
+  CUTEST_ASSERT("invalid top-level marker should fail", rc < 0);
+  CUTEST_ASSERT("dtype must remain NULL on malformed metadata", dtype == NULL);
+
+  // Corrupt dtype MsgPack marker; parser must reject non-str32 marker.
+  memcpy(smeta_bad, smeta, (size_t)smeta_len);
+  CUTEST_ASSERT("dtype marker out of bounds", dtype_offset + 1 < (size_t)smeta_len);
+  smeta_bad[dtype_offset + 1] = 0xda;  // str16 marker (unexpected in this format)
+
+  dtype = NULL;
+  rc = b2nd_deserialize_meta(smeta_bad, smeta_len, &parsed_ndim, parsed_shape,
+                             parsed_chunkshape, parsed_blockshape, &dtype, &dtype_format);
+  CUTEST_ASSERT("invalid dtype marker should fail", rc < 0);
+  CUTEST_ASSERT("dtype must remain NULL on malformed metadata", dtype == NULL);
+
   free(smeta_bad);
   free(smeta);
 


### PR DESCRIPTION
This PR hardens `b2nd_deserialize_meta` against malformed or truncated metadata by introducing strict bounds checking and validation of length fields before reading from the input buffer.

The parser previously assumed well-formed input and could advance pointers and read fields without verifying that sufficient bytes remained. This could lead to out-of-bounds reads and unsafe memory operations when handling corrupted or adversarial inputs.

-Added systematic bounds checks before reading each metadata field
-Validated `dtype_len` to ensure it is non-negative and within remaining buffer limits
-Added early checks for null or invalid input buffers
-Ensured safe failure on malformed metadata instead of continuing parsing