### PR TITLE
Properly check the cframe argument

### DIFF
--- a/blosc/schunk.c
+++ b/blosc/schunk.c
@@ -600,15 +600,13 @@ int blosc2_schunk_free(blosc2_schunk *schunk) {
 
 /* Create a super-chunk out of a contiguous frame buffer */
 blosc2_schunk* blosc2_schunk_from_buffer(uint8_t *cframe, int64_t len, bool copy) {
-  blosc2_frame_s* frame = frame_from_cframe(cframe, len, false);
-  if (frame == NULL) {
+  // Check that the buffer actually comes from a cframe
+  char *magic_number = (char *)cframe + FRAME_HEADER_MAGIC;
+  if (len < FRAME_HEADER_MINLEN || memcmp(magic_number, "b2frame", sizeof("b2frame")) != 0) {
     return NULL;
   }
-  // Check that the buffer actually comes from a cframe
-  char *magic_number = (char *)cframe;
-  magic_number += FRAME_HEADER_MAGIC;
-  if (strcmp(magic_number, "b2frame\0") != 0) {
-    frame_free(frame);
+  blosc2_frame_s* frame = frame_from_cframe(cframe, len, false);
+  if (frame == NULL) {
     return NULL;
   }
   blosc2_schunk* schunk = frame_to_schunk(frame, copy, &BLOSC2_IO_DEFAULTS);

--- a/blosc/schunk.c
+++ b/blosc/schunk.c
@@ -601,8 +601,11 @@ int blosc2_schunk_free(blosc2_schunk *schunk) {
 /* Create a super-chunk out of a contiguous frame buffer */
 blosc2_schunk* blosc2_schunk_from_buffer(uint8_t *cframe, int64_t len, bool copy) {
   // Check that the buffer actually comes from a cframe
+  if (cframe == NULL || len < FRAME_HEADER_MINLEN) {
+    return NULL;
+  }
   char *magic_number = (char *)cframe + FRAME_HEADER_MAGIC;
-  if (len < FRAME_HEADER_MINLEN || memcmp(magic_number, "b2frame", sizeof("b2frame")) != 0) {
+  if (memcmp(magic_number, "b2frame", sizeof("b2frame")) != 0) {
     return NULL;
   }
   blosc2_frame_s* frame = frame_from_cframe(cframe, len, false);

--- a/tests/test_schunk_frame.c
+++ b/tests/test_schunk_frame.c
@@ -8,6 +8,7 @@
 
 #include <stdio.h>
 #include "test_common.h"
+#include "frame.h"
 
 #define CHUNKSIZE (200 * 1000)
 #define NTHREADS (2)
@@ -106,6 +107,48 @@ static char* test_schunk_cframe(void) {
   return EXIT_SUCCESS;
 }
 
+static char* test_schunk_from_buffer_bad_magic(void) {
+  blosc2_schunk* schunk;
+  uint8_t* cframe;
+  bool cframe_needs_free;
+
+  blosc2_init();
+
+  blosc2_storage storage = {.contiguous = true};
+  schunk = blosc2_schunk_new(&storage);
+  mu_assert("blosc2_schunk_new() failed", schunk != NULL);
+
+  int32_t data[16];
+  for (int i = 0; i < (int)ARRAY_SIZE(data); ++i) {
+    data[i] = i;
+  }
+  int64_t nchunks_ = blosc2_schunk_append_buffer(schunk, data, sizeof(data));
+  mu_assert("ERROR: bad append in frame", nchunks_ > 0);
+
+  int64_t len = blosc2_schunk_to_buffer(schunk, &cframe, &cframe_needs_free);
+  mu_assert("Error in getting a frame buffer", len > FRAME_HEADER_MINLEN);
+
+  uint8_t* mutated = malloc((size_t)len);
+  mu_assert("Error allocating mutated frame buffer", mutated != NULL);
+  memcpy(mutated, cframe, (size_t)len);
+  mutated[FRAME_HEADER_MAGIC] ^= 0x1;
+
+  blosc2_schunk* reopened = blosc2_schunk_from_buffer(mutated, len, true);
+  mu_assert("blosc2_schunk_from_buffer() should reject invalid magic", reopened == NULL);
+
+  reopened = blosc2_schunk_from_buffer(mutated, FRAME_HEADER_MINLEN - 1, true);
+  mu_assert("blosc2_schunk_from_buffer() should reject too-small buffers safely", reopened == NULL);
+
+  free(mutated);
+  blosc2_schunk_free(schunk);
+  if (cframe_needs_free) {
+    free(cframe);
+  }
+  blosc2_destroy();
+
+  return EXIT_SUCCESS;
+}
+
 static char *all_tests(void) {
   nchunks = 0;
   contiguous = true;
@@ -147,6 +190,8 @@ static char *all_tests(void) {
   copy = false;
   special_chunks = true;
   mu_run_test(test_schunk_cframe);
+
+  mu_run_test(test_schunk_from_buffer_bad_magic);
 
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Check that the buffer is an actual cframe before creating a frame.

Also, use `memcmp()` instead of `strcmp()` to check an unknown array of 8 bytes that may not end with a terminating NUL character `'\0'`. Relying on null-termination semantics is confusing.

In any case, `"b2frame\0"` is useless and adds more confusion. It is an array of 9 bytes with two terminating NUL characters `'\0'`, whereas `"b2frame"` is an array of 8 bytes with a single terminating NUL character `'\0'`. Because `strcmp()` will stop at the first `'\0'` anyway, the second `'\0'` is useless.