### PR TITLE
Fix out-of-bounds read in lazy VL chunk decompression

### DIFF
--- a/blosc/blosc2.c
+++ b/blosc/blosc2.c
@@ -1780,8 +1780,17 @@ static int blosc_d(
     nchunk = *(int32_t*)(src + trailer_offset);
     chunk_offset = *(int64_t*)(src + trailer_offset + sizeof(int32_t));
     // Get the csize of the nblock
+    if (nblock < 0 || nblock >= context->nblocks) {
+      BLOSC_TRACE_ERROR("Invalid block index in lazy trailer.");
+      return BLOSC2_ERROR_DATA;
+    }
     int32_t *block_csizes = (int32_t *)(src + trailer_offset + sizeof(int32_t) + sizeof(int64_t));
     int32_t block_csize = block_csizes[nblock];
+    int32_t max_lazy_block_csize = context->blocksize + context->typesize * (signed)sizeof(int32_t);
+    if (block_csize <= 0 || block_csize > max_lazy_block_csize) {
+      BLOSC_TRACE_ERROR("Invalid lazy block size in trailer.");
+      return BLOSC2_ERROR_DATA;
+    }
     // Read the lazy block on disk
     void* fp = NULL;
     blosc2_io_cb *io_cb = blosc2_get_io_cb(context->schunk->storage->io->id);

--- a/blosc/blosc2.c
+++ b/blosc/blosc2.c
@@ -828,6 +828,11 @@ int read_chunk_header(const uint8_t* src, int32_t srcsize, bool extended_header,
     /* Version from future with unsupported chunk features. */
     return BLOSC2_ERROR_VERSION_SUPPORT;
   }
+  if ((header->blosc2_flags2 & BLOSC2_VL_BLOCKS) != 0 &&
+      (header->flags & (uint8_t)BLOSC_MEMCPYED) != 0) {
+    BLOSC_TRACE_ERROR("VL-block chunks cannot be memcpyed.");
+    return BLOSC2_ERROR_INVALID_HEADER;
+  }
   if ((header->blosc2_flags2 & BLOSC2_VL_BLOCKS) == 0 &&
       header->nbytes > 0 && header->blocksize > header->nbytes) {
     header->blocksize = header->nbytes;
@@ -1766,7 +1771,7 @@ static int blosc_d(
         !checked_add_size(sizeof(int32_t) + sizeof(int64_t), block_csizes_nbytes, &trailer_meta_nbytes) ||
         !checked_add_size(trailer_offset, trailer_meta_nbytes, &lazy_trailer_end) ||
         (size_t)srcsize < lazy_trailer_end) {
-      BLOSC_TRACE_ERROR("Lazy VL trailer exceeds source buffer.");
+      BLOSC_TRACE_ERROR("Lazy trailer exceeds source buffer.");
       return BLOSC2_ERROR_READ_BUFFER;
     }
     int32_t nchunk;
@@ -2731,7 +2736,7 @@ static int initialize_context_decompression(blosc2_context* context, blosc_heade
         !checked_add_size(sizeof(int32_t) + sizeof(int64_t), block_csizes_nbytes, &trailer_meta_nbytes) ||
         !checked_add_size((size_t)bstarts_end, trailer_meta_nbytes, &lazy_trailer_end) ||
         (size_t)context->srcsize < lazy_trailer_end) {
-      BLOSC_TRACE_ERROR("Lazy VL trailer exceeds source buffer.");
+      BLOSC_TRACE_ERROR("Lazy trailer exceeds source buffer.");
       return BLOSC2_ERROR_READ_BUFFER;
     }
   }

--- a/blosc/blosc2.c
+++ b/blosc/blosc2.c
@@ -152,6 +152,22 @@ static int init_threadpool(blosc2_context *context);
 #endif
 static int parallel_blosc(blosc2_context* context);
 
+static inline bool checked_mul_size(size_t a, size_t b, size_t* out) {
+  if (a != 0 && b > SIZE_MAX / a) {
+    return false;
+  }
+  *out = a * b;
+  return true;
+}
+
+static inline bool checked_add_size(size_t a, size_t b, size_t* out) {
+  if (a > SIZE_MAX - b) {
+    return false;
+  }
+  *out = a + b;
+  return true;
+}
+
 /* global variable to change threading backend from Blosc-managed to caller-managed */
 static blosc_threads_callback threads_callback = 0;
 static void *threads_callback_data = 0;
@@ -934,7 +950,7 @@ int fill_codec(blosc2_codec *codec) {
     codec->free = NULL;
   }
   */
- 
+
   return BLOSC2_ERROR_SUCCESS;
 }
 
