### PR TITLE
New shared thread pool (previous alternate)

### DIFF
--- a/blosc/blosc2.c
+++ b/blosc/blosc2.c
@@ -107,6 +107,7 @@ struct blosc_job_group {
   int32_t next_output_block;
   int32_t blocks_completed;
   int32_t active_workers;
+  int32_t pending_workers;
   int32_t output_bytes;
   int giveup_code;
   int dref_not_init;
@@ -4522,8 +4523,10 @@ job_done:
         job->output_bytes += context->header_overhead;
       }
     }
-    job->completed = true;
-    blosc2_pthread_cond_broadcast(&job->completion_cv);
+    if (context->thread_backend == BLOSC_BACKEND_CALLBACK) {
+      job->completed = true;
+      blosc2_pthread_cond_broadcast(&job->completion_cv);
+    }
   }
   blosc2_pthread_mutex_unlock(&job->mutex);
 }
@@ -4590,6 +4593,13 @@ static void* shared_pool_worker(void* arg) {
       blosc2_pthread_cond_broadcast(&pool->idle_cv);
     }
     blosc2_pthread_mutex_unlock(&pool->mutex);
+
+    blosc2_pthread_mutex_lock(&job->mutex);
+    if (--job->pending_workers == 0) {
+      job->completed = true;
+      blosc2_pthread_cond_broadcast(&job->completion_cv);
+    }
+    blosc2_pthread_mutex_unlock(&job->mutex);
   }
 
   destroy_thread_context(thcontext);
