### PR TITLE
add centralized nchunk validation to prevent out-of-bounds access

### DIFF
--- a/blosc/schunk.c
+++ b/blosc/schunk.c
@@ -38,10 +38,8 @@ static int schunk_get_chunk_flags2(blosc2_schunk *schunk, int64_t nchunk, uint8_
 
 
 static int validate_nchunk(blosc2_schunk *schunk, int64_t nchunk, bool allow_end, const char *func_name) {
-  BLOSC_UNUSED_PARAM(func_name);
-
   if (nchunk < 0) {
-    BLOSC_TRACE_ERROR("nchunk ('%" PRId64 "') is negative.", nchunk);
+    BLOSC_TRACE_ERROR("nchunk ('%" PRId64 "') is negative in %s.", nchunk, func_name);
     return BLOSC2_ERROR_INVALID_PARAM;
   }
 

--- a/blosc/schunk.c
+++ b/blosc/schunk.c
@@ -37,6 +37,33 @@
 static int schunk_get_chunk_flags2(blosc2_schunk *schunk, int64_t nchunk, uint8_t *chunk_flags2);
 
 
+static int validate_nchunk(blosc2_schunk *schunk, int64_t nchunk, bool allow_end, const char *func_name) {
+  BLOSC_UNUSED_PARAM(func_name);
+
+  if (nchunk < 0) {
+    BLOSC_TRACE_ERROR("nchunk ('%" PRId64 "') is negative.", nchunk);
+    return BLOSC2_ERROR_INVALID_PARAM;
+  }
+
+  if (allow_end) {
+    if (nchunk > schunk->nchunks) {
+      BLOSC_TRACE_ERROR("nchunk ('%" PRId64 "') is out of range [0, %" PRId64 "] in %s.",
+                        nchunk, schunk->nchunks, func_name);
+      return BLOSC2_ERROR_INVALID_PARAM;
+    }
+  }
+  else {
+    if (nchunk >= schunk->nchunks) {
+      BLOSC_TRACE_ERROR("nchunk ('%" PRId64 "') exceeds the number of chunks "
+                        "('%" PRId64 "') in %s.", nchunk, schunk->nchunks, func_name);
+      return BLOSC2_ERROR_INVALID_PARAM;
+    }
+  }
+
+  return BLOSC2_ERROR_SUCCESS;
+}
+
+
 /* Get the cparams associated with a super-chunk */
 int blosc2_schunk_get_cparams(blosc2_schunk *schunk, blosc2_cparams **cparams) {
   *cparams = calloc(1, sizeof(blosc2_cparams));
@@ -861,12 +888,17 @@ int64_t blosc2_schunk_append_chunk(blosc2_schunk *schunk, uint8_t *chunk, bool c
 
 /* Insert an existing @p chunk in a specified position on a super-chunk */
 int64_t blosc2_schunk_insert_chunk(blosc2_schunk *schunk, int64_t nchunk, uint8_t *chunk, bool copy) {
+  int rc = validate_nchunk(schunk, nchunk, true, "blosc2_schunk_insert_chunk");
+  if (rc < 0) {
+    return rc;
+  }
+
   int32_t chunk_nbytes;
   int32_t chunk_cbytes;
   int64_t nchunks = schunk->nchunks;
   bool chunk_vlblocks = (chunk[BLOSC2_CHUNK_BLOSC2_FLAGS2] & BLOSC2_VL_BLOCKS) != 0;
 
-  int rc = blosc2_cbuffer_sizes(chunk, &chunk_nbytes, &chunk_cbytes, NULL);
+  rc = blosc2_cbuffer_sizes(chunk, &chunk_nbytes, &chunk_cbytes, NULL);
   if (rc < 0) {
     return rc;
   }
@@ -970,11 +1002,16 @@ int64_t blosc2_schunk_insert_chunk(blosc2_schunk *schunk, int64_t nchunk, uint8_
 
 
 int64_t blosc2_schunk_update_chunk(blosc2_schunk *schunk, int64_t nchunk, uint8_t *chunk, bool copy) {
+  int rc = validate_nchunk(schunk, nchunk, false, "blosc2_schunk_update_chunk");
+  if (rc < 0) {
+    return rc;
+  }
+
   int32_t chunk_nbytes;
   int32_t chunk_cbytes;
   bool chunk_vlblocks = (chunk[BLOSC2_CHUNK_BLOSC2_FLAGS2] & BLOSC2_VL_BLOCKS) != 0;
 
-  int rc = blosc2_cbuffer_sizes(chunk, &chunk_nbytes, &chunk_cbytes, NULL);
+  rc = blosc2_cbuffer_sizes(chunk, &chunk_nbytes, &chunk_cbytes, NULL);
   if (rc < 0) {
     return rc;
   }
@@ -1091,9 +1128,9 @@ int64_t blosc2_schunk_update_chunk(blosc2_schunk *schunk, int64_t nchunk, uint8_
 }
 
 int64_t blosc2_schunk_delete_chunk(blosc2_schunk *schunk, int64_t nchunk) {
-  int rc;
-  if (schunk->nchunks < nchunk) {
-    BLOSC_TRACE_ERROR("The schunk has not enough chunks (%" PRId64 ")!", schunk->nchunks);
+  int rc = validate_nchunk(schunk, nchunk, false, "blosc2_schunk_delete_chunk");
+  if (rc < 0) {
+    return rc;
   }
 
   bool needs_free;
@@ -1185,19 +1222,18 @@ int64_t blosc2_schunk_append_buffer(blosc2_schunk *schunk, const void *src, int3
 /* Decompress and return a chunk that is part of a super-chunk. */
 int blosc2_schunk_decompress_chunk(blosc2_schunk *schunk, int64_t nchunk,
                                    void *dest, int32_t nbytes) {
+  int rc = validate_nchunk(schunk, nchunk, false, "blosc2_schunk_decompress_chunk");
+  if (rc < 0) {
+    return rc;
+  }
+
   int32_t chunk_nbytes;
   int32_t chunk_cbytes;
   int chunksize;
-  int rc;
   blosc2_frame_s* frame = (blosc2_frame_s*)schunk->frame;
 
   schunk->current_nchunk = nchunk;
   if (frame == NULL) {
-    if (nchunk >= schunk->nchunks) {
-      BLOSC_TRACE_ERROR("nchunk ('%" PRId64 "') exceeds the number of chunks "
-                        "('%" PRId64 "') in super-chunk.", nchunk, schunk->nchunks);
-      return BLOSC2_ERROR_INVALID_PARAM;
-    }
     uint8_t* src = schunk->data[nchunk];
     if (src == 0) {
       return 0;
@@ -1242,6 +1278,11 @@ int blosc2_schunk_decompress_chunk(blosc2_schunk *schunk, int64_t nchunk,
  * is returned instead.
 */
 int blosc2_schunk_get_chunk(blosc2_schunk *schunk, int64_t nchunk, uint8_t **chunk, bool *needs_free) {
+  int rc = validate_nchunk(schunk, nchunk, false, "blosc2_schunk_get_chunk");
+  if (rc < 0) {
+    return rc;
+  }
+
   if (ctx_uses_parallel_backend(schunk->dctx)) {
     blosc2_pthread_mutex_lock(&schunk->dctx->nchunk_mutex);
     schunk->current_nchunk = nchunk;
@@ -1255,12 +1296,6 @@ int blosc2_schunk_get_chunk(blosc2_schunk *schunk, int64_t nchunk, uint8_t **chu
     return frame_get_chunk(frame, nchunk, chunk, needs_free);
   }
 
-  if (nchunk >= schunk->nchunks) {
-    BLOSC_TRACE_ERROR("nchunk ('%" PRId64 "') exceeds the number of chunks "
-                      "('%" PRId64 "') in schunk.", nchunk, schunk->nchunks);
-    return BLOSC2_ERROR_INVALID_PARAM;
-  }
-
   *chunk = schunk->data[nchunk];
   if (*chunk == 0) {
     *needs_free = 0;
@@ -1269,7 +1304,7 @@ int blosc2_schunk_get_chunk(blosc2_schunk *schunk, int64_t nchunk, uint8_t **chu
 
   *needs_free = false;
   int32_t chunk_cbytes;
-  int rc = blosc2_cbuffer_sizes(*chunk, NULL, &chunk_cbytes, NULL);
+  rc = blosc2_cbuffer_sizes(*chunk, NULL, &chunk_cbytes, NULL);
   if (rc < 0) {
     return rc;
   }
@@ -1288,6 +1323,11 @@ int blosc2_schunk_get_chunk(blosc2_schunk *schunk, int64_t nchunk, uint8_t **chu
  * is returned instead.
 */
 int blosc2_schunk_get_lazychunk(blosc2_schunk *schunk, int64_t nchunk, uint8_t **chunk, bool *needs_free) {
+  int rc = validate_nchunk(schunk, nchunk, false, "blosc2_schunk_get_lazychunk");
+  if (rc < 0) {
+    return rc;
+  }
+
   if (ctx_uses_parallel_backend(schunk->dctx)) {
     blosc2_pthread_mutex_lock(&schunk->dctx->nchunk_mutex);
     schunk->current_nchunk = nchunk;
@@ -1301,12 +1341,6 @@ int blosc2_schunk_get_lazychunk(blosc2_schunk *schunk, int64_t nchunk, uint8_t *
     return frame_get_lazychunk(frame, nchunk, chunk, needs_free);
   }
 
-  if (nchunk >= schunk->nchunks) {
-    BLOSC_TRACE_ERROR("nchunk ('%" PRId64 "') exceeds the number of chunks "
-                      "('%" PRId64 "') in schunk.", nchunk, schunk->nchunks);
-    return BLOSC2_ERROR_INVALID_PARAM;
-  }
-
   *chunk = schunk->data[nchunk];
   if (*chunk == 0) {
     *needs_free = 0;
@@ -1315,7 +1349,7 @@ int blosc2_schunk_get_lazychunk(blosc2_schunk *schunk, int64_t nchunk, uint8_t *
 
   *needs_free = false;
   int32_t chunk_cbytes;
-  int rc = blosc2_cbuffer_sizes(*chunk, NULL, &chunk_cbytes, NULL);
+  rc = blosc2_cbuffer_sizes(*chunk, NULL, &chunk_cbytes, NULL);
   if (rc < 0) {
     return rc;
   }
@@ -1532,7 +1566,7 @@ int blosc2_schunk_set_slice_buffer(blosc2_schunk *schunk, int64_t start, int64_t
 
 int64_t schunk_get_slice_nchunks(blosc2_schunk *schunk, int64_t start, int64_t stop, int64_t **chunks_idx) {
   BLOSC_ERROR_NULL(schunk, BLOSC2_ERROR_NULL_POINTER);
-  if (schunk->nchunks == 0){  
+  if (schunk->nchunks == 0){
     *chunks_idx = NULL;
     return 0;
   }

--- a/tests/test_schunk_negative_index.c
+++ b/tests/test_schunk_negative_index.c
@@ -7,7 +7,7 @@
 #include <stdio.h>
 #include "test_common.h"
 
-#define CHUNKSIZE 256
+#define CHUNK_ELEMS 256
 
 int tests_run = 0;
 
@@ -25,8 +25,8 @@ static test_storage tstorage[] = {
 static test_storage tdata;
 
 static char *test_negative_chunk_index_rejected(void) {
-  int32_t src[CHUNKSIZE];
-  int32_t dst[CHUNKSIZE];
+  int32_t src[CHUNK_ELEMS];
+  int32_t dst[CHUNK_ELEMS];
   int32_t isize = (int32_t)(sizeof(src));
 
   blosc2_remove_urlpath(tdata.urlpath);
@@ -48,7 +48,7 @@ static char *test_negative_chunk_index_rejected(void) {
   blosc2_schunk *schunk = blosc2_schunk_new(&storage);
   mu_assert("ERROR: cannot create schunk", schunk != NULL);
 
-  for (int i = 0; i < CHUNKSIZE; ++i) {
+  for (int i = 0; i < CHUNK_ELEMS; ++i) {
     src[i] = i;
   }
   mu_assert("ERROR: cannot append initial chunk", blosc2_schunk_append_buffer(schunk, src, isize) == 1);
@@ -80,6 +80,53 @@ static char *test_negative_chunk_index_rejected(void) {
 
   rc = (int)blosc2_schunk_delete_chunk(schunk, -1);
   mu_assert("ERROR: negative index should fail in delete_chunk", rc == BLOSC2_ERROR_INVALID_PARAM);
+  mu_assert("ERROR: delete_chunk changed nchunks on failure", schunk->nchunks == 1);
+
+  rc = blosc2_schunk_get_chunk(schunk, schunk->nchunks, &chunk, &needs_free);
+  mu_assert("ERROR: nchunks index should fail in get_chunk", rc == BLOSC2_ERROR_INVALID_PARAM);
+
+  rc = blosc2_schunk_get_lazychunk(schunk, schunk->nchunks, &chunk, &needs_free);
+  mu_assert("ERROR: nchunks index should fail in get_lazychunk", rc == BLOSC2_ERROR_INVALID_PARAM);
+
+  rc = blosc2_schunk_decompress_chunk(schunk, schunk->nchunks, dst, isize);
+  mu_assert("ERROR: nchunks index should fail in decompress_chunk", rc == BLOSC2_ERROR_INVALID_PARAM);
+
+  rc = (int)blosc2_schunk_update_chunk(schunk, schunk->nchunks, new_chunk, true);
+  mu_assert("ERROR: nchunks index should fail in update_chunk", rc == BLOSC2_ERROR_INVALID_PARAM);
+  mu_assert("ERROR: update_chunk changed nchunks on failure", schunk->nchunks == 1);
+
+  rc = (int)blosc2_schunk_insert_chunk(schunk, schunk->nchunks, new_chunk, true);
+  mu_assert("ERROR: nchunks index should succeed in insert_chunk", rc == 2);
+  mu_assert("ERROR: insert_chunk did not increase nchunks", schunk->nchunks == 2);
+
+  rc = (int)blosc2_schunk_delete_chunk(schunk, schunk->nchunks);
+  mu_assert("ERROR: nchunks index should fail in delete_chunk", rc == BLOSC2_ERROR_INVALID_PARAM);
+
+  rc = (int)blosc2_schunk_delete_chunk(schunk, 1);
+  mu_assert("ERROR: cannot delete inserted chunk", rc == 1);
+  mu_assert("ERROR: delete_chunk changed nchunks unexpectedly", schunk->nchunks == 1);
+
+  int64_t out_of_bounds = schunk->nchunks + 1;
+
+  rc = blosc2_schunk_get_chunk(schunk, out_of_bounds, &chunk, &needs_free);
+  mu_assert("ERROR: nchunks + 1 index should fail in get_chunk", rc == BLOSC2_ERROR_INVALID_PARAM);
+
+  rc = blosc2_schunk_get_lazychunk(schunk, out_of_bounds, &chunk, &needs_free);
+  mu_assert("ERROR: nchunks + 1 index should fail in get_lazychunk", rc == BLOSC2_ERROR_INVALID_PARAM);
+
+  rc = blosc2_schunk_decompress_chunk(schunk, out_of_bounds, dst, isize);
+  mu_assert("ERROR: nchunks + 1 index should fail in decompress_chunk", rc == BLOSC2_ERROR_INVALID_PARAM);
+
+  rc = (int)blosc2_schunk_update_chunk(schunk, out_of_bounds, new_chunk, true);
+  mu_assert("ERROR: nchunks + 1 index should fail in update_chunk", rc == BLOSC2_ERROR_INVALID_PARAM);
+  mu_assert("ERROR: update_chunk changed nchunks on failure", schunk->nchunks == 1);
+
+  rc = (int)blosc2_schunk_insert_chunk(schunk, out_of_bounds, new_chunk, true);
+  mu_assert("ERROR: nchunks + 1 index should fail in insert_chunk", rc == BLOSC2_ERROR_INVALID_PARAM);
+  mu_assert("ERROR: insert_chunk changed nchunks on failure", schunk->nchunks == 1);
+
+  rc = (int)blosc2_schunk_delete_chunk(schunk, out_of_bounds);
+  mu_assert("ERROR: nchunks + 1 index should fail in delete_chunk", rc == BLOSC2_ERROR_INVALID_PARAM);
   mu_assert("ERROR: delete_chunk changed nchunks on failure", schunk->nchunks == 1);
 
   free(new_chunk);

--- a/tests/test_schunk_negative_index.c
+++ b/tests/test_schunk_negative_index.c
@@ -1,0 +1,125 @@
+/*
+  Copyright (c) 2026  Blosc Development Team <blosc@blosc.org>
+  https://blosc.org
+  License: BSD 3-Clause (see LICENSE.txt)
+*/
+
+#include <stdio.h>
+#include "test_common.h"
+
+#define CHUNKSIZE 256
+
+int tests_run = 0;
+
+typedef struct {
+  bool contiguous;
+  char *urlpath;
+} test_storage;
+
+static test_storage tstorage[] = {
+    {false, NULL},
+    {true, NULL},
+    {true, "test_schunk_negative_index.b2frame"},
+};
+
+static test_storage tdata;
+
+static char *test_negative_chunk_index_rejected(void) {
+  int32_t src[CHUNKSIZE];
+  int32_t dst[CHUNKSIZE];
+  int32_t isize = (int32_t)(sizeof(src));
+
+  blosc2_remove_urlpath(tdata.urlpath);
+
+  blosc2_cparams cparams = BLOSC2_CPARAMS_DEFAULTS;
+  cparams.typesize = sizeof(int32_t);
+  cparams.nthreads = 1;
+
+  blosc2_dparams dparams = BLOSC2_DPARAMS_DEFAULTS;
+  dparams.nthreads = 1;
+
+  blosc2_storage storage = {
+      .contiguous = tdata.contiguous,
+      .urlpath = tdata.urlpath,
+      .cparams = &cparams,
+      .dparams = &dparams,
+  };
+
+  blosc2_schunk *schunk = blosc2_schunk_new(&storage);
+  mu_assert("ERROR: cannot create schunk", schunk != NULL);
+
+  for (int i = 0; i < CHUNKSIZE; ++i) {
+    src[i] = i;
+  }
+  mu_assert("ERROR: cannot append initial chunk", blosc2_schunk_append_buffer(schunk, src, isize) == 1);
+
+  uint8_t *chunk = NULL;
+  bool needs_free = false;
+  int rc = blosc2_schunk_get_chunk(schunk, -1, &chunk, &needs_free);
+  mu_assert("ERROR: negative index should fail in get_chunk", rc == BLOSC2_ERROR_INVALID_PARAM);
+
+  rc = blosc2_schunk_get_lazychunk(schunk, -1, &chunk, &needs_free);
+  mu_assert("ERROR: negative index should fail in get_lazychunk", rc == BLOSC2_ERROR_INVALID_PARAM);
+
+  rc = blosc2_schunk_decompress_chunk(schunk, -1, dst, isize);
+  mu_assert("ERROR: negative index should fail in decompress_chunk", rc == BLOSC2_ERROR_INVALID_PARAM);
+
+  int32_t chunk_cap = isize + BLOSC2_MAX_OVERHEAD;
+  uint8_t *new_chunk = malloc((size_t)chunk_cap);
+  mu_assert("ERROR: cannot allocate compressed chunk", new_chunk != NULL);
+  int cbytes = blosc2_compress_ctx(schunk->cctx, src, isize, new_chunk, chunk_cap);
+  mu_assert("ERROR: cannot compress replacement chunk", cbytes > 0);
+
+  rc = (int)blosc2_schunk_update_chunk(schunk, -1, new_chunk, true);
+  mu_assert("ERROR: negative index should fail in update_chunk", rc == BLOSC2_ERROR_INVALID_PARAM);
+  mu_assert("ERROR: update_chunk changed nchunks on failure", schunk->nchunks == 1);
+
+  rc = (int)blosc2_schunk_insert_chunk(schunk, -1, new_chunk, true);
+  mu_assert("ERROR: negative index should fail in insert_chunk", rc == BLOSC2_ERROR_INVALID_PARAM);
+  mu_assert("ERROR: insert_chunk changed nchunks on failure", schunk->nchunks == 1);
+
+  rc = (int)blosc2_schunk_delete_chunk(schunk, -1);
+  mu_assert("ERROR: negative index should fail in delete_chunk", rc == BLOSC2_ERROR_INVALID_PARAM);
+  mu_assert("ERROR: delete_chunk changed nchunks on failure", schunk->nchunks == 1);
+
+  free(new_chunk);
+
+  rc = blosc2_schunk_decompress_chunk(schunk, 0, dst, isize);
+  mu_assert("ERROR: valid chunk cannot be decompressed after invalid operations", rc == isize);
+
+  blosc2_schunk_free(schunk);
+  blosc2_remove_urlpath(tdata.urlpath);
+
+  return EXIT_SUCCESS;
+}
+
+
+static char *all_tests(void) {
+  for (int i = 0; i < (int)ARRAY_SIZE(tstorage); ++i) {
+    tdata = tstorage[i];
+    mu_run_test(test_negative_chunk_index_rejected);
+  }
+
+  return EXIT_SUCCESS;
+}
+
+
+int main(void) {
+  char *result;
+
+  install_blosc_callback_test();
+  blosc2_init();
+
+  result = all_tests();
+  if (result != EXIT_SUCCESS) {
+    printf(" (%s)\n", result);
+  }
+  else {
+    printf(" ALL TESTS PASSED");
+  }
+  printf("\tTests run: %d\n", tests_run);
+
+  blosc2_destroy();
+
+  return result != EXIT_SUCCESS;
+}


### PR DESCRIPTION
This patch introduces a centralized validation helper `validate_nchunk` to ensure that chunk indices `nchunk` are consistently validated across all schunk operations.

changes:
- Adds `validate_nchunk()` to enforce bounds checking
- Rejects negative indices and out-of-range accesses
- Allows `nchunk == nchunks` only where semantically valid (e.g., insert)
- Replaces duplicated validation logic with a consistent approach across:
  - insert_chunk
  - update_chunk
  - delete_chunk
  - decompress_chunk
  - get_chunk
  - get_lazychunk

Behavior for valid inputs remains unchanged. The only difference is that previously undefined or unsafe inputs are now rejected early with a clear error.