### PR TITLE
Avoid NULL frame dereference

### DIFF
--- a/blosc/schunk.c
+++ b/blosc/schunk.c
@@ -620,7 +620,7 @@ blosc2_schunk* blosc2_schunk_from_buffer(uint8_t *cframe, int64_t len, bool copy
 }
 
 
-/* Create a super-chunk out of a contiguous frame buffer */
+/* Set whether freeing this super-chunk should avoid freeing its contiguous frame buffer */
 void blosc2_schunk_avoid_cframe_free(blosc2_schunk *schunk, bool avoid_cframe_free) {
   blosc2_frame_s* frame = (blosc2_frame_s*)schunk->frame;
   if (frame) {

--- a/blosc/schunk.c
+++ b/blosc/schunk.c
@@ -623,7 +623,9 @@ blosc2_schunk* blosc2_schunk_from_buffer(uint8_t *cframe, int64_t len, bool copy
 /* Create a super-chunk out of a contiguous frame buffer */
 void blosc2_schunk_avoid_cframe_free(blosc2_schunk *schunk, bool avoid_cframe_free) {
   blosc2_frame_s* frame = (blosc2_frame_s*)schunk->frame;
-  frame_avoid_cframe_free(frame, avoid_cframe_free);
+  if (frame) {
+    frame_avoid_cframe_free(frame, avoid_cframe_free);
+  }
 }
 
 

--- a/tests/test_schunk_frame.c
+++ b/tests/test_schunk_frame.c
@@ -106,6 +106,25 @@ static char* test_schunk_cframe(void) {
   return EXIT_SUCCESS;
 }
 
+static char* test_schunk_avoid_cframe_free_without_frame(void) {
+  blosc2_schunk* schunk;
+
+  blosc2_init();
+
+  blosc2_storage storage = {.contiguous = false};
+  schunk = blosc2_schunk_new(&storage);
+  mu_assert("blosc2_schunk_new() failed", schunk != NULL);
+  mu_assert("Expected in-memory non-contiguous schunk to have no frame", schunk->frame == NULL);
+
+  blosc2_schunk_avoid_cframe_free(schunk, true);
+  blosc2_schunk_avoid_cframe_free(schunk, false);
+
+  blosc2_schunk_free(schunk);
+  blosc2_destroy();
+
+  return EXIT_SUCCESS;
+}
+
 static char *all_tests(void) {
   nchunks = 0;
   contiguous = true;
@@ -147,6 +166,8 @@ static char *all_tests(void) {
   copy = false;
   special_chunks = true;
   mu_run_test(test_schunk_cframe);
+
+  mu_run_test(test_schunk_avoid_cframe_free_without_frame);
 
   return EXIT_SUCCESS;
 }

--- a/tests/test_schunk_frame.c
+++ b/tests/test_schunk_frame.c
@@ -121,6 +121,11 @@ static char* test_schunk_avoid_cframe_free_without_frame(void) {
   blosc2_schunk_avoid_cframe_free(schunk, false);
 
   blosc2_schunk_free(schunk);
+  blosc2_destroy();
+
+  return EXIT_SUCCESS;
+}
+
 static char* test_schunk_from_buffer_bad_magic(void) {
   blosc2_schunk* schunk;
   uint8_t* cframe;


### PR DESCRIPTION
Fixes #699.

Need to add the code snippet in as a test. Not sure where to add it, perhaps [`tests/test_schunk_frame.c`](https://github.com/Blosc/c-blosc2/blob/main/tests/test_schunk_frame.c)?