### PR TITLE
Return -1 in case of unknown or unsupported compcode

### DIFF
--- a/blosc/blosc2.c
+++ b/blosc/blosc2.c
@@ -274,20 +274,29 @@ int blosc2_compcode_to_compname(int compcode, const char** compname) {
   int code = -1;    /* -1 means non-existent compressor code */
   const char* name = NULL;
 
-  /* Map the compressor code */
-  if (compcode == BLOSC_BLOSCLZ)
+  if (compcode == BLOSC_BLOSCLZ) {
+    code = BLOSC_BLOSCLZ;
     name = BLOSC_BLOSCLZ_COMPNAME;
-  else if (compcode == BLOSC_LZ4)
+  } else if (compcode == BLOSC_LZ4) {
+    code = BLOSC_LZ4;
     name = BLOSC_LZ4_COMPNAME;
-  else if (compcode == BLOSC_LZ4HC)
+  } else if (compcode == BLOSC_LZ4HC) {
+    code = BLOSC_LZ4HC;
     name = BLOSC_LZ4HC_COMPNAME;
-  else if (compcode == BLOSC_ZLIB)
+  } else if (compcode == BLOSC_ZLIB) {
+#if defined(HAVE_ZLIB)
+    code = BLOSC_ZLIB;
+#endif /* HAVE_ZLIB */
     name = BLOSC_ZLIB_COMPNAME;
-  else if (compcode == BLOSC_ZSTD)
+  } else if (compcode == BLOSC_ZSTD) {
+#if defined(HAVE_ZSTD)
+    code = BLOSC_ZSTD;
+#endif /* HAVE_ZSTD */
     name = BLOSC_ZSTD_COMPNAME;
-  else {
+  } else {
     for (int i = 0; i < g_ncodecs; ++i) {
       if (compcode == g_codecs[i].compcode) {
+        code = compcode;
         name = g_codecs[i].compname;
         break;
       }
@@ -295,24 +304,6 @@ int blosc2_compcode_to_compname(int compcode, const char** compname) {
   }
 
   *compname = name;
-
-  /* Guess if there is support for this code */
-  if (compcode == BLOSC_BLOSCLZ)
-    code = BLOSC_BLOSCLZ;
-  else if (compcode == BLOSC_LZ4)
-    code = BLOSC_LZ4;
-  else if (compcode == BLOSC_LZ4HC)
-    code = BLOSC_LZ4HC;
-#if defined(HAVE_ZLIB)
-  else if (compcode == BLOSC_ZLIB)
-    code = BLOSC_ZLIB;
-#endif /* HAVE_ZLIB */
-#if defined(HAVE_ZSTD)
-  else if (compcode == BLOSC_ZSTD)
-    code = BLOSC_ZSTD;
-#endif /* HAVE_ZSTD */
-  else if (compcode >= BLOSC_LAST_CODEC)
-    code = compcode;
   return code;
 }
 

--- a/tests/test_api.c
+++ b/tests/test_api.c
@@ -86,6 +86,16 @@ static char *test_blocksize(void) {
   return 0;
 }
 
+static char *test_compcode_to_compname_unknown(void) {
+  const char *compname = "sentinel";
+  int compcode;
+
+  compcode = blosc2_compcode_to_compname(BLOSC_LAST_CODEC, &compname);
+  mu_assert("ERROR: unknown compcode should return -1", compcode == -1);
+  mu_assert("ERROR: compname should be NULL for unknown compcode", compname == NULL);
+  return 0;
+}
+
 
 static char* all_tests(void) {
   mu_run_test(test_cbuffer_sizes);
@@ -94,6 +104,7 @@ static char* all_tests(void) {
   mu_run_test(test_cbuffer_complib);
   mu_run_test(test_nthreads);
   mu_run_test(test_blocksize);
+  mu_run_test(test_compcode_to_compname_unknown);
   return 0;
 }
 


### PR DESCRIPTION
From the [documentation](https://blosc.org/c-blosc2/reference/blosc1.html#c.blosc2_compcode_to_compname):
> If the compressor code is not recognized, or there is not support for it in this build, -1 is returned.

Fixes #700.

Need to add the code snippet in as a test. Not sure where to add it, perhaps a new test file?