### PR TITLE
Harden lazy VL trailer parsing and reject malformed lazy block metadata

### DIFF
--- a/blosc/blosc2.c
+++ b/blosc/blosc2.c
@@ -1792,7 +1792,7 @@ static int blosc_d(
       BLOSC_TRACE_ERROR("Invalid lazy block size in trailer.");
       return BLOSC2_ERROR_INVALID_HEADER;
     }
-    if (vlblocks && block_csize < (int32_t)sizeof(int32_t)) {
+    if (vlblocks && block_csize <= (int32_t)sizeof(int32_t)) {
       BLOSC_TRACE_ERROR("Lazy VL block compressed size is too small.");
       return BLOSC2_ERROR_INVALID_HEADER;
     }
@@ -4057,7 +4057,7 @@ static int decompress_single_vlblock(blosc2_context* context, int32_t nblock,
     memcpy(&nchunk_lazy, context->src + trailer_offset, sizeof(nchunk_lazy));
     memcpy(&chunk_offset, context->src + trailer_offset + (int32_t)sizeof(int32_t), sizeof(chunk_offset));
     int32_t block_csize = *(const int32_t*)(context->src + block_csize_pos);
-  if (block_csize < (int32_t)sizeof(int32_t)) {
+    if (block_csize < (int32_t)sizeof(int32_t)) {
       BLOSC_TRACE_ERROR("Lazy VL block compressed size is too small.");
       return BLOSC2_ERROR_INVALID_HEADER;
     }

--- a/blosc/blosc2.c
+++ b/blosc/blosc2.c
@@ -1783,14 +1783,18 @@ static int blosc_d(
     // Get the csize of the nblock
     if (nblock < 0 || nblock >= context->nblocks) {
       BLOSC_TRACE_ERROR("Invalid block index in lazy trailer.");
-      return BLOSC2_ERROR_DATA;
+      return BLOSC2_ERROR_INVALID_HEADER;
     }
     int32_t *block_csizes = (int32_t *)(src + trailer_offset + sizeof(int32_t) + sizeof(int64_t));
     int32_t block_csize = block_csizes[nblock];
     int32_t max_lazy_block_csize = context->blocksize + context->typesize * (signed)sizeof(int32_t);
     if (block_csize <= 0 || block_csize > max_lazy_block_csize) {
       BLOSC_TRACE_ERROR("Invalid lazy block size in trailer.");
-      return BLOSC2_ERROR_DATA;
+      return BLOSC2_ERROR_INVALID_HEADER;
+    }
+    if (vlblocks && block_csize < (int32_t)sizeof(int32_t)) {
+      BLOSC_TRACE_ERROR("Lazy VL block compressed size is too small.");
+      return BLOSC2_ERROR_INVALID_HEADER;
     }
     // Read the lazy block on disk
     void* fp = NULL;
@@ -1806,13 +1810,34 @@ static int blosc_d(
       fp = sframe_open_chunk(frame->urlpath, nchunk, "rb", context->schunk->storage->io);
       BLOSC_ERROR_NULL(fp, BLOSC2_ERROR_FILE_OPEN);
       // The offset of the block is src_offset
+      if (src_offset < 0) {
+        io_cb->close(fp);
+        BLOSC_TRACE_ERROR("Lazy block offset cannot be negative.");
+        return BLOSC2_ERROR_INVALID_HEADER;
+      }
       io_pos = src_offset;
     }
     else {
       fp = io_cb->open(urlpath, "rb", context->schunk->storage->io->params);
       BLOSC_ERROR_NULL(fp, BLOSC2_ERROR_FILE_OPEN);
       // The offset of the block is src_offset
-      io_pos = frame->file_offset + chunk_offset + src_offset;
+      if (src_offset < 0) {
+        io_cb->close(fp);
+        BLOSC_TRACE_ERROR("Lazy block offset cannot be negative.");
+        return BLOSC2_ERROR_INVALID_HEADER;
+      }
+      if (frame->file_offset > INT64_MAX - chunk_offset) {
+        io_cb->close(fp);
+        BLOSC_TRACE_ERROR("Lazy chunk offset overflows file position.");
+        return BLOSC2_ERROR_INVALID_HEADER;
+      }
+      io_pos = frame->file_offset + chunk_offset;
+      if (io_pos > INT64_MAX - src_offset) {
+        io_cb->close(fp);
+        BLOSC_TRACE_ERROR("Lazy block offset overflows file position.");
+        return BLOSC2_ERROR_INVALID_HEADER;
+      }
+      io_pos += src_offset;
     }
     // We can make use of tmp3 because it will be used after src is not needed anymore
     int64_t rbytes = io_cb->read((void**)&tmp3, 1, block_csize, io_pos, fp);
@@ -3993,12 +4018,28 @@ static int decompress_single_vlblock(blosc2_context* context, int32_t nblock,
     }
 
     // Lazy chunk trailer: [nchunk int32 | chunk_offset int64 | block_csizes int32*N]
-    int32_t trailer_offset = BLOSC_EXTENDED_HEADER_LENGTH +
-                             context->nblocks * (int32_t)sizeof(int32_t);
+    int64_t trailer_offset = (int64_t)BLOSC_EXTENDED_HEADER_LENGTH +
+                             (int64_t)context->nblocks * (int64_t)sizeof(int32_t);
+    int64_t trailer_min_end = trailer_offset + (int64_t)sizeof(int32_t) + (int64_t)sizeof(int64_t);
+    int64_t block_csize_pos = trailer_min_end + ((int64_t)nblock * (int64_t)sizeof(int32_t));
+    if (trailer_offset < 0 || block_csize_pos < 0 ||
+        (block_csize_pos + (int64_t)sizeof(int32_t)) > context->srcsize) {
+      BLOSC_TRACE_ERROR("Malformed lazy trailer exceeds chunk bounds.");
+      return BLOSC2_ERROR_INVALID_HEADER;
+    }
     int32_t nchunk_lazy = *(const int32_t*)(context->src + trailer_offset);
     int64_t chunk_offset = *(const int64_t*)(context->src + trailer_offset +
                                              (int32_t)sizeof(int32_t));
+    int32_t block_csize = *(const int32_t*)(context->src + block_csize_pos);
+    if (block_csize < (int32_t)sizeof(int32_t)) {
+      BLOSC_TRACE_ERROR("Lazy VL block compressed size is too small.");
+      return BLOSC2_ERROR_INVALID_HEADER;
+    }
     int32_t bstart = sw32_(context->bstarts + nblock);
+    if (bstart < 0) {
+      BLOSC_TRACE_ERROR("Lazy VL block offset cannot be negative.");
+      return BLOSC2_ERROR_INVALID_HEADER;
+    }
 
     void* fp = NULL;
     int64_t io_pos;
@@ -4008,7 +4049,22 @@ static int decompress_single_vlblock(blosc2_context* context, int32_t nblock,
     }
     else {
       fp = io_cb->open(frame->urlpath, "rb", context->schunk->storage->io->params);
-      io_pos = frame->file_offset + chunk_offset + bstart;
+      if (fp == NULL) {
+        BLOSC_TRACE_ERROR("Cannot open frame file for lazy VL block size peek.");
+        return BLOSC2_ERROR_FILE_OPEN;
+      }
+      if (frame->file_offset > INT64_MAX - chunk_offset) {
+        BLOSC_TRACE_ERROR("Lazy chunk offset overflows file position.");
+        io_cb->close(fp);
+        return BLOSC2_ERROR_INVALID_HEADER;
+      }
+      io_pos = frame->file_offset + chunk_offset;
+      if (io_pos > INT64_MAX - bstart) {
+        BLOSC_TRACE_ERROR("Lazy block offset overflows file position.");
+        io_cb->close(fp);
+        return BLOSC2_ERROR_INVALID_HEADER;
+      }
+      io_pos += bstart;
     }
     if (fp == NULL) {
       BLOSC_TRACE_ERROR("Cannot open frame file for lazy VL block size peek.");

--- a/blosc/blosc2.c
+++ b/blosc/blosc2.c
@@ -1792,7 +1792,7 @@ static int blosc_d(
       BLOSC_TRACE_ERROR("Invalid lazy block size in trailer.");
       return BLOSC2_ERROR_INVALID_HEADER;
     }
-    if (vlblocks && block_csize <= (int32_t)sizeof(int32_t)) {
+    if (vlblocks && block_csize < (int32_t)sizeof(int32_t)) {
       BLOSC_TRACE_ERROR("Lazy VL block compressed size is too small.");
       return BLOSC2_ERROR_INVALID_HEADER;
     }
@@ -4057,7 +4057,7 @@ static int decompress_single_vlblock(blosc2_context* context, int32_t nblock,
     memcpy(&nchunk_lazy, context->src + trailer_offset, sizeof(nchunk_lazy));
     memcpy(&chunk_offset, context->src + trailer_offset + (int32_t)sizeof(int32_t), sizeof(chunk_offset));
     int32_t block_csize = *(const int32_t*)(context->src + block_csize_pos);
-    if (block_csize <= (int32_t)sizeof(int32_t)) {
+  if (block_csize < (int32_t)sizeof(int32_t)) {
       BLOSC_TRACE_ERROR("Lazy VL block compressed size is too small.");
       return BLOSC2_ERROR_INVALID_HEADER;
     }

--- a/blosc/blosc2.c
+++ b/blosc/blosc2.c
@@ -1778,8 +1778,8 @@ static int blosc_d(
     int32_t nchunk;
     int64_t chunk_offset;
     // The nchunk and the offset of the current chunk are in the trailer
-    nchunk = *(int32_t*)(src + trailer_offset);
-    chunk_offset = *(int64_t*)(src + trailer_offset + sizeof(int32_t));
+    memcpy(&nchunk, src + trailer_offset, sizeof(nchunk));
+    memcpy(&chunk_offset, src + trailer_offset + sizeof(int32_t), sizeof(chunk_offset));
     // Get the csize of the nblock
     if (nblock < 0 || nblock >= context->nblocks) {
       BLOSC_TRACE_ERROR("Invalid block index in lazy trailer.");
@@ -1792,7 +1792,7 @@ static int blosc_d(
       BLOSC_TRACE_ERROR("Invalid lazy block size in trailer.");
       return BLOSC2_ERROR_INVALID_HEADER;
     }
-    if (vlblocks && block_csize < (int32_t)sizeof(int32_t)) {
+    if (vlblocks && block_csize <= (int32_t)sizeof(int32_t)) {
       BLOSC_TRACE_ERROR("Lazy VL block compressed size is too small.");
       return BLOSC2_ERROR_INVALID_HEADER;
     }
@@ -1824,6 +1824,11 @@ static int blosc_d(
       if (src_offset < 0) {
         io_cb->close(fp);
         BLOSC_TRACE_ERROR("Lazy block offset cannot be negative.");
+        return BLOSC2_ERROR_INVALID_HEADER;
+      }
+      if (chunk_offset < 0) {
+        io_cb->close(fp);
+        BLOSC_TRACE_ERROR("Lazy chunk offset cannot be negative.");
         return BLOSC2_ERROR_INVALID_HEADER;
       }
       if (frame->file_offset > INT64_MAX - chunk_offset) {
@@ -2579,9 +2584,10 @@ static int read_lazy_chunk_bytes(blosc2_context* context, int32_t offset, uint8_
 
   int32_t trailer_offset = BLOSC_EXTENDED_HEADER_LENGTH +
                            context->nblocks * (int32_t)sizeof(int32_t);
-  int32_t nchunk_lazy = *(const int32_t*)(context->src + trailer_offset);
-  int64_t chunk_offset = *(const int64_t*)(context->src + trailer_offset +
-                                           (int32_t)sizeof(int32_t));
+  int32_t nchunk_lazy;
+  int64_t chunk_offset;
+  memcpy(&nchunk_lazy, context->src + trailer_offset, sizeof(nchunk_lazy));
+  memcpy(&chunk_offset, context->src + trailer_offset + (int32_t)sizeof(int32_t), sizeof(chunk_offset));
 
   void* fp = NULL;
   int64_t io_pos;
@@ -2590,8 +2596,27 @@ static int read_lazy_chunk_bytes(blosc2_context* context, int32_t offset, uint8_
     io_pos = offset;
   }
   else {
+    if (chunk_offset < 0 || offset < 0) {
+      BLOSC_TRACE_ERROR("Lazy chunk offset cannot be negative.");
+      return BLOSC2_ERROR_INVALID_HEADER;
+    }
     fp = io_cb->open(frame->urlpath, "rb", context->schunk->storage->io->params);
-    io_pos = frame->file_offset + chunk_offset + offset;
+    if (frame->file_offset > INT64_MAX - chunk_offset) {
+      BLOSC_TRACE_ERROR("Lazy chunk offset overflows file position.");
+      if (fp != NULL) {
+        io_cb->close(fp);
+      }
+      return BLOSC2_ERROR_INVALID_HEADER;
+    }
+    io_pos = frame->file_offset + chunk_offset;
+    if (io_pos > INT64_MAX - offset) {
+      BLOSC_TRACE_ERROR("Lazy block offset overflows file position.");
+      if (fp != NULL) {
+        io_cb->close(fp);
+      }
+      return BLOSC2_ERROR_INVALID_HEADER;
+    }
+    io_pos += offset;
   }
   if (fp == NULL) {
     BLOSC_TRACE_ERROR("%s", open_error);
@@ -4027,11 +4052,12 @@ static int decompress_single_vlblock(blosc2_context* context, int32_t nblock,
       BLOSC_TRACE_ERROR("Malformed lazy trailer exceeds chunk bounds.");
       return BLOSC2_ERROR_INVALID_HEADER;
     }
-    int32_t nchunk_lazy = *(const int32_t*)(context->src + trailer_offset);
-    int64_t chunk_offset = *(const int64_t*)(context->src + trailer_offset +
-                                             (int32_t)sizeof(int32_t));
+    int32_t nchunk_lazy;
+    int64_t chunk_offset;
+    memcpy(&nchunk_lazy, context->src + trailer_offset, sizeof(nchunk_lazy));
+    memcpy(&chunk_offset, context->src + trailer_offset + (int32_t)sizeof(int32_t), sizeof(chunk_offset));
     int32_t block_csize = *(const int32_t*)(context->src + block_csize_pos);
-    if (block_csize < (int32_t)sizeof(int32_t)) {
+    if (block_csize <= (int32_t)sizeof(int32_t)) {
       BLOSC_TRACE_ERROR("Lazy VL block compressed size is too small.");
       return BLOSC2_ERROR_INVALID_HEADER;
     }
@@ -4052,6 +4078,11 @@ static int decompress_single_vlblock(blosc2_context* context, int32_t nblock,
       if (fp == NULL) {
         BLOSC_TRACE_ERROR("Cannot open frame file for lazy VL block size peek.");
         return BLOSC2_ERROR_FILE_OPEN;
+      }
+      if (chunk_offset < 0) {
+        BLOSC_TRACE_ERROR("Lazy chunk offset cannot be negative.");
+        io_cb->close(fp);
+        return BLOSC2_ERROR_INVALID_HEADER;
       }
       if (frame->file_offset > INT64_MAX - chunk_offset) {
         BLOSC_TRACE_ERROR("Lazy chunk offset overflows file position.");

--- a/tests/test_vlblocks.c
+++ b/tests/test_vlblocks.c
@@ -1114,6 +1114,44 @@ static char *test_lazy_vldecompress_block_ctx(void) {
   return EXIT_SUCCESS;
 }
 
+static char *test_lazy_vldecompress_block_ctx_rejects_tiny_block_csize(void) {
+  const char* urlpath = "test_lazy_vldecomp_corrupt_csize.b2frame";
+  blosc2_schunk* schunk = make_lazy_vl_schunk(urlpath, true);
+  mu_assert("ERROR: cannot create lazy VL schunk", schunk != NULL);
+
+  blosc2_context* dctx = schunk->dctx;
+
+  uint8_t* lazy_chunk = NULL;
+  bool needs_free = false;
+  int cbytes = blosc2_schunk_get_lazychunk(schunk, 0, &lazy_chunk, &needs_free);
+  mu_assert("ERROR: blosc2_schunk_get_lazychunk failed", cbytes > 0);
+
+  int32_t nblocks = -1;
+  int rc = blosc2_vlchunk_get_nblocks(lazy_chunk, cbytes, &nblocks);
+  mu_assert("ERROR: cannot read lazy chunk nblocks", rc == 0);
+  mu_assert("ERROR: expected positive number of VL blocks", nblocks > 0);
+
+  int32_t trailer_offset = BLOSC_EXTENDED_HEADER_LENGTH + nblocks * (int32_t)sizeof(int32_t);
+  int32_t block_csize0_offset = trailer_offset + (int32_t)sizeof(int32_t) + (int32_t)sizeof(int64_t);
+  mu_assert("ERROR: malformed test chunk offsets", block_csize0_offset + (int32_t)sizeof(int32_t) <= cbytes);
+
+  /* Corrupt first lazy block csize to 1 byte, which cannot hold VL block metadata. */
+  put_le32(lazy_chunk + block_csize0_offset, 1U);
+
+  uint8_t* blk = NULL;
+  int32_t blksize = -1;
+  rc = blosc2_vldecompress_block_ctx(dctx, lazy_chunk, cbytes, 0, &blk, &blksize);
+  mu_assert("ERROR: malformed lazy VL trailer must be rejected",
+            rc == BLOSC2_ERROR_INVALID_HEADER);
+
+  if (needs_free) {
+    free(lazy_chunk);
+  }
+  blosc2_schunk_free(schunk);
+  blosc2_remove_urlpath(urlpath);
+  return EXIT_SUCCESS;
+}
+
 
 static char *test_lazy_vldecompress_block_ctx_sframe(void) {
   const char* urlpath = "test_lazy_vldecomp_s.b2frame";
@@ -1164,6 +1202,7 @@ static char *all_tests(void) {
   mu_run_test(test_lazy_vlchunk_rejects_truncated_trailer);
   mu_run_test(test_vlchunk_rejects_memcpyed_flag);
   mu_run_test(test_lazy_vldecompress_block_ctx);
+  mu_run_test(test_lazy_vldecompress_block_ctx_rejects_tiny_block_csize);
   mu_run_test(test_lazy_vldecompress_block_ctx_sframe);
   mu_run_test(test_lazy_vldecompress_block_ctx_dict_lz4);
 #ifdef HAVE_ZSTD

--- a/tests/test_vlblocks.c
+++ b/tests/test_vlblocks.c
@@ -1136,7 +1136,8 @@ static char *test_lazy_vldecompress_block_ctx_rejects_tiny_block_csize(void) {
   mu_assert("ERROR: malformed test chunk offsets", block_csize0_offset + (int32_t)sizeof(int32_t) <= cbytes);
 
   /* Corrupt first lazy block csize to 1 byte, which cannot hold VL block metadata. */
-  put_le32(lazy_chunk + block_csize0_offset, 1U);
+  int32_t corrupt_block_csize = 1;
+  memcpy(lazy_chunk + block_csize0_offset, &corrupt_block_csize, sizeof(corrupt_block_csize));
 
   uint8_t* blk = NULL;
   int32_t blksize = -1;

--- a/tests/test_vlblocks.c
+++ b/tests/test_vlblocks.c
@@ -1136,8 +1136,7 @@ static char *test_lazy_vldecompress_block_ctx_rejects_tiny_block_csize(void) {
   mu_assert("ERROR: malformed test chunk offsets", block_csize0_offset + (int32_t)sizeof(int32_t) <= cbytes);
 
   /* Corrupt first lazy block csize to 1 byte, which cannot hold VL block metadata. */
-  int32_t corrupt_block_csize = 1;
-  memcpy(lazy_chunk + block_csize0_offset, &corrupt_block_csize, sizeof(corrupt_block_csize));
+  put_le32(lazy_chunk + block_csize0_offset, 1U);
 
   uint8_t* blk = NULL;
   int32_t blksize = -1;


### PR DESCRIPTION
This PR hardens lazy chunk decompression by validating trailer-derived metadata before it is used in VL-block paths. It prevents out-of-bounds reads and invalid file offset computations caused by malformed lazy chunk metadata.

-Ensures trailer layout is within srcsize before accessing metadata

-Rejects non-positive sizes

-Enforces minimum size for VL blocks

-Rejects negative block offsets

-Adds checked arithmetic for:

- `file_offset + chunk_offset`
- ` + block_offset`

-Applies the same validation to:
- blosc_d lazy path
- decompress_single_vlblock