@@ -1032,7 +1048,7 @@ uint8_t* pipeline_forward(struct thread_context* thread_context, const int32_t b
   uint8_t* filters_meta = context->filters_meta;
   bool memcpyed = context->header_flags & (uint8_t)BLOSC_MEMCPYED;
   bool output_is_disposable = (context->preparams != NULL) ? context->preparams->output_is_disposable : false;
-  
+
   /* Prefilter function */
   if (context->prefilter != NULL) {
     // Create new prefilter parameters for this block (must be private for each thread)
@@ -1738,7 +1754,21 @@ static int blosc_d(
     }
     blosc2_frame_s* frame = (blosc2_frame_s*)context->schunk->frame;
     char* urlpath = frame->urlpath;
-    size_t trailer_offset = BLOSC_EXTENDED_HEADER_LENGTH + context->nblocks * sizeof(int32_t);
+    size_t bstarts_nbytes;
+    size_t trailer_offset;
+    size_t block_csizes_nbytes;
+    size_t trailer_meta_nbytes;
+    size_t lazy_trailer_end;
+    if (srcsize < 0 || context->nblocks < 0 ||
+        !checked_mul_size((size_t)context->nblocks, sizeof(int32_t), &bstarts_nbytes) ||
+        !checked_add_size((size_t)BLOSC_EXTENDED_HEADER_LENGTH, bstarts_nbytes, &trailer_offset) ||
+        !checked_mul_size((size_t)context->nblocks, sizeof(int32_t), &block_csizes_nbytes) ||
+        !checked_add_size(sizeof(int32_t) + sizeof(int64_t), block_csizes_nbytes, &trailer_meta_nbytes) ||
+        !checked_add_size(trailer_offset, trailer_meta_nbytes, &lazy_trailer_end) ||
+        (size_t)srcsize < lazy_trailer_end) {
+      BLOSC_TRACE_ERROR("Lazy VL trailer exceeds source buffer.");
+      return BLOSC2_ERROR_READ_BUFFER;
+    }
     int32_t nchunk;
     int64_t chunk_offset;
     // The nchunk and the offset of the current chunk are in the trailer
@@ -2674,13 +2704,36 @@ static int initialize_context_decompression(blosc2_context* context, blosc_heade
   context->bstarts = (int32_t *) (context->src + context->header_overhead);
   bstarts_end = context->header_overhead;
   if (!context->special_type && !memcpyed) {
+    size_t bstarts_end_tmp;
+    size_t bstarts_nbytes;
+    if (context->nblocks < 0 ||
+        !checked_mul_size((size_t)context->nblocks, sizeof(int32_t), &bstarts_nbytes) ||
+        !checked_add_size((size_t)context->header_overhead, bstarts_nbytes, &bstarts_end_tmp) ||
+        bstarts_end_tmp > (size_t)INT32_MAX) {
+      BLOSC_TRACE_ERROR("Invalid bstarts size in chunk header.");
+      return BLOSC2_ERROR_INVALID_HEADER;
+    }
     /* If chunk is not special or a memcpyed, we do have a bstarts section */
-    bstarts_end = (int32_t)(context->header_overhead + (context->nblocks * sizeof(int32_t)));
+    bstarts_end = (int32_t)bstarts_end_tmp;
   }
 
   if (srcsize < bstarts_end) {
     BLOSC_TRACE_ERROR("`bstarts` exceeds length of source buffer.");
     return BLOSC2_ERROR_READ_BUFFER;
+  }
+
+  if (vlblocks && is_lazy && !context->special_type && !memcpyed) {
+    size_t block_csizes_nbytes;
+    size_t trailer_meta_nbytes;
+    size_t lazy_trailer_end;
+    if (context->srcsize < 0 || context->nblocks < 0 ||
+        !checked_mul_size((size_t)context->nblocks, sizeof(int32_t), &block_csizes_nbytes) ||
+        !checked_add_size(sizeof(int32_t) + sizeof(int64_t), block_csizes_nbytes, &trailer_meta_nbytes) ||
+        !checked_add_size((size_t)bstarts_end, trailer_meta_nbytes, &lazy_trailer_end) ||
+        (size_t)context->srcsize < lazy_trailer_end) {
+      BLOSC_TRACE_ERROR("Lazy VL trailer exceeds source buffer.");
+      return BLOSC2_ERROR_READ_BUFFER;
+    }
   }
   srcsize -= bstarts_end;
 
@@ -5889,7 +5942,7 @@ void blosc2_free_ctx(blosc2_context* context) {
           if (fill_codec(&g_codecs[i]) < 0) {
             BLOSC_TRACE_ERROR("Could not load codec %d.", g_codecs[i].compcode);
             return BLOSC2_ERROR_CODEC_SUPPORT;
-          } 
+          }
         }
         if (g_codecs[i].free == NULL){
           // no free func, codec_params is simple

--- a/tests/test_vlblocks.c
+++ b/tests/test_vlblocks.c
@@ -1050,6 +1050,38 @@ static char *test_lazy_vlchunk_rejects_truncated_trailer(void) {
 }
 
 
+static char *test_vlchunk_rejects_memcpyed_flag(void) {
+  blosc2_cparams cparams = BLOSC2_CPARAMS_DEFAULTS;
+  cparams.typesize = 1;
+  blosc2_context *cctx = blosc2_create_cctx(cparams);
+  mu_assert("ERROR: cannot create cctx", cctx != NULL);
+
+  int32_t destsize = total_nbytes() + BLOSC2_MAX_OVERHEAD + 64;
+  uint8_t *chunk = malloc((size_t)destsize);
+  mu_assert("ERROR: cannot allocate chunk buffer", chunk != NULL);
+
+  int32_t cbytes = blosc2_vlcompress_ctx(cctx, (const void * const *)srcs, srcsizes, 3,
+                                         chunk, destsize);
+  mu_assert("ERROR: cannot create VL-block chunk", cbytes > 0);
+  chunk[BLOSC2_CHUNK_FLAGS] |= (uint8_t)BLOSC_MEMCPYED;
+
+  blosc2_dparams dparams = BLOSC2_DPARAMS_DEFAULTS;
+  blosc2_context *dctx = blosc2_create_dctx(dparams);
+  mu_assert("ERROR: cannot create dctx", dctx != NULL);
+
+  uint8_t *buffer = malloc((size_t)total_nbytes());
+  mu_assert("ERROR: cannot allocate destination buffer", buffer != NULL);
+  int32_t nbytes = blosc2_decompress_ctx(dctx, chunk, cbytes, buffer, total_nbytes());
+  mu_assert("ERROR: VL-block chunks marked memcpyed must be rejected", nbytes < 0);
+
+  free(buffer);
+  blosc2_free_ctx(dctx);
+  blosc2_free_ctx(cctx);
+  free(chunk);
+  return EXIT_SUCCESS;
+}
+
+
 static char *test_lazy_vldecompress_block_ctx(void) {
   const char* urlpath = "test_lazy_vldecomp.b2frame";
   blosc2_schunk* schunk = make_lazy_vl_schunk(urlpath, true);
@@ -1130,6 +1162,7 @@ static char *all_tests(void) {
   mu_run_test(test_lazy_vlchunk_get_nblocks);
   mu_run_test(test_lazy_vlchunk_rejects_huge_nblocks);
   mu_run_test(test_lazy_vlchunk_rejects_truncated_trailer);
+  mu_run_test(test_vlchunk_rejects_memcpyed_flag);
   mu_run_test(test_lazy_vldecompress_block_ctx);
   mu_run_test(test_lazy_vldecompress_block_ctx_sframe);
   mu_run_test(test_lazy_vldecompress_block_ctx_dict_lz4);

--- a/tests/test_vlblocks.c
+++ b/tests/test_vlblocks.c
@@ -1008,6 +1008,48 @@ static char *test_lazy_vlchunk_rejects_huge_nblocks(void) {
 }
 
 
+static char *test_lazy_vlchunk_rejects_truncated_trailer(void) {
+  const char* urlpath = "test_lazy_vl_truncated_trailer.b2frame";
+  blosc2_schunk* schunk = make_lazy_vl_schunk(urlpath, true);
+  mu_assert("ERROR: cannot create lazy VL schunk", schunk != NULL);
+
+  uint8_t* dest = malloc((size_t)total_nbytes());
+  mu_assert("ERROR: cannot allocate destination buffer", dest != NULL);
+
+  for (int64_t nchunk = 0; nchunk < schunk->nchunks; ++nchunk) {
+    uint8_t* lazy_chunk = NULL;
+    bool needs_free = false;
+    int cbytes = blosc2_schunk_get_lazychunk(schunk, nchunk, &lazy_chunk, &needs_free);
+    mu_assert("ERROR: blosc2_schunk_get_lazychunk failed", cbytes > 0);
+
+    int32_t nblocks = -1;
+    int rc = blosc2_vlchunk_get_nblocks(lazy_chunk, cbytes, &nblocks);
+    mu_assert("ERROR: cannot inspect lazy VL nblocks", rc == 0 && nblocks > 0);
+
+    int64_t trailer_offset = BLOSC_EXTENDED_HEADER_LENGTH + (int64_t)nblocks * (int64_t)sizeof(int32_t);
+    int64_t trailer_nbytes = (int64_t)sizeof(int32_t) + (int64_t)sizeof(int64_t) +
+                             (int64_t)nblocks * (int64_t)sizeof(int32_t);
+    int64_t truncated_srcsize = trailer_offset + trailer_nbytes - 1;
+    mu_assert("ERROR: malformed srcsize should be positive", truncated_srcsize > 0);
+    mu_assert("ERROR: malformed srcsize should be smaller than cbytes", truncated_srcsize < cbytes);
+
+    memset(dest, 0, (size_t)total_nbytes());
+    rc = blosc2_decompress_ctx(schunk->dctx, lazy_chunk, (int32_t)truncated_srcsize,
+                               dest, total_nbytes());
+    mu_assert("ERROR: truncated lazy VL trailer must be rejected", rc < 0);
+
+    if (needs_free) {
+      free(lazy_chunk);
+    }
+  }
+
+  free(dest);
+  blosc2_schunk_free(schunk);
+  blosc2_remove_urlpath(urlpath);
+  return EXIT_SUCCESS;
+}
+
+
 static char *test_lazy_vldecompress_block_ctx(void) {
   const char* urlpath = "test_lazy_vldecomp.b2frame";
   blosc2_schunk* schunk = make_lazy_vl_schunk(urlpath, true);
@@ -1087,6 +1129,7 @@ static char *all_tests(void) {
   mu_run_test(test_vlblocks_mt_roundtrip);
   mu_run_test(test_lazy_vlchunk_get_nblocks);
   mu_run_test(test_lazy_vlchunk_rejects_huge_nblocks);
+  mu_run_test(test_lazy_vlchunk_rejects_truncated_trailer);
   mu_run_test(test_lazy_vldecompress_block_ctx);
   mu_run_test(test_lazy_vldecompress_block_ctx_sframe);
   mu_run_test(test_lazy_vldecompress_block_ctx_dict_lz4);


### PR DESCRIPTION
this PR fixes a memory safety issue in the lazy variable-length chunk decompression path in blosc2.

This patch introduces:

- Checked size arithmetic to prevent overflow in trailer size calculations
- Explicit validation ensuring trailer accesses remain within `srcsize`
- Early validation during decompression context initialization to reject malformed inputs before block decoding begins