### PR TITLE
Harden sframe chunk path handling

### DIFF
--- a/blosc/blosc2.c
+++ b/blosc/blosc2.c
@@ -13,6 +13,7 @@
 #include "blosc-private.h"
 #include "../plugins/codecs/zfp/blosc2-zfp.h"
 #include "frame.h"
+#include "sframe.h"
 #include "b2nd-private.h"
 #include "schunk-private.h"
 
@@ -1758,12 +1759,8 @@ static int blosc_d(
     int64_t io_pos = 0;
     if (frame->sframe) {
       // The chunk is not in the frame
-      char* chunkpath = malloc(strlen(frame->urlpath) + 1 + 8 + strlen(".chunk") + 1);
-      BLOSC_ERROR_NULL(chunkpath, BLOSC2_ERROR_MEMORY_ALLOC);
-      sprintf(chunkpath, "%s/%08X.chunk", frame->urlpath, nchunk);
-      fp = io_cb->open(chunkpath, "rb", context->schunk->storage->io->params);
+      fp = sframe_open_chunk(frame->urlpath, nchunk, "rb", context->schunk->storage->io);
       BLOSC_ERROR_NULL(fp, BLOSC2_ERROR_FILE_OPEN);
-      free(chunkpath);
       // The offset of the block is src_offset
       io_pos = src_offset;
     }
@@ -2520,11 +2517,7 @@ static int read_lazy_chunk_bytes(blosc2_context* context, int32_t offset, uint8_
   void* fp = NULL;
   int64_t io_pos;
   if (frame->sframe) {
-    char* chunkpath = malloc(strlen(frame->urlpath) + 1 + 8 + strlen(".chunk") + 1);
-    BLOSC_ERROR_NULL(chunkpath, BLOSC2_ERROR_MEMORY_ALLOC);
-    sprintf(chunkpath, "%s/%08X.chunk", frame->urlpath, nchunk_lazy);
-    fp = io_cb->open(chunkpath, "rb", context->schunk->storage->io->params);
-    free(chunkpath);
+    fp = sframe_open_chunk(frame->urlpath, nchunk_lazy, "rb", context->schunk->storage->io);
     io_pos = offset;
   }
   else {
@@ -3943,11 +3936,7 @@ static int decompress_single_vlblock(blosc2_context* context, int32_t nblock,
     void* fp = NULL;
     int64_t io_pos;
     if (frame->sframe) {
-      char* chunkpath = malloc(strlen(frame->urlpath) + 1 + 8 + strlen(".chunk") + 1);
-      BLOSC_ERROR_NULL(chunkpath, BLOSC2_ERROR_MEMORY_ALLOC);
-      sprintf(chunkpath, "%s/%08X.chunk", frame->urlpath, nchunk_lazy);
-      fp = io_cb->open(chunkpath, "rb", context->schunk->storage->io->params);
-      free(chunkpath);
+      fp = sframe_open_chunk(frame->urlpath, nchunk_lazy, "rb", context->schunk->storage->io);
       io_pos = bstart;
     }
     else {

--- a/blosc/sframe.c
+++ b/blosc/sframe.c
@@ -11,6 +11,8 @@
 #include "frame.h"
 #include "blosc2.h"
 
+#include <inttypes.h>
+#include <limits.h>
 #include <stdio.h>
 #include <stdint.h>
 #include <stdlib.h>
@@ -23,15 +25,70 @@
 #endif
 
 
+static char* sframe_make_index_path(const char* urlpath) {
+  size_t path_len = strlen(urlpath);
+  size_t suffix_len = strlen("/chunks.b2frame");
+  if (path_len > SIZE_MAX - suffix_len - 1) {
+    BLOSC_TRACE_ERROR("Index path length overflows size limits");
+    return NULL;
+  }
+
+  char* index_path = malloc(path_len + suffix_len + 1);
+  if (index_path == NULL) {
+    return NULL;
+  }
+
+  int written = snprintf(index_path, path_len + suffix_len + 1, "%s/chunks.b2frame", urlpath);
+  if (written < 0 || (size_t)written >= path_len + suffix_len + 1) {
+    BLOSC_TRACE_ERROR("Error building index path");
+    free(index_path);
+    return NULL;
+  }
+
+  return index_path;
+}
+
+
+static char* sframe_make_chunk_path(const char* urlpath, int64_t nchunk) {
+  if (nchunk < 0 || (uint64_t)nchunk > UINT32_MAX) {
+    BLOSC_TRACE_ERROR("Chunk index (%" PRId64 ") is out of range for sframe filenames", nchunk);
+    return NULL;
+  }
+
+  size_t path_len = strlen(urlpath);
+  size_t suffix_len = strlen("/.chunk");
+  size_t chunk_hex_len = 8;
+  if (path_len > SIZE_MAX - suffix_len - chunk_hex_len - 1) {
+    BLOSC_TRACE_ERROR("Chunk path length overflows size limits");
+    return NULL;
+  }
+
+  size_t total_len = path_len + suffix_len + chunk_hex_len + 1;
+  char* chunk_path = malloc(total_len);
+  if (chunk_path == NULL) {
+    return NULL;
+  }
+
+  int written = snprintf(chunk_path, total_len, "%s/%08X.chunk", urlpath, (uint32_t)nchunk);
+  if (written < 0 || (size_t)written >= total_len) {
+    BLOSC_TRACE_ERROR("Error building chunk path for chunk index (%" PRId64 ")", nchunk);
+    free(chunk_path);
+    return NULL;
+  }
+
+  return chunk_path;
+}
+
+
 /* Open sparse frame index chunk */
 void* sframe_open_index(const char* urlpath, const char* mode, const blosc2_io *io) {
   void* fp = NULL;
-  char* index_path = malloc(strlen(urlpath) + strlen("/chunks.b2frame") + 1);
+  char* index_path = sframe_make_index_path(urlpath);
   if (index_path) {
-    sprintf(index_path, "%s/chunks.b2frame", urlpath);
     blosc2_io_cb *io_cb = blosc2_get_io_cb(io->id);
     if (io_cb == NULL) {
       BLOSC_TRACE_ERROR("Error getting the input/output API");
+      free(index_path);
       return NULL;
     }
     fp = io_cb->open(index_path, mode, io->params);
@@ -45,12 +102,12 @@ void* sframe_open_index(const char* urlpath, const char* mode, const blosc2_io *
 /* Open directory/nchunk.chunk with 8 zeros of padding */
 void* sframe_open_chunk(const char* urlpath, int64_t nchunk, const char* mode, const blosc2_io *io) {
   void* fp = NULL;
-  char* chunk_path = malloc(strlen(urlpath) + 1 + 8 + strlen(".chunk") + 1);
+  char* chunk_path = sframe_make_chunk_path(urlpath, nchunk);
   if (chunk_path) {
-    sprintf(chunk_path, "%s/%08X.chunk", urlpath, (unsigned int)nchunk);
     blosc2_io_cb *io_cb = blosc2_get_io_cb(io->id);
     if (io_cb == NULL) {
       BLOSC_TRACE_ERROR("Error getting the input/output API");
+      free(chunk_path);
       return NULL;
     }
     fp = io_cb->open(chunk_path, mode, io->params);
@@ -86,9 +143,8 @@ void* sframe_create_chunk(blosc2_frame_s* frame, uint8_t* chunk, int64_t nchunk,
 
 /* Append an existing chunk into a sparse frame. */
 int sframe_delete_chunk(const char *urlpath, int64_t nchunk) {
-  char* chunk_path = malloc(strlen(urlpath) + 1 + 8 + strlen(".chunk") + 1);
+  char* chunk_path = sframe_make_chunk_path(urlpath, nchunk);
   if (chunk_path) {
-    sprintf(chunk_path, "%s/%08X.chunk", urlpath, (unsigned int)nchunk);
     int rc = remove(chunk_path);
     free(chunk_path);
     return rc;

--- a/blosc/sframe.c
+++ b/blosc/sframe.c
@@ -69,7 +69,7 @@ static char* sframe_make_chunk_path(const char* urlpath, int64_t nchunk) {
     return NULL;
   }
 
-  int written = snprintf(chunk_path, total_len, "%s/%08X.chunk", urlpath, (uint32_t)nchunk);
+  int written = snprintf(chunk_path, total_len, "%s/%08" PRIX32 ".chunk", urlpath, (uint32_t)nchunk);
   if (written < 0 || (size_t)written >= total_len) {
     BLOSC_TRACE_ERROR("Error building chunk path for chunk index (%" PRId64 ")", nchunk);
     free(chunk_path);

--- a/tests/test_sframe.c
+++ b/tests/test_sframe.c
@@ -8,6 +8,7 @@
 
 #include <stdio.h>
 #include "test_common.h"
+#include "sframe.h"
 
 #define CHUNKSIZE (200 * 1000)
 #define NTHREADS (2)
@@ -321,6 +322,40 @@ static char* test_sframe_typesize(void) {
 }
 
 
+static char* test_sframe_reject_large_chunk_index(void) {
+  blosc2_cparams cparams = BLOSC2_CPARAMS_DEFAULTS;
+  blosc2_dparams dparams = BLOSC2_DPARAMS_DEFAULTS;
+  blosc2_storage storage = {
+      .contiguous = false,
+      .urlpath = "test_sframe_reject_large_chunk_index.b2frame",
+      .cparams = &cparams,
+      .dparams = &dparams,
+  };
+
+  blosc2_init();
+  blosc2_remove_dir(storage.urlpath);
+
+  blosc2_schunk* schunk = blosc2_schunk_new(&storage);
+  mu_assert("Error in creating schunk", schunk != NULL);
+
+  // Chunk IDs are encoded as 8-hex-digit filenames. Values beyond UINT32_MAX must be rejected.
+  int64_t out_of_range_chunk = (int64_t)UINT32_MAX + 1;
+  blosc2_io io = BLOSC2_IO_DEFAULTS;
+  void* fp = sframe_open_chunk(storage.urlpath, out_of_range_chunk, "wb", &io);
+  mu_assert("Out-of-range chunk index should be rejected", fp == NULL);
+
+  // If rejection worked, chunk 0 was not spuriously created via truncation.
+  void* fp0 = sframe_open_chunk(storage.urlpath, 0, "rb", &io);
+  mu_assert("Chunk 0 must not exist after rejecting out-of-range chunk index", fp0 == NULL);
+
+  blosc2_schunk_free(schunk);
+  blosc2_remove_dir(storage.urlpath);
+  blosc2_destroy();
+
+  return EXIT_SUCCESS;
+}
+
+
 static char *all_tests(void) {
   directory = "dir1.b2frame";
 
@@ -341,6 +376,8 @@ static char *all_tests(void) {
 
   nchunks = 10;
   mu_run_test(test_sframe_typesize);
+
+  mu_run_test(test_sframe_reject_large_chunk_index);
 
   // Check directory with a trailing slash
   directory = "dir1.b2frame/";


### PR DESCRIPTION
This patch hardens sparse-frame chunk file handling to prevent chunk ID aliasing and unsafe path construction.


- Added validation for sparse-frame chunk indices so values outside the valid 32-bit filename range are rejected.
- Replaced unbounded string formatting with bounded path construction and overflow-aware length checks in sparse-frame path builders.
- Reused the validated sparse-frame chunk opener in lazy-load paths to remove duplicated ad-hoc path formatting logic.
- Added a regression test that verifies out-of-range chunk IDs are rejected and do not resolve to chunk 0 via truncation.