### PR TITLE
integer overflow in _blosc_getitem leading to out-of-bounds memcpy

### DIFF
--- a/blosc/blosc2.c
+++ b/blosc/blosc2.c
@@ -934,7 +934,7 @@ int fill_codec(blosc2_codec *codec) {
     codec->free = NULL;
   }
   */
- 
+
   return BLOSC2_ERROR_SUCCESS;
 }
 
@@ -1032,7 +1032,7 @@ uint8_t* pipeline_forward(struct thread_context* thread_context, const int32_t b
   uint8_t* filters_meta = context->filters_meta;
   bool memcpyed = context->header_flags & (uint8_t)BLOSC_MEMCPYED;
   bool output_is_disposable = (context->preparams != NULL) ? context->preparams->output_is_disposable : false;
-  
+
   /* Prefilter function */
   if (context->prefilter != NULL) {
     // Create new prefilter parameters for this block (must be private for each thread)
@@ -4125,27 +4125,51 @@ int _blosc_getitem(blosc2_context* context, blosc_header* header, const void* sr
   int32_t ntbytes = 0;              /* the number of uncompressed bytes */
   int32_t bsize, bsize2, ebsize, leftoverblock;
   int32_t startb, stopb;
-  int32_t stop = start + nitems;
+  int32_t stop;
+  int32_t nitems_bytes;
+  int64_t start64 = (int64_t)start;
+  int64_t nitems64 = (int64_t)nitems;
+  int64_t typesize64 = (int64_t)header->typesize;
+  int64_t stop64;
+  int64_t nitems_bytes64;
+  int64_t start_bytes64;
+  int64_t stop_bytes64;
   int j, rc;
 
   if (nitems == 0) {
     // We have nothing to do
     return 0;
   }
-  if (nitems * header->typesize > destsize) {
+  if (nitems < 0) {
+    BLOSC_TRACE_ERROR("`nitems` out of bounds.");
+    return BLOSC2_ERROR_INVALID_PARAM;
+  }
+
+  nitems_bytes64 = nitems64 * typesize64;
+  if (nitems_bytes64 < 0 || nitems_bytes64 > INT32_MAX || nitems_bytes64 > destsize) {
     BLOSC_TRACE_ERROR("`nitems`*`typesize` out of dest bounds.");
     return BLOSC2_ERROR_WRITE_BUFFER;
   }
+  nitems_bytes = (int32_t)nitems_bytes64;
 
   int32_t* bstarts = (int32_t*)(_src + context->header_overhead);
 
   /* Check region boundaries */
-  if ((start < 0) || (start * header->typesize > header->nbytes)) {
+  start_bytes64 = start64 * typesize64;
+  if ((start < 0) || (start_bytes64 < 0) || (start_bytes64 > header->nbytes)) {
     BLOSC_TRACE_ERROR("`start` out of bounds.");
     return BLOSC2_ERROR_INVALID_PARAM;
   }
 
-  if ((stop < 0) || (stop * header->typesize > header->nbytes)) {
+  stop64 = start64 + nitems64;
+  if ((stop64 < 0) || (stop64 > INT32_MAX)) {
+    BLOSC_TRACE_ERROR("`start`+`nitems` out of bounds.");
+    return BLOSC2_ERROR_INVALID_PARAM;
+  }
+  stop = (int32_t)stop64;
+
+  stop_bytes64 = stop64 * typesize64;
+  if ((stop_bytes64 < 0) || (stop_bytes64 > header->nbytes)) {
     BLOSC_TRACE_ERROR("`start`+`nitems` out of bounds.");
     return BLOSC2_ERROR_INVALID_PARAM;
   }
@@ -4167,7 +4191,7 @@ int _blosc_getitem(blosc2_context* context, blosc_header* header, const void* sr
                   (context->blosc2_flags & 0x08u) && !context->special_type);
   if (memcpyed && !is_lazy && !context->postfilter) {
     // Short-circuit for (non-lazy) memcpyed or special values
-    ntbytes = nitems * header->typesize;
+    ntbytes = nitems_bytes;
     switch (context->special_type) {
       case BLOSC2_SPECIAL_VALUE:
         // All repeated values
@@ -4191,7 +4215,7 @@ int _blosc_getitem(blosc2_context* context, blosc_header* header, const void* sr
         // We do nothing here
         break;
       case BLOSC2_NO_SPECIAL:
-        _src += context->header_overhead + start * context->typesize;
+        _src += context->header_overhead + (int32_t)start_bytes64;
         memcpy(_dest, _src, ntbytes);
         break;
       default:
@@ -4251,7 +4275,7 @@ int _blosc_getitem(blosc2_context* context, blosc_header* header, const void* sr
     /* Do the actual data copy */
     // Regular decompression.  Put results in tmp2.
     // If the block is aligned and the worst case fits in destination, let's avoid a copy
-    bool get_single_block = ((startb == 0) && (bsize == nitems * header->typesize));
+    bool get_single_block = ((startb == 0) && (bsize == nitems_bytes));
     uint8_t* tmp2 = get_single_block ? dest : scontext->tmp2;
 
     // If memcpyed we don't have a bstarts section (because it is not needed)
@@ -5889,7 +5913,7 @@ void blosc2_free_ctx(blosc2_context* context) {
           if (fill_codec(&g_codecs[i]) < 0) {
             BLOSC_TRACE_ERROR("Could not load codec %d.", g_codecs[i].compcode);
             return BLOSC2_ERROR_CODEC_SUPPORT;
-          } 
+          }
         }
         if (g_codecs[i].free == NULL){
           // no free func, codec_params is simple

--- a/blosc/blosc2.c
+++ b/blosc/blosc2.c
@@ -4174,8 +4174,8 @@ int _blosc_getitem(blosc2_context* context, blosc_header* header, const void* sr
     return BLOSC2_ERROR_INVALID_PARAM;
   }
 
-  int chunk_memcpy = header->flags & 0x1;
-  if (!context->special_type && !chunk_memcpy &&
+  bool chunk_memcpyed = (header->flags & (uint8_t)BLOSC_MEMCPYED) != 0;
+  if (!context->special_type && !chunk_memcpyed &&
       ((uint8_t *)(_src + srcsize) < (uint8_t *)(bstarts + context->nblocks))) {
     BLOSC_TRACE_ERROR("`bstarts` out of bounds.");
     return BLOSC2_ERROR_READ_BUFFER;
@@ -4215,7 +4215,15 @@ int _blosc_getitem(blosc2_context* context, blosc_header* header, const void* sr
         // We do nothing here
         break;
       case BLOSC2_NO_SPECIAL:
-        _src += context->header_overhead + (int32_t)start_bytes64;
+        {
+          int64_t src_offset64 = (int64_t)context->header_overhead + start_bytes64;
+          int64_t src_stop64 = src_offset64 + nitems_bytes64;
+          if ((src_offset64 < 0) || (src_stop64 < src_offset64) || (src_stop64 > srcsize)) {
+            BLOSC_TRACE_ERROR("getitem memcpy source out of bounds.");
+            return BLOSC2_ERROR_READ_BUFFER;
+          }
+          _src += (int32_t)src_offset64;
+        }
         memcpy(_dest, _src, ntbytes);
         break;
       default:

--- a/tests/test_getitem_overflow.c
+++ b/tests/test_getitem_overflow.c
@@ -1,0 +1,49 @@
+/*********************************************************************
+  Blosc - Blocked Shuffling and Compression Library
+
+  Regression test for integer overflow in _blosc_getitem.
+
+  Copyright (c) 2026  Blosc Development Team <blosc@blosc.org>
+  https://blosc.org
+  License: BSD 3-Clause (see LICENSE.txt)
+**********************************************************************/
+
+#include "test_common.h"
+
+#include <limits.h>
+#include <stdint.h>
+#include <string.h>
+
+int main(void) {
+  blosc2_init();
+
+  uint8_t chunk[BLOSC_MIN_HEADER_LENGTH];
+  memset(chunk, 0, sizeof(chunk));
+
+  chunk[0] = 2;
+  chunk[1] = 1;
+  chunk[2] = (uint8_t)(BLOSC_MEMCPYED | BLOSC_DOSHUFFLE);
+  chunk[3] = 2;
+
+  int32_t nbytes = INT32_MAX;
+  int32_t blocksize = 16;
+  int32_t cbytes = BLOSC_MIN_HEADER_LENGTH;
+  memcpy(chunk + 4, &nbytes, sizeof(nbytes));
+  memcpy(chunk + 8, &blocksize, sizeof(blocksize));
+  memcpy(chunk + 12, &cbytes, sizeof(cbytes));
+
+  int start = 0;
+  int nitems = 1073741824;
+  uint8_t dest[16] = {0};
+
+  int rc = blosc2_getitem(chunk, BLOSC_MIN_HEADER_LENGTH, start, nitems, dest, (int32_t)sizeof(dest));
+
+  blosc2_destroy();
+
+  if (rc >= 0) {
+    printf("Expected blosc2_getitem to fail for overflow-triggering arguments, got rc=%d\n", rc);
+    return EXIT_FAILURE;
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/tests/test_getitem_overflow.c
+++ b/tests/test_getitem_overflow.c
@@ -14,6 +14,14 @@
 #include <stdint.h>
 #include <string.h>
 
+static void put_i32_le(uint8_t* dst, int32_t value) {
+  uint32_t uvalue = (uint32_t)value;
+  dst[0] = (uint8_t)(uvalue & 0xffu);
+  dst[1] = (uint8_t)((uvalue >> 8) & 0xffu);
+  dst[2] = (uint8_t)((uvalue >> 16) & 0xffu);
+  dst[3] = (uint8_t)((uvalue >> 24) & 0xffu);
+}
+
 int main(void) {
   blosc2_init();
 
@@ -28,9 +36,9 @@ int main(void) {
   int32_t nbytes = INT32_MAX;
   int32_t blocksize = 16;
   int32_t cbytes = BLOSC_MIN_HEADER_LENGTH;
-  memcpy(chunk + 4, &nbytes, sizeof(nbytes));
-  memcpy(chunk + 8, &blocksize, sizeof(blocksize));
-  memcpy(chunk + 12, &cbytes, sizeof(cbytes));
+  put_i32_le(chunk + BLOSC2_CHUNK_NBYTES, nbytes);
+  put_i32_le(chunk + BLOSC2_CHUNK_BLOCKSIZE, blocksize);
+  put_i32_le(chunk + BLOSC2_CHUNK_CBYTES, cbytes);
 
   int start = 0;
   int nitems = 1073741824;


### PR DESCRIPTION
_blasc_getitem performs size calculations using 32-bit signed arithmetic when deriving byte ranges from user-controlled inputs (`start`, `nitems`, and `typesize`).

Specifically, expressions like:

    nitems * typesize
    start + nitems
    stop * typesize

can overflow and wrap around before bounds checks are evaluated. This allows invalid values to bypass validation and propagate into `ntbytes`, which is later passed to `memcpy`.

Because `memcpy` expects a `size_t`, a negative 32-bit value is implicitly converted into a very large unsigned value, resulting in out-of-bounds read/write and potential heap corruption.

### Root cause
Arithmetic on untrusted inputs is performed in 32-bit signed integers prior to validation, allowing overflow to invalidate safety checks.

### Fix
All arithmetic is promoted to `int64_t` before validation. Computed byte sizes and offsets are checked against:
- `destsize`
- `header->nbytes`
- `INT32_MAX`

Values are only cast back to 32-bit after bounds are proven safe. Negative `nitems` is explicitly rejected.

### Impact
Prevents memory corruption when processing malformed or attacker-controlled input buffers via `blosc2_getitem`.

### Reproduction
A minimal PoC can trigger the issue by passing large `nitems` such that:

    nitems * typesize > INT32_MAX

This results in a negative size being passed to `memcpy`, leading to a crash or undefined behavior.