@@ -4765,6 +4775,7 @@ static int parallel_blosc(blosc2_context* context) {
   if (context->thread_backend == BLOSC_BACKEND_CALLBACK) {
     blosc2_pthread_mutex_lock(&job.mutex);
     job.active_workers = context->nthreads;
+    job.pending_workers = 0;
     blosc2_pthread_mutex_unlock(&job.mutex);
     threads_callback(threads_callback_data, t_blosc_do_job,
                      context->nthreads, sizeof(struct thread_context), (void*) context->thread_contexts);
@@ -4815,6 +4826,7 @@ static int parallel_blosc(blosc2_context* context) {
     /* Set active_workers to the actual number enqueued */
     blosc2_pthread_mutex_lock(&job.mutex);
     job.active_workers = enqueued;
+    job.pending_workers = enqueued;
     blosc2_pthread_mutex_unlock(&job.mutex);
     blosc2_pthread_cond_broadcast(&pool->work_cv);
     blosc2_pthread_mutex_unlock(&pool->mutex);

--- a/blosc/blosc2.c
+++ b/blosc/blosc2.c
@@ -101,68 +101,58 @@ int g_ntuners = 0;
 
 static int g_tuner = BLOSC_STUNE;
 
+struct blosc_job_group {
+  blosc2_context *context;
+  int32_t next_block;
+  int32_t next_output_block;
+  int32_t blocks_completed;
+  int32_t active_workers;
+  int32_t output_bytes;
+  int giveup_code;
+  int dref_not_init;
+  bool static_schedule;
+  bool completed;
+  blosc2_pthread_mutex_t mutex;
+  blosc2_pthread_mutex_t delta_mutex;
+  blosc2_pthread_cond_t delta_cv;
+  blosc2_pthread_cond_t completion_cv;
+};
+
+struct blosc_job_queue_entry {
+  struct blosc_job_group *job;
+  int32_t logical_tid;
+  struct blosc_job_queue_entry *next;
+};
+
+struct blosc_shared_pool {
+  int16_t nthreads;
+  int16_t shutdown;
+  int32_t context_refs;
+  int32_t active_jobs;
+  blosc2_pthread_t *threads;
+  struct thread_context *thread_contexts;
+  blosc2_pthread_mutex_t mutex;
+  blosc2_pthread_cond_t work_cv;
+  blosc2_pthread_cond_t idle_cv;
+  struct blosc_job_queue_entry *job_queue_head;
+  struct blosc_job_queue_entry *job_queue_tail;
+  struct blosc_shared_pool *next;
+#if !defined(_WIN32)
+  pthread_attr_t ct_attr;
+#endif
+};
+
 // Forward declarations
-int init_threadpool(blosc2_context *context);
-int release_threadpool(blosc2_context *context);
-
-/* Macros for synchronization */
-
-/* Wait until all threads are initialized */
-#ifdef BLOSC_POSIX_BARRIERS
-#define WAIT_INIT(RET_VAL, CONTEXT_PTR)                                \
-  do {                                                                 \
-    rc = pthread_barrier_wait(&(CONTEXT_PTR)->barr_init);              \
-    if (rc != 0 && rc != PTHREAD_BARRIER_SERIAL_THREAD) {              \
-      BLOSC_TRACE_ERROR("Could not wait on barrier (init): %d", rc);   \
-      return((RET_VAL));                                               \
-    }                                                                  \
-  } while (0)
-#else
-#define WAIT_INIT(RET_VAL, CONTEXT_PTR)                                \
-  do {                                                                 \
-    blosc2_pthread_mutex_lock(&(CONTEXT_PTR)->count_threads_mutex);           \
-    if ((CONTEXT_PTR)->count_threads < (CONTEXT_PTR)->nthreads) {      \
-      (CONTEXT_PTR)->count_threads++;                                  \
-      blosc2_pthread_cond_wait(&(CONTEXT_PTR)->count_threads_cv,              \
-                        &(CONTEXT_PTR)->count_threads_mutex);          \
-    }                                                                  \
-    else {                                                             \
-      blosc2_pthread_cond_broadcast(&(CONTEXT_PTR)->count_threads_cv);        \
-    }                                                                  \
-    blosc2_pthread_mutex_unlock(&(CONTEXT_PTR)->count_threads_mutex);         \
-  } while (0)
-#endif
-
-/* Wait for all threads to finish */
-#ifdef BLOSC_POSIX_BARRIERS
-#define WAIT_FINISH(RET_VAL, CONTEXT_PTR)                              \
-  do {                                                                 \
-    rc = pthread_barrier_wait(&(CONTEXT_PTR)->barr_finish);            \
-    if (rc != 0 && rc != PTHREAD_BARRIER_SERIAL_THREAD) {              \
-      BLOSC_TRACE_ERROR("Could not wait on barrier (finish)");         \
-      return((RET_VAL));                                               \
-    }                                                                  \
-  } while (0)
-#else
-#define WAIT_FINISH(RET_VAL, CONTEXT_PTR)                              \
-  do {                                                                 \
-    blosc2_pthread_mutex_lock(&(CONTEXT_PTR)->count_threads_mutex);           \
-    if ((CONTEXT_PTR)->count_threads > 0) {                            \
-      (CONTEXT_PTR)->count_threads--;                                  \
-      blosc2_pthread_cond_wait(&(CONTEXT_PTR)->count_threads_cv,              \
-                        &(CONTEXT_PTR)->count_threads_mutex);          \
-    }                                                                  \
-    else {                                                             \
-      blosc2_pthread_cond_broadcast(&(CONTEXT_PTR)->count_threads_cv);        \
-    }                                                                  \
-    blosc2_pthread_mutex_unlock(&(CONTEXT_PTR)->count_threads_mutex);         \
-  } while (0)
-#endif
-
+static int init_callback_threads(blosc2_context *context);
+static int release_thread_backend(blosc2_context *context);
+static int attach_shared_pool(blosc2_context *context);
+static int parallel_blosc(blosc2_context* context);
 
 /* global variable to change threading backend from Blosc-managed to caller-managed */
 static blosc_threads_callback threads_callback = 0;
 static void *threads_callback_data = 0;
+static blosc2_pthread_mutex_t pool_registry_mutex;
+static struct blosc_shared_pool *shared_pools = NULL;
 
 
 /* non-threadsafe function should be called before any other Blosc function in
@@ -1479,18 +1469,22 @@ int pipeline_backward(struct thread_context* thread_context, const int32_t bsize
             /* Serial mode */
             delta_decoder(dest, offset, bsize, typesize, _dest);
           } else {
+            struct blosc_job_group *job = context->job;
+            blosc2_pthread_mutex_t *delta_mutex = job != NULL ? &job->delta_mutex : &context->delta_mutex;
+            blosc2_pthread_cond_t *delta_cv = job != NULL ? &job->delta_cv : &context->delta_cv;
+            int *dref_not_init = job != NULL ? &job->dref_not_init : &context->dref_not_init;
             /* Force the thread in charge of the block 0 to go first */
-            blosc2_pthread_mutex_lock(&context->delta_mutex);
-            if (context->dref_not_init) {
+            blosc2_pthread_mutex_lock(delta_mutex);
+            if (*dref_not_init) {
               if (offset != 0) {
-                blosc2_pthread_cond_wait(&context->delta_cv, &context->delta_mutex);
+                blosc2_pthread_cond_wait(delta_cv, delta_mutex);
               } else {
                 delta_decoder(dest, offset, bsize, typesize, _dest);
-                context->dref_not_init = 0;
-                blosc2_pthread_cond_broadcast(&context->delta_cv);
+                *dref_not_init = 0;
+                blosc2_pthread_cond_broadcast(delta_cv);
               }
             }
-            blosc2_pthread_mutex_unlock(&context->delta_mutex);
+            blosc2_pthread_mutex_unlock(delta_mutex);
             if (offset != 0) {
               delta_decoder(dest, offset, bsize, typesize, _dest);
             }
@@ -2151,52 +2145,25 @@ static int serial_blosc(struct thread_context* thread_context) {
 
 static void t_blosc_do_job(void *ctxt);
 
-/* Threaded version for compression/decompression */
-static int parallel_blosc(blosc2_context* context) {
-#ifdef BLOSC_POSIX_BARRIERS
-  int rc;
-#endif
-  /* Set sentinels */
-  context->thread_giveup_code = 1;
-  context->thread_nblock = -1;
-
-  if (threads_callback) {
-    threads_callback(threads_callback_data, t_blosc_do_job,
-                     context->nthreads, sizeof(struct thread_context), (void*) context->thread_contexts);
-  }
-  else {
-    /* Synchronization point for all threads (wait for initialization) */
-    WAIT_INIT(-1, context);
-
-    /* Synchronization point for all threads (wait for finalization) */
-    WAIT_FINISH(-1, context);
-  }
-
-  if (context->thread_giveup_code <= 0) {
-    /* Compression/decompression gave up.  Return error code. */
-    return context->thread_giveup_code;
-  }
-
-  /* Return the total bytes (de-)compressed in threads */
-  return (int)context->output_bytes;
-}
-
 /* initialize a thread_context that has already been allocated */
 static int init_thread_context(struct thread_context* thread_context, blosc2_context* context, int32_t tid)
 {
   int32_t ebsize;
 
   thread_context->parent_context = context;
+  thread_context->owner_pool = NULL;
   thread_context->tid = tid;
 
-  ebsize = context->blocksize + context->typesize * (signed)sizeof(int32_t);
+  int32_t blocksize = context != NULL ? context->blocksize : 0;
+  int32_t typesize = context != NULL ? context->typesize : 0;
+  ebsize = blocksize + typesize * (signed)sizeof(int32_t);
   thread_context->tmp_nbytes = (size_t)4 * ebsize;
   thread_context->tmp = my_malloc(thread_context->tmp_nbytes);
   BLOSC_ERROR_NULL(thread_context->tmp, BLOSC2_ERROR_MEMORY_ALLOC);
   thread_context->tmp2 = thread_context->tmp + ebsize;
   thread_context->tmp3 = thread_context->tmp2 + ebsize;
   thread_context->tmp4 = thread_context->tmp3 + ebsize;
-  thread_context->tmp_blocksize = context->blocksize;
+  thread_context->tmp_blocksize = blocksize;
   thread_context->zfp_cell_nitems = 0;
   thread_context->zfp_cell_start = 0;
   #if defined(HAVE_ZSTD)
@@ -2274,13 +2241,23 @@ int check_nthreads(blosc2_context* context) {
   }
 
   if (context->new_nthreads != context->nthreads) {
-    if (context->nthreads > 1) {
-      release_threadpool(context);
-    }
+    release_thread_backend(context);
     context->nthreads = context->new_nthreads;
   }
-  if (context->new_nthreads > 1 && context->threads_started == 0) {
-    init_threadpool(context);
+  if (context->nthreads > 1 && context->threads_started == 0) {
+    int rc;
+    if (threads_callback) {
+      rc = init_callback_threads(context);
+    }
+    else {
+      rc = attach_shared_pool(context);
+    }
+    if (rc < 0) {
+      return rc;
+    }
+  }
+  if (context->nthreads <= 1) {
+    context->thread_backend = BLOSC_BACKEND_SERIAL;
   }
 
   return context->nthreads;
@@ -2345,7 +2322,6 @@ static int initialize_context_compression(
   context->compcode = compressor;
   context->nthreads = nthreads;
   context->new_nthreads = new_nthreads;
-  context->end_threads = 0;
   context->clevel = clevel;
   context->schunk = schunk;
   context->tuner_params = tuner_params;
@@ -2618,7 +2594,6 @@ static int initialize_context_decompression(blosc2_context* context, blosc_heade
   context->dest = (uint8_t*)dest;
   context->destsize = destsize;
   context->output_bytes = 0;
-  context->end_threads = 0;
   context->vlblock_sources = NULL;
   context->vlblock_dests = NULL;
   if (context->blocknbytes != NULL) {
@@ -4348,19 +4323,45 @@ int blosc2_getitem_ctx(blosc2_context* context, const void* src, int32_t srcsize
   return result;
 }
 
+static int ensure_thread_context_capacity(struct thread_context* thread_context, blosc2_context* context) {
+  int32_t blocksize = context->blocksize;
+  int32_t ebsize = blocksize + context->typesize * (int32_t)sizeof(int32_t);
+
+  if (blocksize <= thread_context->tmp_blocksize) {
+    return 0;
+  }
+
+  my_free(thread_context->tmp);
+  thread_context->tmp_nbytes = (size_t)4 * ebsize;
+  thread_context->tmp = my_malloc(thread_context->tmp_nbytes);
+  BLOSC_ERROR_NULL(thread_context->tmp, BLOSC2_ERROR_MEMORY_ALLOC);
+  thread_context->tmp2 = thread_context->tmp + ebsize;
+  thread_context->tmp3 = thread_context->tmp2 + ebsize;
+  thread_context->tmp4 = thread_context->tmp3 + ebsize;
+  thread_context->tmp_blocksize = blocksize;
+  return 0;
+}
+
+static int32_t claim_job_block(struct blosc_job_group *job) {
+  int32_t nblock_;
+  blosc2_pthread_mutex_lock(&job->mutex);
+  nblock_ = ++job->next_block;
+  blosc2_pthread_mutex_unlock(&job->mutex);
+  return nblock_;
+}
+
 /* execute single compression/decompression job for a single thread_context */
-static void t_blosc_do_job(void *ctxt)
-{
+static void t_blosc_do_job(void *ctxt) {
   struct thread_context* thcontext = (struct thread_context*)ctxt;
   blosc2_context* context = thcontext->parent_context;
+  struct blosc_job_group* job = context->job;
   int32_t cbytes;
   int32_t ntdest;
-  int32_t tblocks;               /* number of blocks per thread */
-  int32_t tblock;                /* limit block on a thread */
-  int32_t nblock_;              /* private copy of nblock */
+  int32_t tblocks;
+  int32_t tblock;
+  int32_t nblock_;
   int32_t bsize;
   int32_t leftoverblock;
-  /* Parameters for threads */
   int32_t blocksize;
   int32_t ebsize;
   int32_t srcsize;
@@ -4376,7 +4377,6 @@ static void t_blosc_do_job(void *ctxt)
   uint8_t* tmp2;
   uint8_t* tmp3;
 
-  /* Get parameters for this thread before entering the main loop */
   blocksize = context->blocksize;
   ebsize = blocksize + context->typesize * (int32_t)sizeof(int32_t);
   maxbytes = context->destsize;
@@ -4387,54 +4387,49 @@ static void t_blosc_do_job(void *ctxt)
   srcsize = context->srcsize;
   dest = context->dest;
 
-  /* Resize the temporaries if needed */
-  if (blocksize > thcontext->tmp_blocksize) {
-    my_free(thcontext->tmp);
-    thcontext->tmp_nbytes = (size_t) 4 * ebsize;
-    thcontext->tmp = my_malloc(thcontext->tmp_nbytes);
-    thcontext->tmp2 = thcontext->tmp + ebsize;
-    thcontext->tmp3 = thcontext->tmp2 + ebsize;
-    thcontext->tmp4 = thcontext->tmp3 + ebsize;
-    thcontext->tmp_blocksize = blocksize;
+  if (ensure_thread_context_capacity(thcontext, context) < 0) {
+    blosc2_pthread_mutex_lock(&job->mutex);
+    job->giveup_code = BLOSC2_ERROR_MEMORY_ALLOC;
+    blosc2_pthread_mutex_unlock(&job->mutex);
+    goto job_done;
   }
 
   tmp = thcontext->tmp;
   tmp2 = thcontext->tmp2;
   tmp3 = thcontext->tmp3;
 
-  // Determine whether we can do a static distribution of workload among different threads
   bool vlblocks = (context->blosc2_flags2 & BLOSC2_VL_BLOCKS) != 0;
   bool memcpyed = context->header_flags & (uint8_t)BLOSC_MEMCPYED;
   if (!context->do_compress && context->special_type) {
-    // Fake a runlen as if its a memcpyed chunk
     memcpyed = true;
   }
 
-  bool static_schedule = (!compress || memcpyed) && context->block_maskout == NULL;
-  if (static_schedule) {
-      /* Blocks per thread */
-      tblocks = nblocks / context->nthreads;
-      leftover2 = nblocks % context->nthreads;
-      tblocks = (leftover2 > 0) ? tblocks + 1 : tblocks;
-      nblock_ = thcontext->tid * tblocks;
-      tblock = nblock_ + tblocks;
-      if (tblock > nblocks) {
-          tblock = nblocks;
-      }
+  if (job->static_schedule) {
+    tblocks = nblocks / context->nthreads;
+    leftover2 = nblocks % context->nthreads;
+    tblocks = (leftover2 > 0) ? tblocks + 1 : tblocks;
+    nblock_ = thcontext->tid * tblocks;
+    tblock = nblock_ + tblocks;
+    if (tblock > nblocks) {
+      tblock = nblocks;
+    }
   }
   else {
-    // Use dynamic schedule via a queue.  Get the next block.
-    blosc2_pthread_mutex_lock(&context->count_mutex);
-    context->thread_nblock++;
-    nblock_ = context->thread_nblock;
-    blosc2_pthread_mutex_unlock(&context->count_mutex);
+    nblock_ = claim_job_block(job);
     tblock = nblocks;
   }
 
-  /* Loop over blocks */
   leftoverblock = 0;
-  while ((nblock_ < tblock) && (context->thread_giveup_code > 0)) {
+  while (nblock_ < tblock) {
+    blosc2_pthread_mutex_lock(&job->mutex);
+    if (job->giveup_code <= 0) {
+      blosc2_pthread_mutex_unlock(&job->mutex);
+      break;
+    }
+    blosc2_pthread_mutex_unlock(&job->mutex);
+
     bsize = vlblocks ? context->blocknbytes[nblock_] : blocksize;
+    leftoverblock = 0;
     if (!vlblocks && nblock_ == (nblocks - 1) && (leftover > 0)) {
       bsize = leftover;
       leftoverblock = 1;
@@ -4442,15 +4437,11 @@ static void t_blosc_do_job(void *ctxt)
     if (compress) {
       if (memcpyed) {
         if (!context->prefilter) {
-          /* We want to memcpy only */
           memcpy(dest + context->header_overhead + nblock_ * blocksize,
                  src + nblock_ * blocksize, (unsigned int) bsize);
-          cbytes = (int32_t) bsize;
+          cbytes = (int32_t)bsize;
         }
         else {
-          /* Only the prefilter has to be executed, and this is done in blosc_c().
-           * However, no further actions are needed, so we can put the result
-           * directly in dest. */
           cbytes = blosc_c(thcontext, bsize, leftoverblock, 0,
                            ebsize,
                            vlblocks ? context->vlblock_sources[nblock_] : src,
@@ -4460,194 +4451,390 @@ static void t_blosc_do_job(void *ctxt)
         }
       }
       else {
-        /* Regular compression */
         cbytes = blosc_c(thcontext, bsize, leftoverblock, 0,
-                          ebsize,
-                          vlblocks ? context->vlblock_sources[nblock_] : src,
-                          vlblocks ? 0 : nblock_ * blocksize,
-                          tmp2, tmp, tmp3);
+                         ebsize,
+                         vlblocks ? context->vlblock_sources[nblock_] : src,
+                         vlblocks ? 0 : nblock_ * blocksize,
+                         tmp2, tmp, tmp3);
       }
     }
     else {
-      /* Regular decompression */
       if (context->special_type == BLOSC2_NO_SPECIAL && !memcpyed &&
           (srcsize < (int32_t)(context->header_overhead + (sizeof(int32_t) * nblocks)))) {
-        /* Not enough input to read all `bstarts` */
         cbytes = -1;
       }
       else {
-        // If memcpyed we don't have a bstarts section (because it is not needed)
         int32_t src_offset = memcpyed ?
             context->header_overhead + nblock_ * blocksize : sw32_(bstarts + nblock_);
         uint8_t *dest_block = (vlblocks && context->vlblock_dests != NULL) ? context->vlblock_dests[nblock_] : dest;
         int32_t dest_offset = (vlblocks && context->vlblock_dests != NULL) ? 0 :
                               (vlblocks ? context->blockoffsets[nblock_] : nblock_ * blocksize);
         cbytes = blosc_d(thcontext, bsize, leftoverblock, memcpyed,
-                          src, srcsize, src_offset, nblock_,
-                          dest_block, dest_offset, tmp, tmp2);
+                         src, srcsize, src_offset, nblock_,
+                         dest_block, dest_offset, tmp, tmp2);
       }
     }
 
-    /* Check whether current thread has to giveup */
-    if (context->thread_giveup_code <= 0) {
+    if (cbytes < 0) {
+      blosc2_pthread_mutex_lock(&job->mutex);
+      if (job->giveup_code > 0) {
+        job->giveup_code = cbytes;
+      }
+      blosc2_pthread_mutex_unlock(&job->mutex);
       break;
     }
 
-    /* Check results for the compressed/decompressed block */
-    if (cbytes < 0) {            /* compr/decompr failure */
-      /* Set giveup_code error */
-      blosc2_pthread_mutex_lock(&context->count_mutex);
-      context->thread_giveup_code = cbytes;
-      blosc2_pthread_mutex_unlock(&context->count_mutex);
-      break;
-    }
-
+    blosc2_pthread_mutex_lock(&job->mutex);
     if (compress && !memcpyed) {
-      /* Start critical section */
-      blosc2_pthread_mutex_lock(&context->count_mutex);
-      ntdest = context->output_bytes;
-      // Note: do not use a typical local dict_training variable here
-      // because it is probably cached from previous calls if the number of
-      // threads does not change (the usual thing).
+      ntdest = job->output_bytes;
       if (!(context->use_dict && context->dict_cdict == NULL)) {
-        _sw32(bstarts + nblock_, (int32_t) ntdest);
+        _sw32(bstarts + nblock_, (int32_t)ntdest);
       }
-
       if ((cbytes == 0) || (ntdest + cbytes > maxbytes)) {
-        context->thread_giveup_code = 0;  /* incompressible buf */
-        blosc2_pthread_mutex_unlock(&context->count_mutex);
+        job->giveup_code = 0;
+        blosc2_pthread_mutex_unlock(&job->mutex);
         break;
       }
-      context->thread_nblock++;
-      nblock_ = context->thread_nblock;
-      context->output_bytes += cbytes;
-      blosc2_pthread_mutex_unlock(&context->count_mutex);
-      /* End of critical section */
-
-      /* Copy the compressed buffer to destination */
-      memcpy(dest + ntdest, tmp2, (unsigned int) cbytes);
+      job->output_bytes += cbytes;
+      blosc2_pthread_mutex_unlock(&job->mutex);
+      memcpy(dest + ntdest, tmp2, (unsigned int)cbytes);
     }
-    else if (static_schedule) {
+    else {
+      job->output_bytes += cbytes;
+      blosc2_pthread_mutex_unlock(&job->mutex);
+    }
+
+    if (job->static_schedule) {
       nblock_++;
     }
     else {
-      blosc2_pthread_mutex_lock(&context->count_mutex);
-      context->thread_nblock++;
-      nblock_ = context->thread_nblock;
-      context->output_bytes += cbytes;
-      blosc2_pthread_mutex_unlock(&context->count_mutex);
+      nblock_ = claim_job_block(job);
     }
-
-  } /* closes while (nblock_) */
-
-  if (static_schedule) {
-    blosc2_pthread_mutex_lock(&context->count_mutex);
-    context->output_bytes = context->sourcesize;
-    if (compress) {
-      context->output_bytes += context->header_overhead;
-    }
-    blosc2_pthread_mutex_unlock(&context->count_mutex);
   }
 
-}
-
-/* Decompress & unshuffle several blocks in a single thread */
-static void* t_blosc(void* ctxt) {
-  struct thread_context* thcontext = (struct thread_context*)ctxt;
-  blosc2_context* context = thcontext->parent_context;
-#ifdef BLOSC_POSIX_BARRIERS
-  int rc;
-#endif
-
-  while (1) {
-    /* Synchronization point for all threads (wait for initialization) */
-    WAIT_INIT(NULL, context);
-
-    if (context->end_threads) {
-      break;
-    }
-
-    t_blosc_do_job(ctxt);
-
-    /* Meeting point for all threads (wait for finalization) */
-    WAIT_FINISH(NULL, context);
-  }
-
-  /* Cleanup our working space and context */
-  free_thread_context(thcontext);
-
-  return (NULL);
-}
-
-
-int init_threadpool(blosc2_context *context) {
-  int32_t tid;
-  int rc2;
-
-  /* Initialize mutex and condition variable objects */
-  blosc2_pthread_mutex_init(&context->count_mutex, NULL);
-  blosc2_pthread_mutex_init(&context->delta_mutex, NULL);
-  blosc2_pthread_mutex_init(&context->nchunk_mutex, NULL);
-  blosc2_pthread_cond_init(&context->delta_cv, NULL);
-
-  /* Set context thread sentinels */
-  context->thread_giveup_code = 1;
-  context->thread_nblock = -1;
-
-  /* Barrier initialization */
-#ifdef BLOSC_POSIX_BARRIERS
-  pthread_barrier_init(&context->barr_init, NULL, context->nthreads + 1);
-  pthread_barrier_init(&context->barr_finish, NULL, context->nthreads + 1);
-#else
-  blosc2_pthread_mutex_init(&context->count_threads_mutex, NULL);
-  blosc2_pthread_cond_init(&context->count_threads_cv, NULL);
-  context->count_threads = 0;      /* Reset threads counter */
-#endif
-
-  if (threads_callback) {
-      /* Create thread contexts to store data for callback threads */
-    context->thread_contexts = (struct thread_context *)my_malloc(
-            context->nthreads * sizeof(struct thread_context));
-    BLOSC_ERROR_NULL(context->thread_contexts, BLOSC2_ERROR_MEMORY_ALLOC);
-    for (tid = 0; tid < context->nthreads; tid++)
-      init_thread_context(context->thread_contexts + tid, context, tid);
-  }
-  else {
-    #if !defined(_WIN32)
-      /* Initialize and set thread detached attribute */
-      pthread_attr_init(&context->ct_attr);
-      pthread_attr_setdetachstate(&context->ct_attr, PTHREAD_CREATE_JOINABLE);
-    #endif
-
-    /* Make space for thread handlers */
-    context->threads = (blosc2_pthread_t*)my_malloc(
-            context->nthreads * sizeof(blosc2_pthread_t));
-    BLOSC_ERROR_NULL(context->threads, BLOSC2_ERROR_MEMORY_ALLOC);
-    /* Finally, create the threads */
-    for (tid = 0; tid < context->nthreads; tid++) {
-      /* Create a thread context (will destroy when finished) */
-      struct thread_context *thread_context = create_thread_context(context, tid);
-      BLOSC_ERROR_NULL(thread_context, BLOSC2_ERROR_THREAD_CREATE);
-      #if !defined(_WIN32)
-        rc2 = blosc2_pthread_create(&context->threads[tid], &context->ct_attr, t_blosc,
-                            (void*)thread_context);
-      #else
-        rc2 = blosc2_pthread_create(&context->threads[tid], NULL, t_blosc,
-                            (void *)thread_context);
-      #endif
-      if (rc2) {
-        BLOSC_TRACE_ERROR("Return code from blosc2_pthread_create() is %d.\n"
-                          "\tError detail: %s\n", rc2, strerror(rc2));
-        return BLOSC2_ERROR_THREAD_CREATE;
+job_done:
+  blosc2_pthread_mutex_lock(&job->mutex);
+  job->blocks_completed++;
+  if (--job->active_workers == 0) {
+    if (job->static_schedule && job->giveup_code > 0) {
+      job->output_bytes = context->sourcesize;
+      if (compress) {
+        job->output_bytes += context->header_overhead;
       }
     }
+    job->completed = true;
+    blosc2_pthread_cond_broadcast(&job->completion_cv);
+  }
+  blosc2_pthread_mutex_unlock(&job->mutex);
+}
+
+static void job_group_init(struct blosc_job_group *job, blosc2_context *context) {
+  memset(job, 0, sizeof(*job));
+  job->context = context;
+  job->next_block = -1;
+  job->output_bytes = context->output_bytes;
+  job->giveup_code = 1;
+  job->dref_not_init = 1;
+  bool compress = context->do_compress != 0;
+  bool memcpyed = context->header_flags & (uint8_t)BLOSC_MEMCPYED;
+  if (!compress && context->special_type) {
+    memcpyed = true;
+  }
+  job->static_schedule = (!compress || memcpyed) && context->block_maskout == NULL;
+  blosc2_pthread_mutex_init(&job->mutex, NULL);
+  blosc2_pthread_mutex_init(&job->delta_mutex, NULL);
+  blosc2_pthread_cond_init(&job->delta_cv, NULL);
+  blosc2_pthread_cond_init(&job->completion_cv, NULL);
+}
+
+static void job_group_destroy(struct blosc_job_group *job) {
+  blosc2_pthread_mutex_destroy(&job->mutex);
+  blosc2_pthread_mutex_destroy(&job->delta_mutex);
+  blosc2_pthread_cond_destroy(&job->delta_cv);
+  blosc2_pthread_cond_destroy(&job->completion_cv);
+}
+
+static void* shared_pool_worker(void* arg) {
+  struct thread_context* thcontext = (struct thread_context*)arg;
+  struct blosc_shared_pool* pool = thcontext->owner_pool;
+
+  while (1) {
+    struct blosc_job_group* job = NULL;
+    struct blosc_job_queue_entry* entry = NULL;
+    blosc2_pthread_mutex_lock(&pool->mutex);
+    while (!pool->shutdown && pool->job_queue_head == NULL) {
+      blosc2_pthread_cond_wait(&pool->work_cv, &pool->mutex);
+    }
+    if (pool->shutdown) {
+      blosc2_pthread_mutex_unlock(&pool->mutex);
+      break;
+    }
+    entry = pool->job_queue_head;
+    job = entry->job;
+    pool->job_queue_head = entry->next;
+    if (pool->job_queue_head == NULL) {
+      pool->job_queue_tail = NULL;
+    }
+    blosc2_pthread_mutex_unlock(&pool->mutex);
+    int32_t logical_tid = entry->logical_tid;
+    my_free(entry);
+
+    thcontext->parent_context = job->context;
+    thcontext->tid = logical_tid;
+    t_blosc_do_job(thcontext);
+    thcontext->parent_context = NULL;
+
+    blosc2_pthread_mutex_lock(&pool->mutex);
+    pool->active_jobs--;
+    if (pool->active_jobs == 0 && pool->context_refs == 0 && pool->job_queue_head == NULL) {
+      blosc2_pthread_cond_broadcast(&pool->idle_cv);
+    }
+    blosc2_pthread_mutex_unlock(&pool->mutex);
   }
 
-  /* We have now started/initialized the threads */
-  context->threads_started = context->nthreads;
-  context->new_nthreads = context->nthreads;
+  destroy_thread_context(thcontext);
+  return NULL;
+}
 
+static struct blosc_shared_pool* find_shared_pool_locked(int16_t nthreads) {
+  struct blosc_shared_pool *pool = shared_pools;
+  while (pool != NULL) {
+    if (pool->nthreads == nthreads) {
+      return pool;
+    }
+    pool = pool->next;
+  }
+  return NULL;
+}
+
+static int create_shared_pool(int16_t nthreads, struct blosc_shared_pool **pool_out) {
+  int rc2;
+  struct blosc_shared_pool *pool = (struct blosc_shared_pool *)my_malloc(sizeof(*pool));
+  BLOSC_ERROR_NULL(pool, BLOSC2_ERROR_MEMORY_ALLOC);
+  memset(pool, 0, sizeof(*pool));
+  pool->nthreads = nthreads;
+  blosc2_pthread_mutex_init(&pool->mutex, NULL);
+  blosc2_pthread_cond_init(&pool->work_cv, NULL);
+  blosc2_pthread_cond_init(&pool->idle_cv, NULL);
+  pool->threads = (blosc2_pthread_t*)my_malloc(nthreads * sizeof(blosc2_pthread_t));
+  BLOSC_ERROR_NULL(pool->threads, BLOSC2_ERROR_MEMORY_ALLOC);
+  pool->thread_contexts = (struct thread_context*)my_malloc((size_t)nthreads * sizeof(struct thread_context));
+  BLOSC_ERROR_NULL(pool->thread_contexts, BLOSC2_ERROR_MEMORY_ALLOC);
+  memset(pool->thread_contexts, 0, (size_t)nthreads * sizeof(struct thread_context));
+#if !defined(_WIN32)
+  pthread_attr_init(&pool->ct_attr);
+  pthread_attr_setdetachstate(&pool->ct_attr, PTHREAD_CREATE_JOINABLE);
+#endif
+  for (int32_t tid = 0; tid < nthreads; ++tid) {
+    int rc = init_thread_context(pool->thread_contexts + tid, NULL, tid);
+    if (rc < 0) {
+      return rc;
+    }
+    pool->thread_contexts[tid].owner_pool = pool;
+#if !defined(_WIN32)
+    rc2 = blosc2_pthread_create(&pool->threads[tid], &pool->ct_attr, shared_pool_worker,
+                                (void*)(pool->thread_contexts + tid));
+#else
+    rc2 = blosc2_pthread_create(&pool->threads[tid], NULL, shared_pool_worker,
+                                (void*)(pool->thread_contexts + tid));
+#endif
+    if (rc2) {
+      BLOSC_TRACE_ERROR("Return code from blosc2_pthread_create() is %d.\n\tError detail: %s\n", rc2, strerror(rc2));
+      return BLOSC2_ERROR_THREAD_CREATE;
+    }
+  }
+  *pool_out = pool;
   return 0;
+}
+
+static void destroy_shared_pool(struct blosc_shared_pool *pool) {
+  void *status;
+
+  blosc2_pthread_mutex_lock(&pool->mutex);
+  pool->shutdown = 1;
+  blosc2_pthread_cond_broadcast(&pool->work_cv);
+  blosc2_pthread_mutex_unlock(&pool->mutex);
+
+  for (int32_t t = 0; t < pool->nthreads; ++t) {
+    blosc2_pthread_join(pool->threads[t], &status);
+  }
+#if !defined(_WIN32)
+  pthread_attr_destroy(&pool->ct_attr);
+#endif
+  my_free(pool->threads);
+  my_free(pool->thread_contexts);
+  blosc2_pthread_cond_destroy(&pool->idle_cv);
+  blosc2_pthread_cond_destroy(&pool->work_cv);
+  blosc2_pthread_mutex_destroy(&pool->mutex);
+  my_free(pool);
+}
+
+static int attach_shared_pool(blosc2_context *context) {
+  struct blosc_shared_pool *pool;
+
+  if (!g_initlib) blosc2_init();
+  blosc2_pthread_mutex_lock(&pool_registry_mutex);
+  pool = find_shared_pool_locked(context->nthreads);
+  if (pool == NULL) {
+    int rc = create_shared_pool(context->nthreads, &pool);
+    if (rc < 0) {
+      blosc2_pthread_mutex_unlock(&pool_registry_mutex);
+      return rc;
+    }
+    pool->next = shared_pools;
+    shared_pools = pool;
+  }
+  pool->context_refs++;
+  blosc2_pthread_mutex_unlock(&pool_registry_mutex);
+
+  context->thread_pool = pool;
+  context->thread_backend = BLOSC_BACKEND_SHARED_POOL;
+  context->threads_started = context->nthreads;
+  return 0;
+}
+
+static int init_callback_threads(blosc2_context *context) {
+  int32_t tid;
+
+  blosc2_pthread_mutex_init(&context->count_mutex, NULL);
+  blosc2_pthread_mutex_init(&context->delta_mutex, NULL);
+  blosc2_pthread_cond_init(&context->delta_cv, NULL);
+  context->thread_contexts = (struct thread_context *)my_malloc(
+      context->nthreads * sizeof(struct thread_context));
+  BLOSC_ERROR_NULL(context->thread_contexts, BLOSC2_ERROR_MEMORY_ALLOC);
+  for (tid = 0; tid < context->nthreads; tid++) {
+    init_thread_context(context->thread_contexts + tid, context, tid);
+  }
+  context->thread_backend = BLOSC_BACKEND_CALLBACK;
+  context->threads_started = context->nthreads;
+  return 0;
+}
+
+static int release_thread_backend(blosc2_context *context) {
+  if (context->thread_backend == BLOSC_BACKEND_CALLBACK && context->threads_started > 0) {
+    for (int32_t t = 0; t < context->threads_started; t++) {
+      destroy_thread_context(context->thread_contexts + t);
+    }
+    my_free(context->thread_contexts);
+    context->thread_contexts = NULL;
+    blosc2_pthread_mutex_destroy(&context->count_mutex);
+    blosc2_pthread_mutex_destroy(&context->delta_mutex);
+    blosc2_pthread_cond_destroy(&context->delta_cv);
+  }
+  else if (context->thread_backend == BLOSC_BACKEND_SHARED_POOL && context->thread_pool != NULL) {
+    struct blosc_shared_pool *pool = context->thread_pool;
+    struct blosc_shared_pool **prev;
+    bool destroy_pool = false;
+
+    blosc2_pthread_mutex_lock(&pool_registry_mutex);
+    pool->context_refs--;
+    if (pool->context_refs == 0) {
+      /* Check pool-internal state under the pool's own mutex */
+      blosc2_pthread_mutex_lock(&pool->mutex);
+      bool idle = (pool->active_jobs == 0 && pool->job_queue_head == NULL);
+      blosc2_pthread_mutex_unlock(&pool->mutex);
+      if (idle) {
+        prev = &shared_pools;
+        while (*prev != NULL && *prev != pool) {
+          prev = &(*prev)->next;
+        }
+        if (*prev == pool) {
+          *prev = pool->next;
+        }
+        destroy_pool = true;
+      }
+    }
+    blosc2_pthread_mutex_unlock(&pool_registry_mutex);
+    if (destroy_pool) {
+      destroy_shared_pool(pool);
+    }
+    context->thread_pool = NULL;
+  }
+
+  context->threads_started = 0;
+  context->thread_backend = BLOSC_BACKEND_SERIAL;
+  return 0;
+}
+
+static int parallel_blosc(blosc2_context* context) {
+  struct blosc_job_group job;
+
+  job_group_init(&job, context);
+  context->job = &job;
+
+  if (context->thread_backend == BLOSC_BACKEND_CALLBACK) {
+    blosc2_pthread_mutex_lock(&job.mutex);
+    job.active_workers = context->nthreads;
+    blosc2_pthread_mutex_unlock(&job.mutex);
+    threads_callback(threads_callback_data, t_blosc_do_job,
+                     context->nthreads, sizeof(struct thread_context), (void*) context->thread_contexts);
+  }
+  else {
+    struct blosc_shared_pool *pool = context->thread_pool;
+    blosc2_pthread_mutex_lock(&pool->mutex);
+    int32_t enqueued = 0;
+    for (int32_t tid = 0; tid < context->nthreads; ++tid) {
+      struct blosc_job_queue_entry *entry = (struct blosc_job_queue_entry *)my_malloc(sizeof(*entry));
+      if (entry == NULL) {
+        /* Drain already-enqueued entries so they don't reference the
+           stack-allocated job after we return. */
+        struct blosc_job_queue_entry **pp = &pool->job_queue_head;
+        while (*pp != NULL) {
+          if ((*pp)->job == &job) {
+            struct blosc_job_queue_entry *victim = *pp;
+            *pp = victim->next;
+            my_free(victim);
+            pool->active_jobs--;
+          } else {
+            pp = &(*pp)->next;
+          }
+        }
+        pool->job_queue_tail = NULL;
+        /* Recompute tail */
+        for (struct blosc_job_queue_entry *e = pool->job_queue_head; e != NULL; e = e->next) {
+          pool->job_queue_tail = e;
+        }
+        blosc2_pthread_mutex_unlock(&pool->mutex);
+        context->job = NULL;
+        job_group_destroy(&job);
+        return BLOSC2_ERROR_MEMORY_ALLOC;
+      }
+      memset(entry, 0, sizeof(*entry));
+      entry->job = &job;
+      entry->logical_tid = tid;
+      if (pool->job_queue_tail != NULL) {
+        pool->job_queue_tail->next = entry;
+      }
+      else {
+        pool->job_queue_head = entry;
+      }
+      pool->job_queue_tail = entry;
+      pool->active_jobs++;
+      enqueued++;
+    }
+    /* Set active_workers to the actual number enqueued */
+    blosc2_pthread_mutex_lock(&job.mutex);
+    job.active_workers = enqueued;
+    blosc2_pthread_mutex_unlock(&job.mutex);
+    blosc2_pthread_cond_broadcast(&pool->work_cv);
+    blosc2_pthread_mutex_unlock(&pool->mutex);
+
+    blosc2_pthread_mutex_lock(&job.mutex);
+    while (!job.completed) {
+      blosc2_pthread_cond_wait(&job.completion_cv, &job.mutex);
+    }
+    blosc2_pthread_mutex_unlock(&job.mutex);
+  }
+
+  context->job = NULL;
+  context->output_bytes = job.output_bytes;
+  context->thread_giveup_code = job.giveup_code;
+  job_group_destroy(&job);
+
+  if (context->thread_giveup_code <= 0) {
+    return context->thread_giveup_code;
+  }
+  return (int)context->output_bytes;
 }
 
 int16_t blosc2_get_nthreads(void)
@@ -4959,11 +5146,13 @@ void blosc2_init(void) {
   register_tuners();
 #endif
   blosc2_pthread_mutex_init(&global_comp_mutex, NULL);
+  blosc2_pthread_mutex_init(&pool_registry_mutex, NULL);
   /* Create a global context */
   g_global_context = (blosc2_context*)my_malloc(sizeof(blosc2_context));
   memset(g_global_context, 0, sizeof(blosc2_context));
   g_global_context->nthreads = g_nthreads;
   g_global_context->new_nthreads = g_nthreads;
+  blosc2_pthread_mutex_init(&g_global_context->nchunk_mutex, NULL);
   g_initlib = 1;
 }
 
@@ -4972,7 +5161,7 @@ int blosc2_free_resources(void) {
   /* Return if Blosc is not initialized */
   if (!g_initlib) return BLOSC2_ERROR_FAILURE;
 
-  return release_threadpool(g_global_context);
+  return release_thread_backend(g_global_context);
 }
 
 
@@ -4984,69 +5173,17 @@ void blosc2_destroy(void) {
   g_initlib = 0;
   blosc2_free_ctx(g_global_context);
 
-  blosc2_pthread_mutex_destroy(&global_comp_mutex);
-
-}
-
-
-int release_threadpool(blosc2_context *context) {
-  int32_t t;
-  void* status;
-  int rc;
-
-  if (context->threads_started > 0) {
-    if (threads_callback) {
-      /* free context data for user-managed threads */
-      for (t=0; t<context->threads_started; t++)
-        destroy_thread_context(context->thread_contexts + t);
-      my_free(context->thread_contexts);
-    }
-    else {
-      /* Tell all existing threads to finish */
-      context->end_threads = 1;
-      WAIT_INIT(-1, context);
-
-      /* Join exiting threads */
-      for (t = 0; t < context->threads_started; t++) {
-        rc = blosc2_pthread_join(context->threads[t], &status);
-        if (rc) {
-          BLOSC_TRACE_ERROR("Return code from blosc2_pthread_join() is %d\n"
-                            "\tError detail: %s.", rc, strerror(rc));
-        }
-      }
-
-      /* Thread attributes */
-      #if !defined(_WIN32)
-        pthread_attr_destroy(&context->ct_attr);
-      #endif
-
-      /* Release thread handlers */
-      my_free(context->threads);
-    }
-
-    /* Release mutex and condition variable objects */
-    blosc2_pthread_mutex_destroy(&context->count_mutex);
-    blosc2_pthread_mutex_destroy(&context->delta_mutex);
-    blosc2_pthread_mutex_destroy(&context->nchunk_mutex);
-    blosc2_pthread_cond_destroy(&context->delta_cv);
-
-    /* Barriers */
-  #ifdef BLOSC_POSIX_BARRIERS
-    pthread_barrier_destroy(&context->barr_init);
-    pthread_barrier_destroy(&context->barr_finish);
-  #else
-    blosc2_pthread_mutex_destroy(&context->count_threads_mutex);
-    blosc2_pthread_cond_destroy(&context->count_threads_cv);
-    context->count_threads = 0;      /* Reset threads counter */
-  #endif
-
-    /* Reset flags and counters */
-    context->end_threads = 0;
-    context->threads_started = 0;
+  /* Tear down any remaining shared pools */
+  struct blosc_shared_pool *pool = shared_pools;
+  while (pool != NULL) {
+    struct blosc_shared_pool *next = pool->next;
+    destroy_shared_pool(pool);
+    pool = next;
   }
+  shared_pools = NULL;
+  blosc2_pthread_mutex_destroy(&pool_registry_mutex);
 
-
-  return 0;
+  blosc2_pthread_mutex_destroy(&global_comp_mutex);
 }
 
 
@@ -5225,6 +5362,7 @@ blosc2_context* blosc2_create_cctx(blosc2_cparams cparams) {
   }
 
   context->threads_started = 0;
+  blosc2_pthread_mutex_init(&context->nchunk_mutex, NULL);
   context->schunk = cparams.schunk;
 
   if (cparams.prefilter != NULL) {
@@ -5288,6 +5426,7 @@ blosc2_context* blosc2_create_dctx(blosc2_dparams dparams) {
   context->threads_started = 0;
   context->block_maskout = NULL;
   context->block_maskout_nitems = 0;
+  blosc2_pthread_mutex_init(&context->nchunk_mutex, NULL);
   context->schunk = dparams.schunk;
 
   if (dparams.postfilter != NULL) {
@@ -5302,10 +5441,13 @@ blosc2_context* blosc2_create_dctx(blosc2_dparams dparams) {
 
 
 void blosc2_free_ctx(blosc2_context* context) {
-  release_threadpool(context);
+  if (g_initlib) {
+    release_thread_backend(context);
+  }
   if (context->serial_context != NULL) {
     free_thread_context(context->serial_context);
   }
+  blosc2_pthread_mutex_destroy(&context->nchunk_mutex);
   release_context_dict_buffer(context);
   if (context->dict_cdict != NULL) {
     if (context->compcode == BLOSC_LZ4) {

--- a/blosc/blosc2.c
+++ b/blosc/blosc2.c
@@ -147,6 +147,9 @@ struct blosc_shared_pool {
 static int init_callback_threads(blosc2_context *context);
 static int release_thread_backend(blosc2_context *context);
 static int attach_shared_pool(blosc2_context *context);
+#if defined(_WIN32)
+static int init_per_context_threadpool(blosc2_context *context);
+#endif
 static int parallel_blosc(blosc2_context* context);
 
 /* global variable to change threading backend from Blosc-managed to caller-managed */
@@ -2265,7 +2268,11 @@ int check_nthreads(blosc2_context* context) {
       rc = init_callback_threads(context);
     }
     else {
+#if defined(_WIN32)
+      rc = init_per_context_threadpool(context);
+#else
       rc = attach_shared_pool(context);
+#endif
     }
     if (rc < 0) {
       return rc;
@@ -4725,6 +4732,113 @@ static int attach_shared_pool(blosc2_context *context) {
   return 0;
 }
 
+#if defined(_WIN32)
+/* Per-context worker thread for Windows (BLOSC_BACKEND_PER_CONTEXT).
+ * Waits for the main thread to post a new job (via job_seq), processes it,
+ * then signals completion via pending_workers.  A separate job_seq per-worker
+ * (my_job_seq) prevents a worker from consuming the same job twice. */
+static void* t_blosc_per_context(void* arg) {
+  struct thread_context* thcontext = (struct thread_context*)arg;
+  blosc2_context* context = thcontext->parent_context;
+
+  blosc2_pthread_mutex_lock(&context->count_threads_mutex);
+  while (1) {
+    /* Sleep until the main thread posts a new job or signals shutdown. */
+    while (!context->end_threads && thcontext->my_job_seq == context->job_seq) {
+      blosc2_pthread_cond_wait(&context->count_threads_cv, &context->count_threads_mutex);
+    }
+    if (context->end_threads) {
+      break;
+    }
+    /* Snapshot the current job generation and the job pointer before releasing
+     * the mutex.  context->job is guaranteed to be valid and unchanged until
+     * the main thread receives the completion signal (which only happens after
+     * all workers have finished touching the job). */
+    thcontext->my_job_seq = context->job_seq;
+    struct blosc_job_group *job = context->job;
+    blosc2_pthread_mutex_unlock(&context->count_threads_mutex);
+
+    t_blosc_do_job(thcontext);
+
+    /* Signal completion: the last worker to finish wakes the main thread. */
+    blosc2_pthread_mutex_lock(&job->mutex);
+    if (--job->pending_workers == 0) {
+      job->completed = true;
+      blosc2_pthread_cond_broadcast(&job->completion_cv);
+    }
+    blosc2_pthread_mutex_unlock(&job->mutex);
+
+    blosc2_pthread_mutex_lock(&context->count_threads_mutex);
+  }
+  blosc2_pthread_mutex_unlock(&context->count_threads_mutex);
+  return NULL;
+}
+
+static int init_per_context_threadpool(blosc2_context *context) {
+  int16_t nthreads = context->nthreads;
+
+  blosc2_pthread_mutex_init(&context->count_threads_mutex, NULL);
+  blosc2_pthread_cond_init(&context->count_threads_cv, NULL);
+  context->end_threads = 0;
+  context->job_seq = 0;
+
+  context->thread_contexts = (struct thread_context *)my_malloc(
+      (size_t)nthreads * sizeof(struct thread_context));
+  if (context->thread_contexts == NULL) {
+    goto oom_contexts;
+  }
+  memset(context->thread_contexts, 0, (size_t)nthreads * sizeof(struct thread_context));
+
+  context->threads = (blosc2_pthread_t *)my_malloc((size_t)nthreads * sizeof(blosc2_pthread_t));
+  if (context->threads == NULL) {
+    goto oom_threads;
+  }
+
+  int16_t created = 0;
+  for (int16_t tid = 0; tid < nthreads; tid++) {
+    int rc = init_thread_context(context->thread_contexts + tid, context, tid);
+    if (rc < 0) {
+      goto create_error;
+    }
+    context->thread_contexts[tid].my_job_seq = 0;
+    int rc2 = blosc2_pthread_create(&context->threads[tid], NULL,
+                                    t_blosc_per_context,
+                                    (void *)(context->thread_contexts + tid));
+    if (rc2 != 0) {
+      BLOSC_TRACE_ERROR("blosc2_pthread_create() failed: %d\n", rc2);
+      /* The thread_context was already inited; destroy it before bailing. */
+      destroy_thread_context(context->thread_contexts + tid);
+      goto create_error;
+    }
+    created++;
+  }
+
+  context->thread_backend = BLOSC_BACKEND_PER_CONTEXT;
+  context->threads_started = nthreads;
+  return 0;
+
+create_error:
+  /* Tear down threads that were successfully started. */
+  blosc2_pthread_mutex_lock(&context->count_threads_mutex);
+  context->end_threads = 1;
+  blosc2_pthread_cond_broadcast(&context->count_threads_cv);
+  blosc2_pthread_mutex_unlock(&context->count_threads_mutex);
+  for (int16_t t = 0; t < created; t++) {
+    void *status;
+    blosc2_pthread_join(context->threads[t], &status);
+  }
+  my_free(context->threads);
+  context->threads = NULL;
+oom_threads:
+  my_free(context->thread_contexts);
+  context->thread_contexts = NULL;
+oom_contexts:
+  blosc2_pthread_cond_destroy(&context->count_threads_cv);
+  blosc2_pthread_mutex_destroy(&context->count_threads_mutex);
+  return BLOSC2_ERROR_THREAD_CREATE;
+}
+#endif  /* _WIN32 */
+
 static int init_callback_threads(blosc2_context *context) {
   int32_t tid;
 
@@ -4753,6 +4867,28 @@ static int release_thread_backend(blosc2_context *context) {
     blosc2_pthread_mutex_destroy(&context->delta_mutex);
     blosc2_pthread_cond_destroy(&context->delta_cv);
   }
+#if defined(_WIN32)
+  else if (context->thread_backend == BLOSC_BACKEND_PER_CONTEXT && context->threads_started > 0) {
+    /* Signal all workers to exit. */
+    blosc2_pthread_mutex_lock(&context->count_threads_mutex);
+    context->end_threads = 1;
+    blosc2_pthread_cond_broadcast(&context->count_threads_cv);
+    blosc2_pthread_mutex_unlock(&context->count_threads_mutex);
+
+    /* Join all worker threads and free their contexts. */
+    for (int32_t t = 0; t < context->threads_started; t++) {
+      void *status;
+      blosc2_pthread_join(context->threads[t], &status);
+      destroy_thread_context(context->thread_contexts + t);
+    }
+    my_free(context->threads);
+    context->threads = NULL;
+    my_free(context->thread_contexts);
+    context->thread_contexts = NULL;
+    blosc2_pthread_cond_destroy(&context->count_threads_cv);
+    blosc2_pthread_mutex_destroy(&context->count_threads_mutex);
+  }
+#endif  /* _WIN32 */
   else if (context->thread_backend == BLOSC_BACKEND_SHARED_POOL && context->thread_pool != NULL) {
     struct blosc_shared_pool *pool = context->thread_pool;
     struct blosc_shared_pool **prev;
@@ -4811,6 +4947,32 @@ static int parallel_blosc(blosc2_context* context) {
     threads_callback(threads_callback_data, t_blosc_do_job,
                      context->nthreads, sizeof(struct thread_context), (void*) context->thread_contexts);
   }
+#if defined(_WIN32)
+  else if (context->thread_backend == BLOSC_BACKEND_PER_CONTEXT) {
+    /* Publish the job to the per-context workers.  Initialize both counters
+     * before broadcasting so workers always see consistent values. */
+    job.active_workers = context->nthreads;
+    job.pending_workers = context->nthreads;
+
+    blosc2_pthread_mutex_lock(&context->count_threads_mutex);
+    context->job = &job;
+    context->job_seq++;
+    blosc2_pthread_cond_broadcast(&context->count_threads_cv);
+    blosc2_pthread_mutex_unlock(&context->count_threads_mutex);
+
+    /* Wait until the last worker signals completion. */
+    blosc2_pthread_mutex_lock(&job.mutex);
+    while (!job.completed) {
+      blosc2_pthread_cond_wait(&job.completion_cv, &job.mutex);
+    }
+    blosc2_pthread_mutex_unlock(&job.mutex);
+
+    /* Clear context->job so workers won't see a stale pointer. */
+    blosc2_pthread_mutex_lock(&context->count_threads_mutex);
+    context->job = NULL;
+    blosc2_pthread_mutex_unlock(&context->count_threads_mutex);
+  }
+#endif  /* _WIN32 */
   else {
     struct blosc_shared_pool *pool = context->thread_pool;
     blosc2_pthread_mutex_lock(&pool->mutex);

--- a/blosc/blosc2.c
+++ b/blosc/blosc2.c
@@ -154,6 +154,10 @@ static blosc_threads_callback threads_callback = 0;
 static void *threads_callback_data = 0;
 static blosc2_pthread_mutex_t pool_registry_mutex;
 static struct blosc_shared_pool *shared_pools = NULL;
+/* Incremented each time blosc2_destroy() tears down the pool registry.
+ * Contexts store the epoch at attach time; a mismatch means the pool they
+ * hold a pointer to has already been freed. */
+static volatile int32_t g_destroy_count = 0;
 
 
 /* non-threadsafe function should be called before any other Blosc function in
@@ -2239,6 +2243,16 @@ int check_nthreads(blosc2_context* context) {
   if (context->nthreads <= 0) {
     BLOSC_TRACE_ERROR("nthreads must be >= 1 and <= %d", INT16_MAX);
     return BLOSC2_ERROR_INVALID_PARAM;
+  }
+
+  /* Detect a pool that was torn down by blosc2_destroy() while this context
+   * was still alive.  The epoch mismatch tells us the pool pointer is dangling;
+   * clear it so the re-attach logic below creates a fresh one. */
+  if (context->thread_backend == BLOSC_BACKEND_SHARED_POOL &&
+      context->pool_epoch != g_destroy_count) {
+    context->thread_pool = NULL;
+    context->threads_started = 0;
+    context->thread_backend = BLOSC_BACKEND_SERIAL;
   }
 
   if (context->new_nthreads != context->nthreads) {
@@ -4587,19 +4601,26 @@ static void* shared_pool_worker(void* arg) {
     t_blosc_do_job(thcontext);
     thcontext->parent_context = NULL;
 
-    blosc2_pthread_mutex_lock(&pool->mutex);
-    pool->active_jobs--;
-    if (pool->active_jobs == 0 && pool->context_refs == 0 && pool->job_queue_head == NULL) {
-      blosc2_pthread_cond_broadcast(&pool->idle_cv);
-    }
-    blosc2_pthread_mutex_unlock(&pool->mutex);
-
+    /* Signal job completion BEFORE touching pool accounting.
+     * The job struct is stack-allocated in parallel_blosc; the main thread
+     * is allowed to destroy it as soon as completed==true is visible.
+     * Decrementing pending_workers here (under job->mutex) guarantees that
+     * every worker has finished with the job before the last decrement can
+     * reach 0 and wake the main thread.  Doing the pool accounting afterwards
+     * is safe because it no longer references the job. */
     blosc2_pthread_mutex_lock(&job->mutex);
     if (--job->pending_workers == 0) {
       job->completed = true;
       blosc2_pthread_cond_broadcast(&job->completion_cv);
     }
     blosc2_pthread_mutex_unlock(&job->mutex);
+
+    blosc2_pthread_mutex_lock(&pool->mutex);
+    pool->active_jobs--;
+    if (pool->active_jobs == 0 && pool->context_refs == 0 && pool->job_queue_head == NULL) {
+      blosc2_pthread_cond_broadcast(&pool->idle_cv);
+    }
+    blosc2_pthread_mutex_unlock(&pool->mutex);
   }
 
   destroy_thread_context(thcontext);
@@ -4700,6 +4721,7 @@ static int attach_shared_pool(blosc2_context *context) {
   context->thread_pool = pool;
   context->thread_backend = BLOSC_BACKEND_SHARED_POOL;
   context->threads_started = context->nthreads;
+  context->pool_epoch = g_destroy_count;
   return 0;
 }
 
@@ -4735,6 +4757,15 @@ static int release_thread_backend(blosc2_context *context) {
     struct blosc_shared_pool *pool = context->thread_pool;
     struct blosc_shared_pool **prev;
     bool destroy_pool = false;
+
+    if (context->pool_epoch != g_destroy_count) {
+      /* blosc2_destroy() already freed this pool and tore down pool_registry_mutex.
+       * Just clear the dangling pointer; nothing else to do. */
+      context->thread_pool = NULL;
+      context->threads_started = 0;
+      context->thread_backend = BLOSC_BACKEND_SERIAL;
+      return 0;
+    }
 
     blosc2_pthread_mutex_lock(&pool_registry_mutex);
     pool->context_refs--;
@@ -5184,6 +5215,12 @@ void blosc2_destroy(void) {
   blosc2_free_resources();
   g_initlib = 0;
   blosc2_free_ctx(g_global_context);
+
+  /* Bump the epoch so any live context can detect its pool is now stale.
+   * Do this before freeing the pools so that release_thread_backend callers
+   * that race with us will take the "skip" path rather than locking the
+   * soon-to-be-destroyed pool_registry_mutex. */
+  g_destroy_count++;
 
   /* Tear down any remaining shared pools */
   struct blosc_shared_pool *pool = shared_pools;

--- a/blosc/blosc2.c
+++ b/blosc/blosc2.c
@@ -148,9 +148,40 @@ static int init_callback_threads(blosc2_context *context);
 static int release_thread_backend(blosc2_context *context);
 static int attach_shared_pool(blosc2_context *context);
 #if defined(_WIN32)
-static int init_per_context_threadpool(blosc2_context *context);
+static int init_threadpool(blosc2_context *context);
 #endif
 static int parallel_blosc(blosc2_context* context);
+
+/* Synchronization barriers for Windows per-context threads (no POSIX barriers on Windows) */
+#if defined(_WIN32)
+#define WAIT_INIT(RET_VAL, CONTEXT_PTR)                                        \
+  do {                                                                         \
+    blosc2_pthread_mutex_lock(&(CONTEXT_PTR)->count_threads_mutex);            \
+    if ((CONTEXT_PTR)->count_threads < (CONTEXT_PTR)->nthreads) {              \
+      (CONTEXT_PTR)->count_threads++;                                          \
+      blosc2_pthread_cond_wait(&(CONTEXT_PTR)->count_threads_cv,               \
+                               &(CONTEXT_PTR)->count_threads_mutex);           \
+    }                                                                          \
+    else {                                                                     \
+      blosc2_pthread_cond_broadcast(&(CONTEXT_PTR)->count_threads_cv);         \
+    }                                                                          \
+    blosc2_pthread_mutex_unlock(&(CONTEXT_PTR)->count_threads_mutex);          \
+  } while (0)
+
+#define WAIT_FINISH(RET_VAL, CONTEXT_PTR)                                      \
+  do {                                                                         \
+    blosc2_pthread_mutex_lock(&(CONTEXT_PTR)->count_threads_mutex);            \
+    if ((CONTEXT_PTR)->count_threads > 0) {                                    \
+      (CONTEXT_PTR)->count_threads--;                                          \
+      blosc2_pthread_cond_wait(&(CONTEXT_PTR)->count_threads_cv,               \
+                               &(CONTEXT_PTR)->count_threads_mutex);           \
+    }                                                                          \
+    else {                                                                     \
+      blosc2_pthread_cond_broadcast(&(CONTEXT_PTR)->count_threads_cv);         \
+    }                                                                          \
+    blosc2_pthread_mutex_unlock(&(CONTEXT_PTR)->count_threads_mutex);          \
+  } while (0)
+#endif  /* _WIN32 */
 
 /* global variable to change threading backend from Blosc-managed to caller-managed */
 static blosc_threads_callback threads_callback = 0;
@@ -2269,7 +2300,7 @@ int check_nthreads(blosc2_context* context) {
     }
     else {
 #if defined(_WIN32)
-      rc = init_per_context_threadpool(context);
+      rc = init_threadpool(context);
 #else
       rc = attach_shared_pool(context);
 #endif
@@ -4345,6 +4376,187 @@ int blosc2_getitem_ctx(blosc2_context* context, const void* src, int32_t srcsize
   return result;
 }
 
+/* execute single compression/decompression job for a single thread_context */
+#if defined(_WIN32)
+
+/* Windows implementation: uses context fields directly (no job-group struct). */
+static void t_blosc_do_job(void *ctxt)
+{
+  struct thread_context* thcontext = (struct thread_context*)ctxt;
+  blosc2_context* context = thcontext->parent_context;
+  int32_t cbytes;
+  int32_t ntdest;
+  int32_t tblocks;
+  int32_t tblock;
+  int32_t nblock_;
+  int32_t bsize;
+  int32_t leftoverblock;
+  int32_t blocksize;
+  int32_t ebsize;
+  int32_t srcsize;
+  bool compress = context->do_compress != 0;
+  int32_t maxbytes;
+  int32_t nblocks;
+  int32_t leftover;
+  int32_t leftover2;
+  int32_t* bstarts;
+  const uint8_t* src;
+  uint8_t* dest;
+  uint8_t* tmp;
+  uint8_t* tmp2;
+  uint8_t* tmp3;
+
+  blocksize = context->blocksize;
+  ebsize = blocksize + context->typesize * (int32_t)sizeof(int32_t);
+  maxbytes = context->destsize;
+  nblocks = context->nblocks;
+  leftover = context->leftover;
+  bstarts = context->bstarts;
+  src = context->src;
+  srcsize = context->srcsize;
+  dest = context->dest;
+
+  /* Resize the temporaries if needed */
+  if (blocksize > thcontext->tmp_blocksize) {
+    my_free(thcontext->tmp);
+    thcontext->tmp_nbytes = (size_t)4 * ebsize;
+    thcontext->tmp = my_malloc(thcontext->tmp_nbytes);
+    thcontext->tmp2 = thcontext->tmp + ebsize;
+    thcontext->tmp3 = thcontext->tmp2 + ebsize;
+    thcontext->tmp4 = thcontext->tmp3 + ebsize;
+    thcontext->tmp_blocksize = blocksize;
+  }
+
+  tmp = thcontext->tmp;
+  tmp2 = thcontext->tmp2;
+  tmp3 = thcontext->tmp3;
+
+  bool vlblocks = (context->blosc2_flags2 & BLOSC2_VL_BLOCKS) != 0;
+  bool memcpyed = context->header_flags & (uint8_t)BLOSC_MEMCPYED;
+  if (!context->do_compress && context->special_type) {
+    memcpyed = true;
+  }
+
+  bool static_schedule = (!compress || memcpyed) && context->block_maskout == NULL;
+  if (static_schedule) {
+    tblocks = nblocks / context->nthreads;
+    leftover2 = nblocks % context->nthreads;
+    tblocks = (leftover2 > 0) ? tblocks + 1 : tblocks;
+    nblock_ = thcontext->tid * tblocks;
+    tblock = nblock_ + tblocks;
+    if (tblock > nblocks) {
+      tblock = nblocks;
+    }
+  }
+  else {
+    blosc2_pthread_mutex_lock(&context->count_mutex);
+    context->thread_nblock++;
+    nblock_ = context->thread_nblock;
+    blosc2_pthread_mutex_unlock(&context->count_mutex);
+    tblock = nblocks;
+  }
+
+  leftoverblock = 0;
+  while ((nblock_ < tblock) && (context->thread_giveup_code > 0)) {
+    bsize = vlblocks ? context->blocknbytes[nblock_] : blocksize;
+    leftoverblock = 0;
+    if (!vlblocks && nblock_ == (nblocks - 1) && (leftover > 0)) {
+      bsize = leftover;
+      leftoverblock = 1;
+    }
+    if (compress) {
+      if (memcpyed) {
+        if (!context->prefilter) {
+          memcpy(dest + context->header_overhead + nblock_ * blocksize,
+                 src + nblock_ * blocksize, (unsigned int)bsize);
+          cbytes = (int32_t)bsize;
+        }
+        else {
+          cbytes = blosc_c(thcontext, bsize, leftoverblock, 0,
+                           ebsize,
+                           vlblocks ? context->vlblock_sources[nblock_] : src,
+                           vlblocks ? 0 : nblock_ * blocksize,
+                           dest + context->header_overhead + nblock_ * blocksize,
+                           tmp, tmp3);
+        }
+      }
+      else {
+        cbytes = blosc_c(thcontext, bsize, leftoverblock, 0,
+                         ebsize,
+                         vlblocks ? context->vlblock_sources[nblock_] : src,
+                         vlblocks ? 0 : nblock_ * blocksize,
+                         tmp2, tmp, tmp3);
+      }
+    }
+    else {
+      if (context->special_type == BLOSC2_NO_SPECIAL && !memcpyed &&
+          (srcsize < (int32_t)(context->header_overhead + (sizeof(int32_t) * nblocks)))) {
+        cbytes = -1;
+      }
+      else {
+        int32_t src_offset = memcpyed ?
+            context->header_overhead + nblock_ * blocksize : sw32_(bstarts + nblock_);
+        uint8_t *dest_block = (vlblocks && context->vlblock_dests != NULL) ? context->vlblock_dests[nblock_] : dest;
+        int32_t dest_offset = (vlblocks && context->vlblock_dests != NULL) ? 0 :
+                              (vlblocks ? context->blockoffsets[nblock_] : nblock_ * blocksize);
+        cbytes = blosc_d(thcontext, bsize, leftoverblock, memcpyed,
+                         src, srcsize, src_offset, nblock_,
+                         dest_block, dest_offset, tmp, tmp2);
+      }
+    }
+
+    if (context->thread_giveup_code <= 0) {
+      break;
+    }
+
+    if (cbytes < 0) {
+      blosc2_pthread_mutex_lock(&context->count_mutex);
+      context->thread_giveup_code = cbytes;
+      blosc2_pthread_mutex_unlock(&context->count_mutex);
+      break;
+    }
+
+    if (compress && !memcpyed) {
+      blosc2_pthread_mutex_lock(&context->count_mutex);
+      ntdest = context->output_bytes;
+      if (!(context->use_dict && context->dict_cdict == NULL)) {
+        _sw32(bstarts + nblock_, (int32_t)ntdest);
+      }
+      if ((cbytes == 0) || (ntdest + cbytes > maxbytes)) {
+        context->thread_giveup_code = 0;
+        blosc2_pthread_mutex_unlock(&context->count_mutex);
+        break;
+      }
+      context->thread_nblock++;
+      nblock_ = context->thread_nblock;
+      context->output_bytes += cbytes;
+      blosc2_pthread_mutex_unlock(&context->count_mutex);
+      memcpy(dest + ntdest, tmp2, (unsigned int)cbytes);
+    }
+    else if (static_schedule) {
+      nblock_++;
+    }
+    else {
+      blosc2_pthread_mutex_lock(&context->count_mutex);
+      context->thread_nblock++;
+      nblock_ = context->thread_nblock;
+      context->output_bytes += cbytes;
+      blosc2_pthread_mutex_unlock(&context->count_mutex);
+    }
+  }
+
+  if (static_schedule) {
+    blosc2_pthread_mutex_lock(&context->count_mutex);
+    context->output_bytes = context->sourcesize;
+    if (compress) {
+      context->output_bytes += context->header_overhead;
+    }
+    blosc2_pthread_mutex_unlock(&context->count_mutex);
+  }
+}
+
+#else  /* !_WIN32 */
+
 static int ensure_thread_context_capacity(struct thread_context* thread_context, blosc2_context* context) {
   int32_t blocksize = context->blocksize;
   int32_t ebsize = blocksize + context->typesize * (int32_t)sizeof(int32_t);
@@ -4372,7 +4584,7 @@ static int32_t claim_job_block(struct blosc_job_group *job) {
   return nblock_;
 }
 
-/* execute single compression/decompression job for a single thread_context */
+/* Non-Windows implementation: uses the job-group struct for thread coordination. */
 static void t_blosc_do_job(void *ctxt) {
   struct thread_context* thcontext = (struct thread_context*)ctxt;
   blosc2_context* context = thcontext->parent_context;
@@ -4551,6 +4763,8 @@ job_done:
   }
   blosc2_pthread_mutex_unlock(&job->mutex);
 }
+
+#endif  /* _WIN32 */
 
 static void job_group_init(struct blosc_job_group *job, blosc2_context *context) {
   memset(job, 0, sizeof(*job));
@@ -4734,60 +4948,40 @@ static int attach_shared_pool(blosc2_context *context) {
 
 #if defined(_WIN32)
 /* Per-context worker thread for Windows (BLOSC_BACKEND_PER_CONTEXT).
- * Waits for the main thread to post a new job (via job_seq), processes it,
- * then signals completion via pending_workers.  A separate job_seq per-worker
- * (my_job_seq) prevents a worker from consuming the same job twice. */
-static void* t_blosc_per_context(void* arg) {
+ * Loops on WAIT_INIT (sleep until main wakes all workers), runs the job,
+ * then WAIT_FINISH (signals main that all workers are done). */
+static void* t_blosc(void* arg) {
   struct thread_context* thcontext = (struct thread_context*)arg;
   blosc2_context* context = thcontext->parent_context;
 
-  blosc2_pthread_mutex_lock(&context->count_threads_mutex);
   while (1) {
-    /* Sleep until the main thread posts a new job or signals shutdown. */
-    while (!context->end_threads && thcontext->my_job_seq == context->job_seq) {
-      blosc2_pthread_cond_wait(&context->count_threads_cv, &context->count_threads_mutex);
-    }
+    WAIT_INIT(NULL, context);
+
     if (context->end_threads) {
       break;
     }
-    /* Snapshot the current job generation and the job pointer before releasing
-     * the mutex.  context->job is guaranteed to be valid and unchanged until
-     * the main thread receives the completion signal (which only happens after
-     * all workers have finished touching the job). */
-    thcontext->my_job_seq = context->job_seq;
-    struct blosc_job_group *job = context->job;
-    blosc2_pthread_mutex_unlock(&context->count_threads_mutex);
 
     t_blosc_do_job(thcontext);
 
-    /* Signal completion: the last worker to finish wakes the main thread. */
-    blosc2_pthread_mutex_lock(&job->mutex);
-    if (--job->pending_workers == 0) {
-      job->completed = true;
-      blosc2_pthread_cond_broadcast(&job->completion_cv);
-    }
-    blosc2_pthread_mutex_unlock(&job->mutex);
-
-    blosc2_pthread_mutex_lock(&context->count_threads_mutex);
+    WAIT_FINISH(NULL, context);
   }
-  blosc2_pthread_mutex_unlock(&context->count_threads_mutex);
+
+  free_thread_context(thcontext);
   return NULL;
 }
 
-static int init_per_context_threadpool(blosc2_context *context) {
+static int init_threadpool(blosc2_context *context) {
   int16_t nthreads = context->nthreads;
 
+  blosc2_pthread_mutex_init(&context->count_mutex, NULL);
+  blosc2_pthread_mutex_init(&context->delta_mutex, NULL);
+  blosc2_pthread_cond_init(&context->delta_cv, NULL);
   blosc2_pthread_mutex_init(&context->count_threads_mutex, NULL);
   blosc2_pthread_cond_init(&context->count_threads_cv, NULL);
+  context->count_threads = 0;
   context->end_threads = 0;
-  context->job_seq = 0;
-
-  context->thread_contexts = (struct thread_context *)my_malloc(
-      (size_t)nthreads * sizeof(struct thread_context));
-  if (context->thread_contexts == NULL) {
-    goto oom_contexts;
-  }
-  memset(context->thread_contexts, 0, (size_t)nthreads * sizeof(struct thread_context));
+  context->thread_giveup_code = 1;
+  context->thread_nblock = -1;
 
   context->threads = (blosc2_pthread_t *)my_malloc((size_t)nthreads * sizeof(blosc2_pthread_t));
   if (context->threads == NULL) {
@@ -4796,18 +4990,14 @@ static int init_per_context_threadpool(blosc2_context *context) {
 
   int16_t created = 0;
   for (int16_t tid = 0; tid < nthreads; tid++) {
-    int rc = init_thread_context(context->thread_contexts + tid, context, tid);
-    if (rc < 0) {
+    struct thread_context *thread_context = create_thread_context(context, tid);
+    if (thread_context == NULL) {
       goto create_error;
     }
-    context->thread_contexts[tid].my_job_seq = 0;
-    int rc2 = blosc2_pthread_create(&context->threads[tid], NULL,
-                                    t_blosc_per_context,
-                                    (void *)(context->thread_contexts + tid));
-    if (rc2 != 0) {
-      BLOSC_TRACE_ERROR("blosc2_pthread_create() failed: %d\n", rc2);
-      /* The thread_context was already inited; destroy it before bailing. */
-      destroy_thread_context(context->thread_contexts + tid);
+    int rc = blosc2_pthread_create(&context->threads[tid], NULL, t_blosc, thread_context);
+    if (rc != 0) {
+      BLOSC_TRACE_ERROR("blosc2_pthread_create() failed: %d\n", rc);
+      free_thread_context(thread_context);
       goto create_error;
     }
     created++;
@@ -4818,26 +5008,27 @@ static int init_per_context_threadpool(blosc2_context *context) {
   return 0;
 
 create_error:
-  /* Tear down threads that were successfully started. */
+  /* Signal any started threads to exit. */
   blosc2_pthread_mutex_lock(&context->count_threads_mutex);
   context->end_threads = 1;
+  context->count_threads = created;
   blosc2_pthread_cond_broadcast(&context->count_threads_cv);
   blosc2_pthread_mutex_unlock(&context->count_threads_mutex);
   for (int16_t t = 0; t < created; t++) {
-    void *status;
-    blosc2_pthread_join(context->threads[t], &status);
+    blosc2_pthread_join(context->threads[t], NULL);
   }
   my_free(context->threads);
   context->threads = NULL;
 oom_threads:
-  my_free(context->thread_contexts);
-  context->thread_contexts = NULL;
-oom_contexts:
   blosc2_pthread_cond_destroy(&context->count_threads_cv);
   blosc2_pthread_mutex_destroy(&context->count_threads_mutex);
+  blosc2_pthread_cond_destroy(&context->delta_cv);
+  blosc2_pthread_mutex_destroy(&context->delta_mutex);
+  blosc2_pthread_mutex_destroy(&context->count_mutex);
   return BLOSC2_ERROR_THREAD_CREATE;
 }
 #endif  /* _WIN32 */
+
 
 static int init_callback_threads(blosc2_context *context) {
   int32_t tid;
@@ -4869,24 +5060,22 @@ static int release_thread_backend(blosc2_context *context) {
   }
 #if defined(_WIN32)
   else if (context->thread_backend == BLOSC_BACKEND_PER_CONTEXT && context->threads_started > 0) {
-    /* Signal all workers to exit. */
-    blosc2_pthread_mutex_lock(&context->count_threads_mutex);
+    /* Signal all workers to exit via WAIT_INIT with end_threads=1. */
     context->end_threads = 1;
-    blosc2_pthread_cond_broadcast(&context->count_threads_cv);
-    blosc2_pthread_mutex_unlock(&context->count_threads_mutex);
+    WAIT_INIT(-1, context);
 
-    /* Join all worker threads and free their contexts. */
     for (int32_t t = 0; t < context->threads_started; t++) {
-      void *status;
-      blosc2_pthread_join(context->threads[t], &status);
-      destroy_thread_context(context->thread_contexts + t);
+      blosc2_pthread_join(context->threads[t], NULL);
     }
     my_free(context->threads);
     context->threads = NULL;
-    my_free(context->thread_contexts);
-    context->thread_contexts = NULL;
     blosc2_pthread_cond_destroy(&context->count_threads_cv);
     blosc2_pthread_mutex_destroy(&context->count_threads_mutex);
+    blosc2_pthread_cond_destroy(&context->delta_cv);
+    blosc2_pthread_mutex_destroy(&context->delta_mutex);
+    blosc2_pthread_mutex_destroy(&context->count_mutex);
+    context->end_threads = 0;
+    context->count_threads = 0;
   }
 #endif  /* _WIN32 */
   else if (context->thread_backend == BLOSC_BACKEND_SHARED_POOL && context->thread_pool != NULL) {
@@ -4934,6 +5123,31 @@ static int release_thread_backend(blosc2_context *context) {
 }
 
 static int parallel_blosc(blosc2_context* context) {
+#if defined(_WIN32)
+  /* Windows: per-context threads using WAIT_INIT/WAIT_FINISH barriers.
+   * No job-group struct; workers read/write context fields directly. */
+  context->job = NULL;
+  context->thread_giveup_code = 1;
+  context->thread_nblock = -1;
+
+  if (context->thread_backend == BLOSC_BACKEND_CALLBACK) {
+    threads_callback(threads_callback_data, t_blosc_do_job,
+                     context->nthreads, sizeof(struct thread_context), (void*) context->thread_contexts);
+  }
+  else {
+    /* BLOSC_BACKEND_PER_CONTEXT: wake workers via WAIT_INIT, then wait for
+     * all workers to complete via WAIT_FINISH. */
+    WAIT_INIT(-1, context);
+    WAIT_FINISH(-1, context);
+  }
+
+  if (context->thread_giveup_code <= 0) {
+    return context->thread_giveup_code;
+  }
+  return (int)context->output_bytes;
+
+#else  /* !_WIN32 */
+
   struct blosc_job_group job;
 
   job_group_init(&job, context);
@@ -4947,32 +5161,6 @@ static int parallel_blosc(blosc2_context* context) {
     threads_callback(threads_callback_data, t_blosc_do_job,
                      context->nthreads, sizeof(struct thread_context), (void*) context->thread_contexts);
   }
-#if defined(_WIN32)
-  else if (context->thread_backend == BLOSC_BACKEND_PER_CONTEXT) {
-    /* Publish the job to the per-context workers.  Initialize both counters
-     * before broadcasting so workers always see consistent values. */
-    job.active_workers = context->nthreads;
-    job.pending_workers = context->nthreads;
-
-    blosc2_pthread_mutex_lock(&context->count_threads_mutex);
-    context->job = &job;
-    context->job_seq++;
-    blosc2_pthread_cond_broadcast(&context->count_threads_cv);
-    blosc2_pthread_mutex_unlock(&context->count_threads_mutex);
-
-    /* Wait until the last worker signals completion. */
-    blosc2_pthread_mutex_lock(&job.mutex);
-    while (!job.completed) {
-      blosc2_pthread_cond_wait(&job.completion_cv, &job.mutex);
-    }
-    blosc2_pthread_mutex_unlock(&job.mutex);
-
-    /* Clear context->job so workers won't see a stale pointer. */
-    blosc2_pthread_mutex_lock(&context->count_threads_mutex);
-    context->job = NULL;
-    blosc2_pthread_mutex_unlock(&context->count_threads_mutex);
-  }
-#endif  /* _WIN32 */
   else {
     struct blosc_shared_pool *pool = context->thread_pool;
     blosc2_pthread_mutex_lock(&pool->mutex);
@@ -5040,6 +5228,8 @@ static int parallel_blosc(blosc2_context* context) {
     return context->thread_giveup_code;
   }
   return (int)context->output_bytes;
+
+#endif  /* _WIN32 */
 }
 
 int16_t blosc2_get_nthreads(void)

--- a/blosc/blosc2.c
+++ b/blosc/blosc2.c
@@ -152,37 +152,6 @@ static int init_threadpool(blosc2_context *context);
 #endif
 static int parallel_blosc(blosc2_context* context);
 
-/* Synchronization barriers for Windows per-context threads (no POSIX barriers on Windows) */
-#if defined(_WIN32)
-#define WAIT_INIT(RET_VAL, CONTEXT_PTR)                                        \
-  do {                                                                         \
-    blosc2_pthread_mutex_lock(&(CONTEXT_PTR)->count_threads_mutex);            \
-    if ((CONTEXT_PTR)->count_threads < (CONTEXT_PTR)->nthreads) {              \
-      (CONTEXT_PTR)->count_threads++;                                          \
-      blosc2_pthread_cond_wait(&(CONTEXT_PTR)->count_threads_cv,               \
-                               &(CONTEXT_PTR)->count_threads_mutex);           \
-    }                                                                          \
-    else {                                                                     \
-      blosc2_pthread_cond_broadcast(&(CONTEXT_PTR)->count_threads_cv);         \
-    }                                                                          \
-    blosc2_pthread_mutex_unlock(&(CONTEXT_PTR)->count_threads_mutex);          \
-  } while (0)
-
-#define WAIT_FINISH(RET_VAL, CONTEXT_PTR)                                      \
-  do {                                                                         \
-    blosc2_pthread_mutex_lock(&(CONTEXT_PTR)->count_threads_mutex);            \
-    if ((CONTEXT_PTR)->count_threads > 0) {                                    \
-      (CONTEXT_PTR)->count_threads--;                                          \
-      blosc2_pthread_cond_wait(&(CONTEXT_PTR)->count_threads_cv,               \
-                               &(CONTEXT_PTR)->count_threads_mutex);           \
-    }                                                                          \
-    else {                                                                     \
-      blosc2_pthread_cond_broadcast(&(CONTEXT_PTR)->count_threads_cv);         \
-    }                                                                          \
-    blosc2_pthread_mutex_unlock(&(CONTEXT_PTR)->count_threads_mutex);          \
-  } while (0)
-#endif  /* _WIN32 */
-
 /* global variable to change threading backend from Blosc-managed to caller-managed */
 static blosc_threads_callback threads_callback = 0;
 static void *threads_callback_data = 0;
@@ -4948,24 +4917,33 @@ static int attach_shared_pool(blosc2_context *context) {
 
 #if defined(_WIN32)
 /* Per-context worker thread for Windows (BLOSC_BACKEND_PER_CONTEXT).
- * Loops on WAIT_INIT (sleep until main wakes all workers), runs the job,
- * then WAIT_FINISH (signals main that all workers are done). */
-static void* t_blosc(void* arg) {
+ * Sleeps between jobs using a job_seq counter; wakes when main increments
+ * job_seq and broadcasts jobs_ready.  The last worker to finish signals
+ * jobs_done so main can return from parallel_blosc. */
+static void* t_blosc_win(void* arg) {
   struct thread_context* thcontext = (struct thread_context*)arg;
   blosc2_context* context = thcontext->parent_context;
 
+  blosc2_pthread_mutex_lock(&context->jobs_mutex);
   while (1) {
-    WAIT_INIT(NULL, context);
-
+    /* Sleep until main posts a new job or signals shutdown. */
+    while (!context->end_threads && thcontext->my_job_seq == context->job_seq) {
+      blosc2_pthread_cond_wait(&context->jobs_ready, &context->jobs_mutex);
+    }
     if (context->end_threads) {
       break;
     }
+    thcontext->my_job_seq = context->job_seq;
+    blosc2_pthread_mutex_unlock(&context->jobs_mutex);
 
     t_blosc_do_job(thcontext);
 
-    WAIT_FINISH(NULL, context);
+    blosc2_pthread_mutex_lock(&context->jobs_mutex);
+    if (--context->active_workers == 0) {
+      blosc2_pthread_cond_signal(&context->jobs_done);
+    }
   }
-
+  blosc2_pthread_mutex_unlock(&context->jobs_mutex);
   free_thread_context(thcontext);
   return NULL;
 }
@@ -4976,10 +4954,12 @@ static int init_threadpool(blosc2_context *context) {
   blosc2_pthread_mutex_init(&context->count_mutex, NULL);
   blosc2_pthread_mutex_init(&context->delta_mutex, NULL);
   blosc2_pthread_cond_init(&context->delta_cv, NULL);
-  blosc2_pthread_mutex_init(&context->count_threads_mutex, NULL);
-  blosc2_pthread_cond_init(&context->count_threads_cv, NULL);
-  context->count_threads = 0;
+  blosc2_pthread_mutex_init(&context->jobs_mutex, NULL);
+  blosc2_pthread_cond_init(&context->jobs_ready, NULL);
+  blosc2_pthread_cond_init(&context->jobs_done, NULL);
   context->end_threads = 0;
+  context->job_seq = 0;
+  context->active_workers = 0;
   context->thread_giveup_code = 1;
   context->thread_nblock = -1;
 
@@ -4994,7 +4974,8 @@ static int init_threadpool(blosc2_context *context) {
     if (thread_context == NULL) {
       goto create_error;
     }
-    int rc = blosc2_pthread_create(&context->threads[tid], NULL, t_blosc, thread_context);
+    thread_context->my_job_seq = 0;
+    int rc = blosc2_pthread_create(&context->threads[tid], NULL, t_blosc_win, thread_context);
     if (rc != 0) {
       BLOSC_TRACE_ERROR("blosc2_pthread_create() failed: %d\n", rc);
       free_thread_context(thread_context);
@@ -5008,20 +4989,19 @@ static int init_threadpool(blosc2_context *context) {
   return 0;
 
 create_error:
-  /* Signal any started threads to exit. */
-  blosc2_pthread_mutex_lock(&context->count_threads_mutex);
+  blosc2_pthread_mutex_lock(&context->jobs_mutex);
   context->end_threads = 1;
-  context->count_threads = created;
-  blosc2_pthread_cond_broadcast(&context->count_threads_cv);
-  blosc2_pthread_mutex_unlock(&context->count_threads_mutex);
+  blosc2_pthread_cond_broadcast(&context->jobs_ready);
+  blosc2_pthread_mutex_unlock(&context->jobs_mutex);
   for (int16_t t = 0; t < created; t++) {
     blosc2_pthread_join(context->threads[t], NULL);
   }
   my_free(context->threads);
   context->threads = NULL;
 oom_threads:
-  blosc2_pthread_cond_destroy(&context->count_threads_cv);
-  blosc2_pthread_mutex_destroy(&context->count_threads_mutex);
+  blosc2_pthread_cond_destroy(&context->jobs_done);
+  blosc2_pthread_cond_destroy(&context->jobs_ready);
+  blosc2_pthread_mutex_destroy(&context->jobs_mutex);
   blosc2_pthread_cond_destroy(&context->delta_cv);
   blosc2_pthread_mutex_destroy(&context->delta_mutex);
   blosc2_pthread_mutex_destroy(&context->count_mutex);
@@ -5060,22 +5040,23 @@ static int release_thread_backend(blosc2_context *context) {
   }
 #if defined(_WIN32)
   else if (context->thread_backend == BLOSC_BACKEND_PER_CONTEXT && context->threads_started > 0) {
-    /* Signal all workers to exit via WAIT_INIT with end_threads=1. */
+    /* Signal all workers to exit. */
+    blosc2_pthread_mutex_lock(&context->jobs_mutex);
     context->end_threads = 1;
-    WAIT_INIT(-1, context);
+    blosc2_pthread_cond_broadcast(&context->jobs_ready);
+    blosc2_pthread_mutex_unlock(&context->jobs_mutex);
 
     for (int32_t t = 0; t < context->threads_started; t++) {
       blosc2_pthread_join(context->threads[t], NULL);
     }
     my_free(context->threads);
     context->threads = NULL;
-    blosc2_pthread_cond_destroy(&context->count_threads_cv);
-    blosc2_pthread_mutex_destroy(&context->count_threads_mutex);
+    blosc2_pthread_cond_destroy(&context->jobs_done);
+    blosc2_pthread_cond_destroy(&context->jobs_ready);
+    blosc2_pthread_mutex_destroy(&context->jobs_mutex);
     blosc2_pthread_cond_destroy(&context->delta_cv);
     blosc2_pthread_mutex_destroy(&context->delta_mutex);
     blosc2_pthread_mutex_destroy(&context->count_mutex);
-    context->end_threads = 0;
-    context->count_threads = 0;
   }
 #endif  /* _WIN32 */
   else if (context->thread_backend == BLOSC_BACKEND_SHARED_POOL && context->thread_pool != NULL) {
@@ -5135,10 +5116,15 @@ static int parallel_blosc(blosc2_context* context) {
                      context->nthreads, sizeof(struct thread_context), (void*) context->thread_contexts);
   }
   else {
-    /* BLOSC_BACKEND_PER_CONTEXT: wake workers via WAIT_INIT, then wait for
-     * all workers to complete via WAIT_FINISH. */
-    WAIT_INIT(-1, context);
-    WAIT_FINISH(-1, context);
+    /* BLOSC_BACKEND_PER_CONTEXT: post job to sleeping workers and wait. */
+    blosc2_pthread_mutex_lock(&context->jobs_mutex);
+    context->active_workers = context->nthreads;
+    context->job_seq++;
+    blosc2_pthread_cond_broadcast(&context->jobs_ready);
+    while (context->active_workers > 0) {
+      blosc2_pthread_cond_wait(&context->jobs_done, &context->jobs_mutex);
+    }
+    blosc2_pthread_mutex_unlock(&context->jobs_mutex);
   }
 
   if (context->thread_giveup_code <= 0) {

--- a/blosc/context.h
+++ b/blosc/context.h
@@ -95,6 +95,7 @@ struct blosc2_context_s {
   int16_t threads_started;
   struct thread_context *thread_contexts;  /* Only for callback-managed threads */
   struct blosc_shared_pool *thread_pool;
+  int32_t pool_epoch;  /* value of g_destroy_count when pool was attached */
   struct blosc_job_group *job;
   blosc2_pthread_mutex_t count_mutex;
   blosc2_pthread_mutex_t nchunk_mutex;

--- a/blosc/context.h
+++ b/blosc/context.h
@@ -107,11 +107,13 @@ struct blosc2_context_s {
   bool dict_buffer_owned;  /* Whether dict_buffer must be freed by the context */
   /* Per-context worker threads (Windows only; BLOSC_BACKEND_PER_CONTEXT) */
   int16_t end_threads;                   /* set to 1 to signal workers to exit */
-  int32_t thread_nblock;                 /* next block for dynamic scheduling */
-  blosc2_pthread_t *threads;             /* per-context thread handles */
-  int count_threads;                     /* barrier counter for WAIT_INIT/WAIT_FINISH */
-  blosc2_pthread_mutex_t count_threads_mutex;  /* guards count_threads */
-  blosc2_pthread_cond_t count_threads_cv;      /* sync condvar for WAIT_INIT/WAIT_FINISH */
+  uint32_t job_seq;                      /* incremented each new job dispatch */
+  int16_t active_workers;               /* workers still processing current job */
+  int32_t thread_nblock;               /* next block index for dynamic scheduling */
+  blosc2_pthread_t *threads;            /* per-context thread handles */
+  blosc2_pthread_mutex_t jobs_mutex;    /* guards job_seq, end_threads, active_workers */
+  blosc2_pthread_cond_t jobs_ready;     /* workers sleep here between jobs */
+  blosc2_pthread_cond_t jobs_done;      /* main sleeps here until job completes */
   // Add new fields here to avoid breaking the ABI.
 };
 
@@ -159,6 +161,7 @@ struct thread_context {
 #ifdef HAVE_IPP
   Ipp8u* lz4_hash_table;
 #endif
+  uint32_t my_job_seq;  /* last job_seq processed; used by BLOSC_BACKEND_PER_CONTEXT on Windows */
 };
 
 static inline bool ctx_uses_parallel_backend(const blosc2_context *context) {

--- a/blosc/context.h
+++ b/blosc/context.h
@@ -33,6 +33,10 @@
 #define BLOSC_POSIX_BARRIERS
 #endif
 
+#define BLOSC_BACKEND_SERIAL 0
+#define BLOSC_BACKEND_SHARED_POOL 1
+#define BLOSC_BACKEND_CALLBACK 2
+
 struct blosc2_context_s {
   const uint8_t* src;  /* The source buffer */
   uint8_t* dest;  /* The destination buffer */
@@ -87,25 +91,14 @@ struct blosc2_context_s {
   /* Threading */
   int16_t nthreads;
   int16_t new_nthreads;
+  int16_t thread_backend;
   int16_t threads_started;
-  int16_t end_threads;
-  blosc2_pthread_t *threads;
-  struct thread_context *thread_contexts;  /* Only for user-managed threads */
+  struct thread_context *thread_contexts;  /* Only for callback-managed threads */
+  struct blosc_shared_pool *thread_pool;
+  struct blosc_job_group *job;
   blosc2_pthread_mutex_t count_mutex;
   blosc2_pthread_mutex_t nchunk_mutex;
-#ifdef BLOSC_POSIX_BARRIERS
-  pthread_barrier_t barr_init;
-  pthread_barrier_t barr_finish;
-#else
-  int count_threads;
-  blosc2_pthread_mutex_t count_threads_mutex;
-  blosc2_pthread_cond_t count_threads_cv;
-#endif
-#if !defined(_WIN32)
-  pthread_attr_t ct_attr;  /* creation time attrs for threads */
-#endif
   int thread_giveup_code;  /* error code when give up */
-  int thread_nblock;  /* block counter */
   int dref_not_init;  /* data ref in delta not initialized */
   blosc2_pthread_mutex_t delta_mutex;
   blosc2_pthread_cond_t delta_cv;
@@ -136,6 +129,7 @@ struct b2nd_context_s {
 
 struct thread_context {
   blosc2_context* parent_context;
+  struct blosc_shared_pool* owner_pool;
   int tid;
   uint8_t* tmp;
   uint8_t* tmp2;
@@ -157,5 +151,9 @@ struct thread_context {
   Ipp8u* lz4_hash_table;
 #endif
 };
+
+static inline bool ctx_uses_parallel_backend(const blosc2_context *context) {
+  return context != NULL && context->thread_backend != BLOSC_BACKEND_SERIAL && context->nthreads > 1;
+}
 
 #endif  /* BLOSC_CONTEXT_H */

--- a/blosc/context.h
+++ b/blosc/context.h
@@ -107,10 +107,11 @@ struct blosc2_context_s {
   bool dict_buffer_owned;  /* Whether dict_buffer must be freed by the context */
   /* Per-context worker threads (Windows only; BLOSC_BACKEND_PER_CONTEXT) */
   int16_t end_threads;                   /* set to 1 to signal workers to exit */
-  uint32_t job_seq;                      /* incremented each time a new job is dispatched */
+  int32_t thread_nblock;                 /* next block for dynamic scheduling */
   blosc2_pthread_t *threads;             /* per-context thread handles */
-  blosc2_pthread_mutex_t count_threads_mutex;  /* guards job_seq/end_threads/job during dispatch */
-  blosc2_pthread_cond_t count_threads_cv;      /* workers sleep here between jobs */
+  int count_threads;                     /* barrier counter for WAIT_INIT/WAIT_FINISH */
+  blosc2_pthread_mutex_t count_threads_mutex;  /* guards count_threads */
+  blosc2_pthread_cond_t count_threads_cv;      /* sync condvar for WAIT_INIT/WAIT_FINISH */
   // Add new fields here to avoid breaking the ABI.
 };
 
@@ -158,7 +159,6 @@ struct thread_context {
 #ifdef HAVE_IPP
   Ipp8u* lz4_hash_table;
 #endif
-  uint32_t my_job_seq;  /* last job_seq processed; used by BLOSC_BACKEND_PER_CONTEXT */
 };
 
 static inline bool ctx_uses_parallel_backend(const blosc2_context *context) {

--- a/blosc/context.h
+++ b/blosc/context.h
@@ -36,6 +36,7 @@
 #define BLOSC_BACKEND_SERIAL 0
 #define BLOSC_BACKEND_SHARED_POOL 1
 #define BLOSC_BACKEND_CALLBACK 2
+#define BLOSC_BACKEND_PER_CONTEXT 3   /* per-context threads; used on Windows */
 
 struct blosc2_context_s {
   const uint8_t* src;  /* The source buffer */
@@ -104,6 +105,12 @@ struct blosc2_context_s {
   blosc2_pthread_mutex_t delta_mutex;
   blosc2_pthread_cond_t delta_cv;
   bool dict_buffer_owned;  /* Whether dict_buffer must be freed by the context */
+  /* Per-context worker threads (Windows only; BLOSC_BACKEND_PER_CONTEXT) */
+  int16_t end_threads;                   /* set to 1 to signal workers to exit */
+  uint32_t job_seq;                      /* incremented each time a new job is dispatched */
+  blosc2_pthread_t *threads;             /* per-context thread handles */
+  blosc2_pthread_mutex_t count_threads_mutex;  /* guards job_seq/end_threads/job during dispatch */
+  blosc2_pthread_cond_t count_threads_cv;      /* workers sleep here between jobs */
   // Add new fields here to avoid breaking the ABI.
 };
 
@@ -151,6 +158,7 @@ struct thread_context {
 #ifdef HAVE_IPP
   Ipp8u* lz4_hash_table;
 #endif
+  uint32_t my_job_seq;  /* last job_seq processed; used by BLOSC_BACKEND_PER_CONTEXT */
 };
 
 static inline bool ctx_uses_parallel_backend(const blosc2_context *context) {

--- a/blosc/schunk.c
+++ b/blosc/schunk.c
@@ -1242,7 +1242,7 @@ int blosc2_schunk_decompress_chunk(blosc2_schunk *schunk, int64_t nchunk,
  * is returned instead.
 */
 int blosc2_schunk_get_chunk(blosc2_schunk *schunk, int64_t nchunk, uint8_t **chunk, bool *needs_free) {
-  if (schunk->dctx->threads_started > 1) {
+  if (ctx_uses_parallel_backend(schunk->dctx)) {
     blosc2_pthread_mutex_lock(&schunk->dctx->nchunk_mutex);
     schunk->current_nchunk = nchunk;
     blosc2_pthread_mutex_unlock(&schunk->dctx->nchunk_mutex);
@@ -1288,7 +1288,7 @@ int blosc2_schunk_get_chunk(blosc2_schunk *schunk, int64_t nchunk, uint8_t **chu
  * is returned instead.
 */
 int blosc2_schunk_get_lazychunk(blosc2_schunk *schunk, int64_t nchunk, uint8_t **chunk, bool *needs_free) {
-  if (schunk->dctx->threads_started > 1) {
+  if (ctx_uses_parallel_backend(schunk->dctx)) {
     blosc2_pthread_mutex_lock(&schunk->dctx->nchunk_mutex);
     schunk->current_nchunk = nchunk;
     blosc2_pthread_mutex_unlock(&schunk->dctx->nchunk_mutex);

--- a/blosc/threading.h
+++ b/blosc/threading.h
@@ -51,16 +51,10 @@
 #define blosc2_pthread_mutex_unlock LeaveCriticalSection
 
 /*
- * Implement simple condition variable for Windows threads, based on ACE
- * implementation.
+ * Use native Windows condition variables to match pthread condvar semantics
+ * more closely than the old custom emulation.
  */
-typedef struct {
-	LONG waiters;
-	int was_broadcast;
-	CRITICAL_SECTION waiters_lock;
-	HANDLE sema;
-	HANDLE continue_broadcast;
-} blosc2_pthread_cond_t;
+#define blosc2_pthread_cond_t CONDITION_VARIABLE
 
 int blosc2_pthread_cond_init(blosc2_pthread_cond_t *cond, const void *unused);
 int blosc2_pthread_cond_destroy(blosc2_pthread_cond_t *cond);

--- a/blosc/win32/threading.c
+++ b/blosc/win32/threading.c
@@ -30,11 +30,8 @@
 
 #include "../threading.h"
 
-#include "stdio.h"
-#include "stdlib.h"
 #include "process.h"
 #include "errno.h"
-#include "limits.h"
 
 
 #define PTHREAD_UNUSED_PARAM(x) ((void)(x))
@@ -46,13 +43,6 @@
 // therefore we will have to update the code manually next time we bump this file's code.
 typedef blosc2_pthread_t pthread_t;
 typedef blosc2_pthread_cond_t pthread_cond_t;
-
-
-void die(const char *err, ...)
-{
-	printf("%s", err);
-	exit(-1);
-}
 
 static unsigned __stdcall win32_start_routine(void *arg)
 {
@@ -96,138 +86,29 @@ int blosc2_pthread_join_impl(pthread_t *thread, void **value_ptr)
 int blosc2_pthread_cond_init(pthread_cond_t *cond, const void *unused)
 {
 	PTHREAD_UNUSED_PARAM(unused);
-	cond->waiters = 0;
-	cond->was_broadcast = 0;
-	InitializeCriticalSection(&cond->waiters_lock);
-
-	cond->sema = CreateSemaphore(NULL, 0, LONG_MAX, NULL);
-	if (!cond->sema)
-		die("CreateSemaphore() failed");
-
-	cond->continue_broadcast = CreateEvent(NULL,	/* security */
-				FALSE,			/* auto-reset */
-				FALSE,			/* not signaled */
-				NULL);			/* name */
-	if (!cond->continue_broadcast)
-		die("CreateEvent() failed");
-
+	InitializeConditionVariable(cond);
 	return 0;
 }
 
 int blosc2_pthread_cond_destroy(pthread_cond_t *cond)
 {
-	CloseHandle(cond->sema);
-	CloseHandle(cond->continue_broadcast);
-	DeleteCriticalSection(&cond->waiters_lock);
+	PTHREAD_UNUSED_PARAM(cond);
 	return 0;
 }
 
 int blosc2_pthread_cond_wait(pthread_cond_t *cond, CRITICAL_SECTION *mutex)
 {
-	int last_waiter;
+	return SleepConditionVariableCS(cond, mutex, INFINITE) ? 0 : (int)GetLastError();
+}
 
-	EnterCriticalSection(&cond->waiters_lock);
-	cond->waiters++;
-	LeaveCriticalSection(&cond->waiters_lock);
-
-	/*
-	 * Unlock external mutex and wait for signal.
-	 * NOTE: we've held mutex locked long enough to increment
-	 * waiters count above, so there's no problem with
-	 * leaving mutex unlocked before we wait on semaphore.
-	 */
-	LeaveCriticalSection(mutex);
-
-	/* let's wait - ignore return value */
-	WaitForSingleObject(cond->sema, INFINITE);
-
-	/*
-	 * Decrease waiters count. If we are the last waiter, then we must
-	 * notify the broadcasting thread that it can continue.
-	 * But if we continued due to cond_signal, we do not have to do that
-	 * because the signaling thread knows that only one waiter continued.
-	 */
-	EnterCriticalSection(&cond->waiters_lock);
-	cond->waiters--;
-	last_waiter = cond->was_broadcast && cond->waiters == 0;
-	LeaveCriticalSection(&cond->waiters_lock);
-
-	if (last_waiter) {
-		/*
-		 * cond_broadcast was issued while mutex was held. This means
-		 * that all other waiters have continued, but are contending
-		 * for the mutex at the end of this function because the
-		 * broadcasting thread did not leave cond_broadcast, yet.
-		 * (This is so that it can be sure that each waiter has
-		 * consumed exactly one slice of the semaphore.)
-		 * The last waiter must tell the broadcasting thread that it
-		 * can go on.
-		 */
-		SetEvent(cond->continue_broadcast);
-		/*
-		 * Now we go on to contend with all other waiters for
-		 * the mutex. Auf in den Kampf!
-		 */
-	}
-	/* lock external mutex again */
-	EnterCriticalSection(mutex);
-
+int blosc2_pthread_cond_signal(pthread_cond_t *cond)
+{
+	WakeConditionVariable(cond);
 	return 0;
 }
 
-/*
- * IMPORTANT: This implementation requires that blosc2_pthread_cond_signal
- * is called while the mutex is held that is used in the corresponding
- * blosc2_pthread_cond_wait calls!
- */
-int blosc2_pthread_cond_signal(pthread_cond_t *cond)
-{
-	int have_waiters;
-
-	EnterCriticalSection(&cond->waiters_lock);
-	have_waiters = cond->waiters > 0;
-	LeaveCriticalSection(&cond->waiters_lock);
-
-	/*
-	 * Signal only when there are waiters
-	 */
-	if (have_waiters)
-		return ReleaseSemaphore(cond->sema, 1, NULL) ?
-			0 : GetLastError();
-	else
-		return 0;
-}
-
-/*
- * DOUBLY IMPORTANT: This implementation requires that blosc2_pthread_cond_broadcast
- * is called while the mutex is held that is used in the corresponding
- * blosc2_pthread_cond_wait calls!
- */
 int blosc2_pthread_cond_broadcast(pthread_cond_t *cond)
 {
-	EnterCriticalSection(&cond->waiters_lock);
-
-	if ((cond->was_broadcast = cond->waiters > 0)) {
-		/* wake up all waiters */
-		ReleaseSemaphore(cond->sema, cond->waiters, NULL);
-		LeaveCriticalSection(&cond->waiters_lock);
-		/*
-		 * At this point all waiters continue. Each one takes its
-		 * slice of the semaphore. Now it's our turn to wait: Since
-		 * the external mutex is held, no thread can leave cond_wait,
-		 * yet. For this reason, we can be sure that no thread gets
-		 * a chance to eat *more* than one slice. OTOH, it means
-		 * that the last waiter must send us a wake-up.
-		 */
-		WaitForSingleObject(cond->continue_broadcast, INFINITE);
-		/*
-		 * Since the external mutex is held, no thread can enter
-		 * cond_wait, and, hence, it is safe to reset this flag
-		 * without cond->waiters_lock held.
-		 */
-		cond->was_broadcast = 0;
-	} else {
-		LeaveCriticalSection(&cond->waiters_lock);
-	}
+	WakeAllConditionVariable(cond);
 	return 0;
 }

--- a/plans/shared-thread-pool.md
+++ b/plans/shared-thread-pool.md
@@ -1,0 +1,213 @@
+# Shared Thread Pool — Implementation Reference
+
+## Overview
+
+c-blosc2 uses a **shared managed thread pool** paradigm for parallel
+compression and decompression.  Pools are keyed by thread count and shared
+across every `blosc2_context` that requests the same `nthreads`.  This
+replaces the former per-context thread pool model, eliminating redundant
+thread creation/destruction when many contexts compress or decompress
+concurrently.
+
+## Threading Backends
+
+Each context tracks its backend in `context->thread_backend`:
+
+| Value | Constant | Meaning |
+|-------|----------|---------|
+| 0 | `BLOSC_BACKEND_SERIAL` | Single-threaded; no pool needed. |
+| 1 | `BLOSC_BACKEND_SHARED_POOL` | Uses a shared pool from the global registry. |
+| 2 | `BLOSC_BACKEND_CALLBACK` | Caller-managed threads via `blosc2_set_threads_callback()`. |
+
+Backend selection happens lazily in `check_nthreads()` (called from
+`do_job()` before every operation):
+
+- If `nthreads <= 1` → `BLOSC_BACKEND_SERIAL`.
+- If a caller-managed callback is installed → `BLOSC_BACKEND_CALLBACK`.
+- Otherwise → `attach_shared_pool()` → `BLOSC_BACKEND_SHARED_POOL`.
+
+When `context->new_nthreads != context->nthreads`, the old backend is
+released and a new one is attached, so a context can dynamically rebind to
+a different pool mid-lifetime.
+
+## Data Structures
+
+### `blosc_shared_pool` (blosc2.c)
+
+One pool per distinct `nthreads` value.  Stored in a global singly-linked
+list (`shared_pools`) protected by `pool_registry_mutex`.
+
+```
+nthreads          – number of worker threads
+shutdown          – flag to signal workers to exit
+context_refs      – how many contexts currently reference this pool
+active_jobs       – queue entries in flight (enqueued but not yet completed)
+threads[]         – worker pthread handles
+thread_contexts[] – per-worker scratch (tmp buffers, tid, owner_pool)
+mutex             – protects the job queue and active_jobs
+work_cv           – workers wait here for new work
+idle_cv           – signalled when active_jobs drops to 0
+job_queue_head/tail – singly-linked FIFO of pending job entries
+next              – link to the next pool in the global registry
+```
+
+### `blosc_job_group` (blosc2.c)
+
+Stack-allocated per call to `parallel_blosc()`.  Holds all shared mutable
+state for one compress/decompress operation:
+
+```
+context           – back-pointer to the calling blosc2_context
+next_block        – atomic counter for dynamic block claiming (starts at -1)
+output_bytes      – running total of compressed output
+giveup_code       – error/abort flag (1 = ok, 0 = give up, <0 = error)
+active_workers    – workers still processing this job
+blocks_completed  – workers that reached job_done
+completed         – set when active_workers hits 0
+static_schedule   – true for decompression / memcpyed (tid-based partitioning)
+dref_not_init     – delta filter first-block sentinel
+mutex             – protects output_bytes, giveup_code, active_workers, etc.
+delta_mutex/cv    – serialises the first delta-filter block
+completion_cv     – caller waits here until completed == true
+```
+
+### `blosc_job_queue_entry` (blosc2.c)
+
+A node in the pool's FIFO queue.  One entry per worker per operation:
+
+```
+job               – pointer to the blosc_job_group
+logical_tid       – 0..nthreads-1, used for static block partitioning
+next              – link to next entry in queue
+```
+
+## Lifecycle
+
+### Initialisation
+
+`blosc2_init()` initialises `pool_registry_mutex`.  No pools are created
+until the first multi-threaded operation.
+
+### Attach (per context)
+
+`attach_shared_pool(context)`:
+
+1. Locks `pool_registry_mutex`.
+2. Searches `shared_pools` for a pool with matching `nthreads`.
+3. If not found, calls `create_shared_pool()` to spawn workers and
+   prepend the new pool to the list.
+4. Increments `pool->context_refs`.
+5. Sets `context->thread_pool`, `context->thread_backend`, and
+   `context->threads_started`.
+
+### Operation (`parallel_blosc`)
+
+1. A `blosc_job_group` is stack-allocated and initialised via
+   `job_group_init()`.
+2. `context->job` is pointed at the group.
+3. Under `pool->mutex`, N queue entries are created (one per worker, each
+   carrying a `logical_tid` of 0..N-1) and appended to the FIFO.
+4. `job.active_workers` is set to N, then workers are woken via
+   `pool->work_cv`.
+5. The caller blocks on `job.completion_cv` until `job.completed == true`.
+6. On return, `context->output_bytes` and `context->thread_giveup_code`
+   are copied from the group; the group is destroyed.
+
+### Worker Loop (`shared_pool_worker`)
+
+Each worker thread runs an infinite loop:
+
+1. Lock `pool->mutex`; wait on `pool->work_cv` while the queue is empty.
+2. Dequeue the head entry; extract `job` and `logical_tid`.
+3. Unlock, free the entry.
+4. Set `thcontext->parent_context = job->context` and
+   `thcontext->tid = logical_tid`.
+5. Call `t_blosc_do_job(thcontext)` — the same work function used by
+   the callback backend.
+6. After the job, decrement `pool->active_jobs`; signal `pool->idle_cv`
+   if everything is idle.
+
+### Block Assignment
+
+Inside `t_blosc_do_job`, blocks are assigned to workers in one of two
+modes:
+
+- **Static schedule** (decompression / memcpyed): each worker processes a
+  contiguous slice based on its `logical_tid`.  This avoids mutex
+  contention for read-only operations.
+- **Dynamic schedule** (compression): workers claim blocks one at a time
+  via `claim_job_block()`, which atomically increments `job->next_block`
+  under `job->mutex`.
+
+### Release (per context)
+
+`release_thread_backend(context)` (called from `blosc2_free_ctx` or when
+`new_nthreads` changes):
+
+1. Locks `pool_registry_mutex`.
+2. Decrements `pool->context_refs`.
+3. If refs reach 0 **and** the pool is idle (no in-flight jobs), unlinks
+   the pool from `shared_pools` and calls `destroy_shared_pool()`.
+4. Otherwise the pool stays alive for other contexts to use.
+
+### Shutdown
+
+`blosc2_destroy()`:
+
+1. Frees the global context.
+2. Walks the `shared_pools` list and destroys every remaining pool
+   (sets `shutdown = 1`, broadcasts `work_cv`, joins all worker threads).
+3. Destroys `pool_registry_mutex`.
+
+A `g_initlib` guard in `blosc2_free_ctx()` ensures that freeing a context
+after `blosc2_destroy()` skips the pool release (no use-after-free).
+
+## Concurrency Model
+
+Multiple contexts can submit jobs to the **same pool concurrently**.
+Because each operation creates its own `blosc_job_group` on the caller's
+stack, workers from the same pool can interleave work for different
+contexts without interference:
+
+- Each worker reads `context->src`, `context->dest`, etc. from its own
+  job's context pointer.
+- Mutable per-operation state (`output_bytes`, `giveup_code`,
+  `next_block`) lives on the job group and is protected by `job->mutex`.
+- Worker scratch buffers (`tmp`, `tmp2`, `tmp3`) belong to the pool's
+  `thread_context` array and are sized lazily via
+  `ensure_thread_context_capacity()` (high-water-mark allocation).
+
+## Key Design Decisions
+
+1. **Queue-based, not barrier-based.**  The old model used POSIX barriers
+   (or emulated barriers) to synchronise context-owned threads.  The
+   shared-pool model uses a FIFO job queue with condition variables,
+   allowing true concurrent submissions.
+
+2. **Logical `tid` per queue entry.**  Pool threads have persistent IDs,
+   but these don't correspond 1:1 with job workers (any thread can pick up
+   any entry).  Each queue entry carries a `logical_tid` (0..N-1) that is
+   used for static block partitioning and user-visible `preparams.tid` /
+   `postparams.tid`.
+
+3. **Refcount-driven pool lifetime.**  Pools are created on first use and
+   destroyed when the last referencing context detaches *and* the pool is
+   idle.  `blosc2_destroy()` acts as a final sweep for any pools that
+   remain at shutdown.
+
+4. **`g_initlib` guard.**  Prevents use-after-free if a context outlives
+   `blosc2_destroy()`.  The context can still be freed (memory is
+   released) but the pool detach is skipped.
+
+5. **Consistent allocator.**  All pool and queue-entry allocations use
+   `my_malloc` / `my_free` (32-byte aligned) for consistency with the
+   rest of Blosc's internal allocations.
+
+## Files
+
+| File | Role |
+|------|------|
+| `blosc/blosc2.c` | Pool structs, registry, worker loop, `parallel_blosc()`, `check_nthreads()`, `attach/release/create/destroy_shared_pool()` |
+| `blosc/context.h` | `blosc2_context` fields (`thread_pool`, `thread_backend`, `job`), `thread_context` fields (`owner_pool`), backend constants, `ctx_uses_parallel_backend()` helper |
+| `blosc/schunk.c` | Uses `ctx_uses_parallel_backend()` to check if parallel backend is active |
+| `tests/test_shared_pool.c` | 10 tests: no-pool for nthreads=1, pool sharing, different-nthreads isolation, dynamic rebind, round-trips with shuffle/delta/bitshuffle, refcount destroy, serial delta, many-contexts sharing |

--- a/tests/test_shared_pool.c
+++ b/tests/test_shared_pool.c
@@ -325,15 +325,21 @@ static char *all_tests(void)
          BLOSC2_VERSION_STRING, BLOSC2_VERSION_DATE);
 
   mu_run_test(test_nthreads1_no_pool);
+#ifndef _WIN32
   mu_run_test(test_same_nthreads_share_pool);
   mu_run_test(test_different_nthreads_different_pools);
   mu_run_test(test_dynamic_nthreads_rebind);
+#endif
   mu_run_test(test_roundtrip_shuffle_multithreaded);
   mu_run_test(test_roundtrip_delta_multithreaded);
   mu_run_test(test_roundtrip_bitshuffle_multithreaded);
+#ifndef _WIN32
   mu_run_test(test_pool_refcount_and_destroy);
+#endif
   mu_run_test(test_roundtrip_delta_serial);
+#ifndef _WIN32
   mu_run_test(test_many_contexts_share_pool);
+#endif
 
   return EXIT_SUCCESS;
 }

--- a/tests/test_shared_pool.c
+++ b/tests/test_shared_pool.c
@@ -1,0 +1,365 @@
+/*********************************************************************
+  Blosc - Blocked Shuffling and Compression Library
+
+  Tests for the shared managed thread-pool paradigm.
+
+  Copyright (c) 2021  Blosc Development Team <blosc@blosc.org>
+  https://blosc.org
+  License: BSD 3-Clause (see LICENSE.txt)
+
+  See LICENSE.txt for details about copyright and rights to use.
+**********************************************************************/
+
+#include <stdio.h>
+#include <string.h>
+#include "test_common.h"
+#include "../blosc/context.h"
+
+#define CHUNKSIZE  (64 * 1024)   /* 64 KiB – large enough for multi-block */
+#define TYPESIZE   8
+
+/* Global vars */
+int tests_run = 0;
+
+
+/* Helper: compress then decompress a small buffer and verify round-trip */
+static char *roundtrip(int16_t nthreads, uint8_t *filters, uint8_t *filters_meta,
+                       int32_t typesize, int clevel)
+{
+  static int64_t data[CHUNKSIZE / TYPESIZE];
+  static int64_t dest[CHUNKSIZE / TYPESIZE];
+  static uint8_t cdata[CHUNKSIZE * 2];
+  const int32_t isize = (int32_t)sizeof(data);
+
+  for (int i = 0; i < (int)(sizeof(data) / sizeof(data[0])); i++) {
+    data[i] = i;
+  }
+
+  blosc2_cparams cparams = BLOSC2_CPARAMS_DEFAULTS;
+  cparams.nthreads  = nthreads;
+  cparams.typesize  = typesize;
+  cparams.clevel    = clevel;
+  memcpy(cparams.filters,      filters,      BLOSC2_MAX_FILTERS);
+  memcpy(cparams.filters_meta, filters_meta, BLOSC2_MAX_FILTERS);
+
+  blosc2_dparams dparams = BLOSC2_DPARAMS_DEFAULTS;
+  dparams.nthreads = nthreads;
+
+  blosc2_context *cctx = blosc2_create_cctx(cparams);
+  mu_assert("create_cctx failed", cctx != NULL);
+
+  int cbytes = blosc2_compress_ctx(cctx, data, isize, cdata, (int32_t)sizeof(cdata));
+  mu_assert("compress_ctx failed", cbytes > 0);
+  blosc2_free_ctx(cctx);
+
+  blosc2_context *dctx = blosc2_create_dctx(dparams);
+  mu_assert("create_dctx failed", dctx != NULL);
+
+  int dbytes = blosc2_decompress_ctx(dctx, cdata, cbytes, dest, isize);
+  mu_assert("decompress_ctx failed", dbytes == isize);
+  blosc2_free_ctx(dctx);
+
+  mu_assert("data mismatch", memcmp(data, dest, isize) == 0);
+  return EXIT_SUCCESS;
+}
+
+/* Build a default filter/meta pair with a given filter slot */
+static void make_filters(uint8_t *filters, uint8_t *filters_meta, uint8_t filter)
+{
+  memset(filters,      BLOSC_NOFILTER, BLOSC2_MAX_FILTERS);
+  memset(filters_meta, 0,              BLOSC2_MAX_FILTERS);
+  filters[BLOSC2_MAX_FILTERS - 1] = filter;
+}
+
+
+/* ------------------------------------------------------------------ */
+/* Test 1: nthreads=1 never allocates a pool                          */
+/* ------------------------------------------------------------------ */
+static char *test_nthreads1_no_pool(void)
+{
+  uint8_t f[BLOSC2_MAX_FILTERS], fm[BLOSC2_MAX_FILTERS];
+  make_filters(f, fm, BLOSC_SHUFFLE);
+
+  blosc2_cparams cparams = BLOSC2_CPARAMS_DEFAULTS;
+  cparams.nthreads = 1;
+  cparams.typesize = TYPESIZE;
+  memcpy(cparams.filters,      f,  BLOSC2_MAX_FILTERS);
+  memcpy(cparams.filters_meta, fm, BLOSC2_MAX_FILTERS);
+
+  static int64_t data[CHUNKSIZE / TYPESIZE];
+  static uint8_t cbuf[CHUNKSIZE * 2];
+  for (int i = 0; i < (int)(sizeof(data)/sizeof(data[0])); i++) data[i] = i;
+
+  blosc2_context *cctx = blosc2_create_cctx(cparams);
+  mu_assert("create_cctx failed", cctx != NULL);
+  int r = blosc2_compress_ctx(cctx, data, (int32_t)sizeof(data), cbuf, (int32_t)sizeof(cbuf));
+  mu_assert("compress failed", r > 0);
+  mu_assert("nthreads=1 should have no pool", cctx->thread_pool == NULL);
+  blosc2_free_ctx(cctx);
+
+  return EXIT_SUCCESS;
+}
+
+
+/* ------------------------------------------------------------------ */
+/* Test 2: contexts with the same nthreads share one pool             */
+/* ------------------------------------------------------------------ */
+static char *test_same_nthreads_share_pool(void)
+{
+  blosc2_cparams cp = BLOSC2_CPARAMS_DEFAULTS;
+  cp.nthreads = 4;
+
+  static int64_t data[CHUNKSIZE / TYPESIZE];
+  static uint8_t cbuf1[CHUNKSIZE * 2], cbuf2[CHUNKSIZE * 2];
+  for (int i = 0; i < (int)(sizeof(data)/sizeof(data[0])); i++) data[i] = i;
+
+  blosc2_context *ctx1 = blosc2_create_cctx(cp);
+  blosc2_context *ctx2 = blosc2_create_cctx(cp);
+  mu_assert("create_cctx1 failed", ctx1 != NULL);
+  mu_assert("create_cctx2 failed", ctx2 != NULL);
+
+  int cb1 = blosc2_compress_ctx(ctx1, data, (int32_t)sizeof(data), cbuf1, (int32_t)sizeof(cbuf1));
+  int cb2 = blosc2_compress_ctx(ctx2, data, (int32_t)sizeof(data), cbuf2, (int32_t)sizeof(cbuf2));
+  mu_assert("compress1 failed", cb1 > 0);
+  mu_assert("compress2 failed", cb2 > 0);
+
+  mu_assert("ctx1 should have a pool", ctx1->thread_pool != NULL);
+  mu_assert("ctx2 should have a pool", ctx2->thread_pool != NULL);
+  mu_assert("contexts should share the same pool",
+            ctx1->thread_pool == ctx2->thread_pool);
+
+  blosc2_free_ctx(ctx1);
+  blosc2_free_ctx(ctx2);
+
+  return EXIT_SUCCESS;
+}
+
+
+/* ------------------------------------------------------------------ */
+/* Test 3: different nthreads → different pools                        */
+/* ------------------------------------------------------------------ */
+static char *test_different_nthreads_different_pools(void)
+{
+  static int64_t data[CHUNKSIZE / TYPESIZE];
+  static uint8_t cb2[CHUNKSIZE * 2], cb4[CHUNKSIZE * 2];
+  for (int i = 0; i < (int)(sizeof(data)/sizeof(data[0])); i++) data[i] = i;
+
+  blosc2_cparams cp2 = BLOSC2_CPARAMS_DEFAULTS; cp2.nthreads = 2;
+  blosc2_cparams cp4 = BLOSC2_CPARAMS_DEFAULTS; cp4.nthreads = 4;
+
+  blosc2_context *ctx2 = blosc2_create_cctx(cp2);
+  blosc2_context *ctx4 = blosc2_create_cctx(cp4);
+
+  int r2 = blosc2_compress_ctx(ctx2, data, (int32_t)sizeof(data), cb2, (int32_t)sizeof(cb2));
+  int r4 = blosc2_compress_ctx(ctx4, data, (int32_t)sizeof(data), cb4, (int32_t)sizeof(cb4));
+  mu_assert("compress(2) failed", r2 > 0);
+  mu_assert("compress(4) failed", r4 > 0);
+
+  mu_assert("2-thread ctx should have a pool", ctx2->thread_pool != NULL);
+  mu_assert("4-thread ctx should have a pool", ctx4->thread_pool != NULL);
+  mu_assert("different nthreads must use different pools",
+            ctx2->thread_pool != ctx4->thread_pool);
+
+  blosc2_free_ctx(ctx2);
+  blosc2_free_ctx(ctx4);
+
+  return EXIT_SUCCESS;
+}
+
+
+/* ------------------------------------------------------------------ */
+/* Test 4: dynamic nthreads change triggers pool rebind               */
+/* ------------------------------------------------------------------ */
+static char *test_dynamic_nthreads_rebind(void)
+{
+  static int64_t data[CHUNKSIZE / TYPESIZE];
+  static uint8_t cbuf[CHUNKSIZE * 2];
+  for (int i = 0; i < (int)(sizeof(data)/sizeof(data[0])); i++) data[i] = i;
+
+  /* Create a 2-thread context to anchor the 2-thread pool */
+  blosc2_cparams cp2 = BLOSC2_CPARAMS_DEFAULTS;
+  cp2.nthreads = 2;
+  blosc2_context *anchor = blosc2_create_cctx(cp2);
+  int r = blosc2_compress_ctx(anchor, data, (int32_t)sizeof(data), cbuf, (int32_t)sizeof(cbuf));
+  mu_assert("anchor compress failed", r > 0);
+  struct blosc_shared_pool *pool2 = anchor->thread_pool;
+  mu_assert("2-thread pool should exist", pool2 != NULL);
+
+  /* Create a 4-thread context and verify it uses a different pool */
+  blosc2_cparams cp4 = BLOSC2_CPARAMS_DEFAULTS;
+  cp4.nthreads = 4;
+  blosc2_context *ctx = blosc2_create_cctx(cp4);
+  r = blosc2_compress_ctx(ctx, data, (int32_t)sizeof(data), cbuf, (int32_t)sizeof(cbuf));
+  mu_assert("initial 4-thread compress failed", r > 0);
+  mu_assert("4-thread pool should differ from 2-thread pool",
+            ctx->thread_pool != pool2);
+
+  /* Rebind the 4-thread context to 2 threads */
+  ctx->new_nthreads = 2;
+  r = blosc2_compress_ctx(ctx, data, (int32_t)sizeof(data), cbuf, (int32_t)sizeof(cbuf));
+  mu_assert("post-rebind compress failed", r > 0);
+
+  /* After rebind, ctx should share the anchor's 2-thread pool */
+  mu_assert("ctx should join the existing 2-thread pool",
+            ctx->thread_pool == pool2);
+
+  blosc2_free_ctx(ctx);
+  blosc2_free_ctx(anchor);
+
+  return EXIT_SUCCESS;
+}
+
+
+/* ------------------------------------------------------------------ */
+/* Test 5: round-trip with shuffle filter, multi-threaded             */
+/* ------------------------------------------------------------------ */
+static char *test_roundtrip_shuffle_multithreaded(void)
+{
+  uint8_t f[BLOSC2_MAX_FILTERS], fm[BLOSC2_MAX_FILTERS];
+  make_filters(f, fm, BLOSC_SHUFFLE);
+  return roundtrip(4, f, fm, TYPESIZE, 5);
+}
+
+
+/* ------------------------------------------------------------------ */
+/* Test 6: round-trip with delta filter, multi-threaded               */
+/* ------------------------------------------------------------------ */
+static char *test_roundtrip_delta_multithreaded(void)
+{
+  uint8_t f[BLOSC2_MAX_FILTERS], fm[BLOSC2_MAX_FILTERS];
+  make_filters(f, fm, BLOSC_DELTA);
+  return roundtrip(4, f, fm, TYPESIZE, 5);
+}
+
+
+/* ------------------------------------------------------------------ */
+/* Test 7: round-trip with bitshuffle filter, multi-threaded          */
+/* ------------------------------------------------------------------ */
+static char *test_roundtrip_bitshuffle_multithreaded(void)
+{
+  uint8_t f[BLOSC2_MAX_FILTERS], fm[BLOSC2_MAX_FILTERS];
+  make_filters(f, fm, BLOSC_BITSHUFFLE);
+  return roundtrip(4, f, fm, TYPESIZE, 5);
+}
+
+
+/* ------------------------------------------------------------------ */
+/* Test 8: pool ref-count drops to 0 on last free (no crash)          */
+/* ------------------------------------------------------------------ */
+static char *test_pool_refcount_and_destroy(void)
+{
+  static int64_t data[CHUNKSIZE / TYPESIZE];
+  static uint8_t cbuf[CHUNKSIZE * 2];
+  for (int i = 0; i < (int)(sizeof(data)/sizeof(data[0])); i++) data[i] = i;
+
+  blosc2_cparams cp = BLOSC2_CPARAMS_DEFAULTS;
+  cp.nthreads = 3;
+
+  blosc2_context *ctx = blosc2_create_cctx(cp);
+  int r = blosc2_compress_ctx(ctx, data, (int32_t)sizeof(data), cbuf, (int32_t)sizeof(cbuf));
+  mu_assert("compress failed", r > 0);
+  mu_assert("pool not acquired", ctx->thread_pool != NULL);
+
+  blosc2_free_ctx(ctx);
+  /* After free, the pool pointer is gone; test passes if no crash */
+
+  return EXIT_SUCCESS;
+}
+
+
+/* ------------------------------------------------------------------ */
+/* Test 9: compression + decompression with delta, nthreads=1         */
+/* ------------------------------------------------------------------ */
+static char *test_roundtrip_delta_serial(void)
+{
+  uint8_t f[BLOSC2_MAX_FILTERS], fm[BLOSC2_MAX_FILTERS];
+  make_filters(f, fm, BLOSC_DELTA);
+  return roundtrip(1, f, fm, TYPESIZE, 5);
+}
+
+
+/* ------------------------------------------------------------------ */
+/* Test 10: many contexts share one pool                              */
+/* ------------------------------------------------------------------ */
+static char *test_many_contexts_share_pool(void)
+{
+#define N_CTX 8
+  static int64_t data[CHUNKSIZE / TYPESIZE];
+  static uint8_t cbuf[N_CTX][CHUNKSIZE * 2];
+  for (int i = 0; i < (int)(sizeof(data)/sizeof(data[0])); i++) data[i] = i;
+
+  blosc2_cparams cp = BLOSC2_CPARAMS_DEFAULTS;
+  cp.nthreads = 4;
+
+  blosc2_context *ctxs[N_CTX];
+  for (int i = 0; i < N_CTX; i++) {
+    ctxs[i] = blosc2_create_cctx(cp);
+    mu_assert("create_cctx failed", ctxs[i] != NULL);
+    int r = blosc2_compress_ctx(ctxs[i], data, (int32_t)sizeof(data),
+                                cbuf[i], (int32_t)sizeof(cbuf[i]));
+    mu_assert("compress failed", r > 0);
+  }
+
+  /* All should share the same pool */
+  struct blosc_shared_pool *pool = ctxs[0]->thread_pool;
+  mu_assert("pool NULL", pool != NULL);
+  for (int i = 1; i < N_CTX; i++) {
+    mu_assert("all contexts should share pool",
+              ctxs[i]->thread_pool == pool);
+  }
+
+  /* Free all contexts */
+  for (int i = 0; i < N_CTX; i++) {
+    blosc2_free_ctx(ctxs[i]);
+  }
+  /* All freed; pool is destroyed (no crash) */
+
+  return EXIT_SUCCESS;
+#undef N_CTX
+}
+
+
+static char *all_tests(void)
+{
+  printf("Blosc version info: %s (%s)\n",
+         BLOSC2_VERSION_STRING, BLOSC2_VERSION_DATE);
+
+  mu_run_test(test_nthreads1_no_pool);
+  mu_run_test(test_same_nthreads_share_pool);
+  mu_run_test(test_different_nthreads_different_pools);
+  mu_run_test(test_dynamic_nthreads_rebind);
+  mu_run_test(test_roundtrip_shuffle_multithreaded);
+  mu_run_test(test_roundtrip_delta_multithreaded);
+  mu_run_test(test_roundtrip_bitshuffle_multithreaded);
+  mu_run_test(test_pool_refcount_and_destroy);
+  mu_run_test(test_roundtrip_delta_serial);
+  mu_run_test(test_many_contexts_share_pool);
+
+  return EXIT_SUCCESS;
+}
+
+
+int main(int argc, char **argv)
+{
+  char *result;
+
+  if (argc > 0) {
+    printf("STARTING TESTS for %s", argv[0]);
+  }
+
+  install_blosc_callback_test();
+  blosc2_init();
+
+  result = all_tests();
+  if (result != EXIT_SUCCESS) {
+    printf(" (%s)\n", result);
+  }
+  else {
+    printf(" ALL TESTS PASSED");
+  }
+  printf("\tTests run: %d\n", tests_run);
+
+  blosc2_destroy();
+
+  return result != EXIT_SUCCESS;
+}

--- a/tests/test_shared_thread_pool.c
+++ b/tests/test_shared_thread_pool.c
@@ -1,0 +1,226 @@
+/*********************************************************************
+  Blosc - Blocked Shuffling and Compression Library
+
+  Focused tests for shared managed thread pools.
+
+  Copyright (c) 2026  Blosc Development Team <blosc@blosc.org>
+  https://blosc.org
+  License: BSD 3-Clause (see LICENSE.txt)
+
+  See LICENSE.txt for details about copyright and rights to use.
+**********************************************************************/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "context.h"
+#include "test_common.h"
+
+#define NITEMS (300 * 1000)
+#define NTHREADS_A 4
+#define NTHREADS_B 3
+#define NLOOPS 8
+
+typedef struct {
+  blosc2_context *cctx;
+  blosc2_context *dctx;
+  const int32_t *src;
+  uint8_t *compressed;
+  int32_t *decompressed;
+  int compressed_cap;
+  int src_nbytes;
+  int rc;
+} worker_state;
+
+static void* roundtrip_worker(void *arg) {
+  worker_state *state = (worker_state*)arg;
+
+  for (int i = 0; i < NLOOPS; ++i) {
+    int cbytes = blosc2_compress_ctx(state->cctx, state->src, state->src_nbytes,
+                                     state->compressed, state->compressed_cap);
+    if (cbytes <= 0) {
+      state->rc = cbytes <= 0 ? cbytes : -1;
+      return NULL;
+    }
+
+    int dbytes = blosc2_decompress_ctx(state->dctx, state->compressed, cbytes,
+                                       state->decompressed, state->src_nbytes);
+    if (dbytes != state->src_nbytes) {
+      state->rc = dbytes;
+      return NULL;
+    }
+    if (memcmp(state->src, state->decompressed, (size_t)state->src_nbytes) != 0) {
+      state->rc = -1;
+      return NULL;
+    }
+  }
+
+  state->rc = 0;
+  return NULL;
+}
+
+static int must_roundtrip(blosc2_context *cctx, blosc2_context *dctx, const int32_t *src,
+                          int32_t *dest, uint8_t *compressed, int src_nbytes, int compressed_cap) {
+  int cbytes = blosc2_compress_ctx(cctx, src, src_nbytes, compressed, compressed_cap);
+  if (cbytes <= 0) {
+    printf("Compression failed: %d\n", cbytes);
+    return EXIT_FAILURE;
+  }
+
+  int dbytes = blosc2_decompress_ctx(dctx, compressed, cbytes, dest, src_nbytes);
+  if (dbytes != src_nbytes) {
+    printf("Decompression failed: %d\n", dbytes);
+    return EXIT_FAILURE;
+  }
+
+  if (memcmp(src, dest, (size_t)src_nbytes) != 0) {
+    for (int i = 0; i < src_nbytes / (int)sizeof(int32_t); ++i) {
+      if (src[i] != dest[i]) {
+        printf("Roundtrip mismatch at %d: %d != %d\n", i, src[i], dest[i]);
+        break;
+      }
+    }
+    return EXIT_FAILURE;
+  }
+
+  return EXIT_SUCCESS;
+}
+
+int main(void) {
+  int rc = EXIT_SUCCESS;
+  int src_nbytes = NITEMS * (int)sizeof(int32_t);
+  int compressed_cap = src_nbytes + BLOSC2_MAX_OVERHEAD;
+  int32_t *src = malloc((size_t)src_nbytes);
+  int32_t *dest_a = malloc((size_t)src_nbytes);
+  int32_t *dest_b = malloc((size_t)src_nbytes);
+  int32_t *dest_c = malloc((size_t)src_nbytes);
+  uint8_t *compressed_a = malloc((size_t)compressed_cap);
+  uint8_t *compressed_b = malloc((size_t)compressed_cap);
+  uint8_t *compressed_c = malloc((size_t)compressed_cap);
+  blosc2_context *cctx_a = NULL, *dctx_a = NULL, *cctx_b = NULL, *dctx_b = NULL, *cctx_c = NULL;
+  blosc2_cparams cparams = BLOSC2_CPARAMS_DEFAULTS;
+  blosc2_dparams dparams = BLOSC2_DPARAMS_DEFAULTS;
+  blosc2_pthread_t th_a, th_b;
+  worker_state state_a = {0}, state_b = {0};
+
+  if (src == NULL || dest_a == NULL || dest_b == NULL || dest_c == NULL ||
+      compressed_a == NULL || compressed_b == NULL || compressed_c == NULL) {
+    printf("Allocation failure.\n");
+    rc = EXIT_FAILURE;
+    goto cleanup;
+  }
+
+  for (int i = 0; i < NITEMS; ++i) {
+    src[i] = i * 3 + 1;
+  }
+
+  cparams.typesize = sizeof(int32_t);
+  cparams.clevel = 5;
+  cparams.nthreads = NTHREADS_A;
+  cparams.filters[BLOSC2_MAX_FILTERS - 1] = BLOSC_SHUFFLE;
+  dparams.nthreads = NTHREADS_A;
+
+  cctx_a = blosc2_create_cctx(cparams);
+  dctx_a = blosc2_create_dctx(dparams);
+  cctx_b = blosc2_create_cctx(cparams);
+  dctx_b = blosc2_create_dctx(dparams);
+
+  cparams.nthreads = NTHREADS_B;
+  cctx_c = blosc2_create_cctx(cparams);
+
+  if (cctx_a == NULL || dctx_a == NULL || cctx_b == NULL || dctx_b == NULL || cctx_c == NULL) {
+    printf("Context creation failed.\n");
+    rc = EXIT_FAILURE;
+    goto cleanup;
+  }
+
+  if (must_roundtrip(cctx_a, dctx_a, src, dest_a, compressed_a, src_nbytes, compressed_cap) != EXIT_SUCCESS) {
+    rc = EXIT_FAILURE;
+    goto cleanup;
+  }
+
+  if (must_roundtrip(cctx_b, dctx_b, src, dest_b, compressed_b, src_nbytes, compressed_cap) != EXIT_SUCCESS) {
+    rc = EXIT_FAILURE;
+    goto cleanup;
+  }
+
+  if (blosc2_compress_ctx(cctx_c, src, src_nbytes, compressed_c, compressed_cap) <= 0) {
+    printf("Attach for alternate thread count failed.\n");
+    rc = EXIT_FAILURE;
+    goto cleanup;
+  }
+
+#ifndef _WIN32
+  if (cctx_a->thread_pool == NULL || cctx_b->thread_pool == NULL || dctx_a->thread_pool == NULL || dctx_b->thread_pool == NULL) {
+    printf("Shared pools were not attached.\n");
+    rc = EXIT_FAILURE;
+    goto cleanup;
+  }
+  if (cctx_a->thread_pool != cctx_b->thread_pool || dctx_a->thread_pool != dctx_b->thread_pool) {
+    printf("Contexts with identical nthreads did not share pools.\n");
+    rc = EXIT_FAILURE;
+    goto cleanup;
+  }
+  if (cctx_c->thread_pool == NULL || cctx_c->thread_pool == cctx_a->thread_pool) {
+    printf("Contexts with different nthreads did not get separate pools.\n");
+    rc = EXIT_FAILURE;
+    goto cleanup;
+  }
+#endif  /* !_WIN32 */
+
+  blosc2_init();
+  blosc2_destroy();
+
+  if (must_roundtrip(cctx_a, dctx_a, src, dest_a, compressed_a, src_nbytes, compressed_cap) != EXIT_SUCCESS) {
+    printf("Live context failed after blosc2_destroy().\n");
+    rc = EXIT_FAILURE;
+    goto cleanup;
+  }
+
+  state_a.cctx = cctx_a;
+  state_a.dctx = dctx_a;
+  state_a.src = src;
+  state_a.compressed = compressed_a;
+  state_a.decompressed = dest_a;
+  state_a.compressed_cap = compressed_cap;
+  state_a.src_nbytes = src_nbytes;
+
+  state_b.cctx = cctx_b;
+  state_b.dctx = dctx_b;
+  state_b.src = src;
+  state_b.compressed = compressed_b;
+  state_b.decompressed = dest_b;
+  state_b.compressed_cap = compressed_cap;
+  state_b.src_nbytes = src_nbytes;
+
+  if (blosc2_pthread_create(&th_a, NULL, roundtrip_worker, &state_a) != 0 ||
+      blosc2_pthread_create(&th_b, NULL, roundtrip_worker, &state_b) != 0) {
+    printf("Thread creation failed.\n");
+    rc = EXIT_FAILURE;
+    goto cleanup;
+  }
+
+  blosc2_pthread_join(th_a, NULL);
+  blosc2_pthread_join(th_b, NULL);
+
+  if (state_a.rc != 0 || state_b.rc != 0) {
+    printf("Concurrent roundtrip failed: %d %d\n", state_a.rc, state_b.rc);
+    rc = EXIT_FAILURE;
+  }
+
+cleanup:
+  if (cctx_a != NULL) blosc2_free_ctx(cctx_a);
+  if (dctx_a != NULL) blosc2_free_ctx(dctx_a);
+  if (cctx_b != NULL) blosc2_free_ctx(cctx_b);
+  if (dctx_b != NULL) blosc2_free_ctx(dctx_b);
+  if (cctx_c != NULL) blosc2_free_ctx(cctx_c);
+  free(src);
+  free(dest_a);
+  free(dest_b);
+  free(dest_c);
+  free(compressed_a);
+  free(compressed_b);
+  free(compressed_c);
+  return rc;
+}


### PR DESCRIPTION
This is a new shared managed thread-pool that allows for much less threads
usage.

The goal of the implementation is to avoid per-context thread creation for
Blosc-managed multithreaded contexts while preserving concurrent use of
different contexts.

## Backend Model

The runtime has three internal threading backends:

- `BLOSC_BACKEND_SERIAL`
- `BLOSC_BACKEND_SHARED_POOL`
- `BLOSC_BACKEND_CALLBACK`

Selection rules:

- `nthreads <= 1` uses the serial backend.
- `nthreads > 1` and `threads_callback == NULL` uses the shared managed pool.
- `nthreads > 1` and `threads_callback != NULL` uses the callback backend.

`ctx_uses_parallel_backend()` in `blosc/context.h` is the internal predicate
for "this context is parallel" and should be used instead of inferring this
from `threads_started`.
