### PR TITLE
Fix out-of-bounds read in frame parsing validation

### DIFF
--- a/blosc/frame.c
+++ b/blosc/frame.c
@@ -2109,6 +2109,12 @@ blosc2_schunk* frame_to_schunk(blosc2_frame_s* frame, bool copy, const blosc2_io
         }
       }
       else {
+        if (offsets[i] > INT64_MAX - header_len ||
+            header_len + offsets[i] > frame->len - BLOSC_EXTENDED_HEADER_LENGTH ||
+            offsets[i] > cbytes - BLOSC_EXTENDED_HEADER_LENGTH) {
+          rc = BLOSC2_ERROR_INVALID_HEADER;
+          break;
+        }
         data_chunk = frame->cframe + header_len + offsets[i];
         needs_free = false;
       }
@@ -2116,10 +2122,17 @@ blosc2_schunk* frame_to_schunk(blosc2_frame_s* frame, bool copy, const blosc2_io
       if (rc < 0) {
         break;
       }
+      if (offsets[i] >= 0 &&
+          (chunk_cbytes < BLOSC_EXTENDED_HEADER_LENGTH ||
+           offsets[i] > INT64_MAX - chunk_cbytes ||
+           offsets[i] + chunk_cbytes > cbytes)) {
+        rc = BLOSC2_ERROR_INVALID_HEADER;
+        break;
+      }
     }
     else {
       int64_t rbytes;
-      if (frame->sframe) {
+      if (offsets[i] < 0 || frame->sframe) {
         if (needs_free) {
           free(data_chunk);
         }
@@ -2129,6 +2142,12 @@ blosc2_schunk* frame_to_schunk(blosc2_frame_s* frame, bool copy, const blosc2_io
         }
       }
       else {
+        if (offsets[i] > INT64_MAX - header_len ||
+            header_len + offsets[i] > frame->len - BLOSC_EXTENDED_HEADER_LENGTH ||
+            offsets[i] > cbytes - BLOSC_EXTENDED_HEADER_LENGTH) {
+          rc = BLOSC2_ERROR_INVALID_HEADER;
+          break;
+        }
         int64_t io_pos = frame->file_offset + header_len + offsets[i];
         rbytes = io_cb->read((void**)&data_chunk, 1, BLOSC_EXTENDED_HEADER_LENGTH, io_pos, fp);
       }
@@ -2138,6 +2157,13 @@ blosc2_schunk* frame_to_schunk(blosc2_frame_s* frame, bool copy, const blosc2_io
       }
       rc = blosc2_cbuffer_sizes(data_chunk, NULL, &chunk_cbytes, NULL);
       if (rc < 0) {
+        break;
+      }
+      if (offsets[i] >= 0 &&
+          (chunk_cbytes < BLOSC_EXTENDED_HEADER_LENGTH ||
+           offsets[i] > INT64_MAX - chunk_cbytes ||
+           offsets[i] + chunk_cbytes > cbytes)) {
+        rc = BLOSC2_ERROR_INVALID_HEADER;
         break;
       }
       if (chunk_cbytes > (int32_t)prev_alloc) {
@@ -2257,9 +2283,23 @@ int get_coffset(blosc2_frame_s* frame, int32_t header_len, int64_t cbytes,
   int rc = blosc2_getitem(coffsets, off_cbytes, (int32_t)nchunk, 1, offset, (int32_t)sizeof(int64_t));
   if (rc < 0) {
     BLOSC_TRACE_ERROR("Problems retrieving a chunk offset.");
-  } else if (!frame->sframe && *offset > frame->len) {
-    BLOSC_TRACE_ERROR("Cannot read chunk %" PRId64 " outside of frame boundary.", nchunk);
-    rc = BLOSC2_ERROR_READ_BUFFER;
+  } else if (!frame->sframe && *offset >= 0) {
+    if (cbytes < 0 || cbytes > INT64_MAX - header_len) {
+      BLOSC_TRACE_ERROR("Invalid compressed size in frame header.");
+      return BLOSC2_ERROR_INVALID_HEADER;
+    }
+    if (*offset > INT64_MAX - header_len) {
+      BLOSC_TRACE_ERROR("Offset for chunk %" PRId64 " overflows frame position.", nchunk);
+      return BLOSC2_ERROR_INVALID_HEADER;
+    }
+    int64_t chunk_pos = header_len + *offset;
+    int64_t data_limit = header_len + cbytes;
+    if (chunk_pos < header_len ||
+        chunk_pos > data_limit - BLOSC_EXTENDED_HEADER_LENGTH ||
+        chunk_pos > frame->len - BLOSC_EXTENDED_HEADER_LENGTH) {
+      BLOSC_TRACE_ERROR("Cannot read chunk %" PRId64 " outside of frame boundary.", nchunk);
+      return BLOSC2_ERROR_INVALID_HEADER;
+    }
   }
 
   return rc;
@@ -2411,6 +2451,13 @@ int frame_get_chunk(blosc2_frame_s *frame, int64_t nchunk, uint8_t **chunk, bool
       io_cb->close(fp);
       return rc;
     }
+    if (chunk_cbytes < BLOSC_EXTENDED_HEADER_LENGTH ||
+        offset > INT64_MAX - chunk_cbytes ||
+        offset + chunk_cbytes > cbytes) {
+      BLOSC_TRACE_ERROR("Invalid chunk size in frame for chunk %" PRId64 ".", nchunk);
+      io_cb->close(fp);
+      return BLOSC2_ERROR_INVALID_HEADER;
+    }
     if (io_cb->is_allocation_necessary) {
       *chunk = malloc(chunk_cbytes);
       *needs_free = true;
@@ -2433,6 +2480,12 @@ int frame_get_chunk(blosc2_frame_s *frame, int64_t nchunk, uint8_t **chunk, bool
     rc = blosc2_cbuffer_sizes(*chunk, NULL, &chunk_cbytes, NULL);
     if (rc < 0) {
       return rc;
+    }
+    if (chunk_cbytes < BLOSC_EXTENDED_HEADER_LENGTH ||
+        offset > INT64_MAX - chunk_cbytes ||
+        offset + chunk_cbytes > cbytes) {
+      BLOSC_TRACE_ERROR("Invalid chunk size in frame for chunk %" PRId64 ".", nchunk);
+      return BLOSC2_ERROR_INVALID_HEADER;
     }
   }
 

--- a/tests/test_frame_malformed_offsets.c
+++ b/tests/test_frame_malformed_offsets.c
@@ -1,0 +1,136 @@
+/*
+  Copyright (c) 2026  Blosc Development Team <blosc@blosc.org>
+  https://blosc.org
+  License: BSD 3-Clause (see LICENSE.txt)
+*/
+
+#include <limits.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#include "blosc-private.h"
+#include "frame.h"
+#include "test_common.h"
+
+#define CHUNKSIZE (256)
+#define NCHUNKS (32)
+
+/* Global vars */
+int tests_run = 0;
+
+static int32_t build_malicious_offsets_chunk(const int64_t *offsets, int32_t offsets_nbytes,
+                                             uint8_t *dest, int32_t dest_capacity) {
+  int8_t clevel_candidates[] = {9, 5, 1, 0};
+  for (size_t i = 0; i < sizeof(clevel_candidates) / sizeof(clevel_candidates[0]); ++i) {
+    blosc2_cparams cparams = BLOSC2_CPARAMS_DEFAULTS;
+    cparams.typesize = sizeof(int64_t);
+    cparams.clevel = clevel_candidates[i];
+    blosc2_context *cctx = blosc2_create_cctx(cparams);
+    if (cctx == NULL) {
+      continue;
+    }
+
+    int32_t cbytes = blosc2_compress_ctx(cctx, offsets, offsets_nbytes, dest, dest_capacity);
+    blosc2_free_ctx(cctx);
+    if (cbytes > 0 && cbytes <= dest_capacity) {
+      return cbytes;
+    }
+  }
+
+  return BLOSC2_ERROR_FAILURE;
+}
+
+static char* test_reject_malformed_frame_offsets(void) {
+  int32_t data[CHUNKSIZE];
+
+  blosc2_init();
+
+  blosc2_storage storage = {.contiguous = true};
+  blosc2_schunk *schunk = blosc2_schunk_new(&storage);
+  mu_assert("Cannot create schunk", schunk != NULL);
+
+  for (int i = 0; i < CHUNKSIZE; ++i) {
+    data[i] = i;
+  }
+
+  for (int nchunk = 0; nchunk < NCHUNKS; ++nchunk) {
+    int64_t n = blosc2_schunk_append_buffer(schunk, data, (int32_t)sizeof(data));
+    mu_assert("Cannot append chunk", n >= 0);
+  }
+
+  uint8_t *cframe = NULL;
+  bool cframe_needs_free = false;
+  int64_t cframe_len = blosc2_schunk_to_buffer(schunk, &cframe, &cframe_needs_free);
+  mu_assert("Cannot export cframe", cframe_len > 0 && cframe != NULL);
+
+  int32_t header_len;
+  int64_t cbytes;
+  from_big(&header_len, cframe + FRAME_HEADER_LEN, sizeof(header_len));
+  from_big(&cbytes, cframe + FRAME_CBYTES, sizeof(cbytes));
+
+  mu_assert("Invalid header_len", header_len >= FRAME_HEADER_MINLEN);
+  mu_assert("Invalid cbytes", cbytes > 0);
+  mu_assert("Invalid data area", header_len + cbytes < cframe_len);
+
+  uint8_t *off_chunk = cframe + header_len + cbytes;
+  int32_t offsets_nbytes;
+  int32_t off_chunk_cbytes;
+  int rc = blosc2_cbuffer_sizes(off_chunk, &offsets_nbytes, &off_chunk_cbytes, NULL);
+  mu_assert("Cannot parse offsets chunk", rc >= 0);
+
+  int32_t expected_offsets_nbytes;
+  bool ok = blosc2_nchunks_to_offsets_nbytes(NCHUNKS, &expected_offsets_nbytes);
+  mu_assert("Cannot compute expected offsets size", ok);
+  mu_assert("Unexpected offsets chunk size", offsets_nbytes == expected_offsets_nbytes);
+
+  int64_t *malicious_offsets = malloc((size_t)offsets_nbytes);
+  mu_assert("Cannot allocate malicious offsets", malicious_offsets != NULL);
+  for (int i = 0; i < NCHUNKS; ++i) {
+    malicious_offsets[i] = INT64_MAX / 4;
+  }
+
+  uint8_t *malicious_off_chunk = malloc((size_t)off_chunk_cbytes);
+  mu_assert("Cannot allocate malicious offsets chunk", malicious_off_chunk != NULL);
+
+  int32_t malicious_cbytes = build_malicious_offsets_chunk(malicious_offsets, offsets_nbytes,
+                                                           malicious_off_chunk, off_chunk_cbytes);
+  mu_assert("Cannot build malformed offsets chunk in-place", malicious_cbytes > 0);
+
+  memset(off_chunk, 0, (size_t)off_chunk_cbytes);
+  memcpy(off_chunk, malicious_off_chunk, (size_t)malicious_cbytes);
+
+  blosc2_schunk *decoded = blosc2_schunk_from_buffer(cframe, cframe_len, true);
+  mu_assert("Malformed offsets must be rejected", decoded == NULL);
+
+  free(malicious_off_chunk);
+  free(malicious_offsets);
+  blosc2_schunk_free(schunk);
+  if (cframe_needs_free) {
+    free(cframe);
+  }
+  blosc2_destroy();
+
+  return EXIT_SUCCESS;
+}
+
+
+static char *all_tests(void) {
+  mu_run_test(test_reject_malformed_frame_offsets);
+  return EXIT_SUCCESS;
+}
+
+
+int main(void) {
+  char *result;
+
+  result = all_tests();
+  if (result != EXIT_SUCCESS) {
+    printf(" (%s)\n", result);
+  }
+  else {
+    printf(" ALL TESTS PASSED");
+  }
+  printf("\tTests run: %d\n", tests_run);
+
+  return result != EXIT_SUCCESS;
+}


### PR DESCRIPTION
This patch fixes a reader-side memory safety issue in frame parsing where chunk offsets derived from untrusted frame data were not sufficiently validated before being used in pointer arithmetic.

Malformed frames could supply crafted offset values that lead to out-of-bounds reads when accessing chunk data.

This patch introduces strict validation for offsets and chunk boundaries across all relevant parsing paths:

1. Offset validation
2. Chunk boundary validation
3. Hardened parsing paths
4. Improved error handling