### PR TITLE
Harden validation for open-path offsets and add malformed-offset test

### DIFF
--- a/blosc/frame.c
+++ b/blosc/frame.c
@@ -1949,6 +1949,66 @@ blosc2_storage* get_new_storage(const blosc2_storage* storage,
 }
 
 
+static int validate_offsets_chunk(blosc2_frame_s* frame, int32_t header_len, int64_t cbytes,
+                                  int64_t nchunks) {
+  int32_t coffsets_cbytes = 0;
+  uint8_t* coffsets = get_coffsets(frame, header_len, cbytes, nchunks, &coffsets_cbytes);
+  if (coffsets == NULL) {
+    BLOSC_TRACE_ERROR("Cannot get compressed offsets from frame.");
+    return BLOSC2_ERROR_DATA;
+  }
+
+  int32_t offsets_nbytes;
+  if (!blosc2_nchunks_to_offsets_nbytes(nchunks, &offsets_nbytes)) {
+    BLOSC_TRACE_ERROR("Too many chunks for offsets representation.");
+    return BLOSC2_ERROR_FAILURE;
+  }
+
+  int64_t* offsets = (int64_t*)malloc((size_t)offsets_nbytes);
+  if (offsets == NULL) {
+    BLOSC_TRACE_ERROR("Cannot allocate memory for offsets validation.");
+    return BLOSC2_ERROR_MEMORY_ALLOC;
+  }
+
+  blosc2_dparams off_dparams = BLOSC2_DPARAMS_DEFAULTS;
+  blosc2_context* dctx = blosc2_create_dctx(off_dparams);
+  if (dctx == NULL) {
+    free(offsets);
+    BLOSC_TRACE_ERROR("Error while creating the decompression context.");
+    return BLOSC2_ERROR_FAILURE;
+  }
+
+  int32_t off_nbytes = blosc2_decompress_ctx(dctx, coffsets, coffsets_cbytes,
+                                             offsets, offsets_nbytes);
+  blosc2_free_ctx(dctx);
+  if (off_nbytes != offsets_nbytes) {
+    free(offsets);
+    BLOSC_TRACE_ERROR("Cannot decompress offsets chunk.");
+    return BLOSC2_ERROR_DATA;
+  }
+
+  for (int64_t i = 0; i < nchunks; ++i) {
+    int64_t offset = offsets[i];
+    if (offset < 0) {
+      continue;
+    }
+    if (offset > INT64_MAX - header_len || offset > cbytes - BLOSC_EXTENDED_HEADER_LENGTH) {
+      free(offsets);
+      BLOSC_TRACE_ERROR("Offset for chunk %" PRId64 " is out of bounds.", i);
+      return BLOSC2_ERROR_INVALID_HEADER;
+    }
+    if (i > 0 && offsets[i - 1] >= 0 && offset < offsets[i - 1]) {
+      free(offsets);
+      BLOSC_TRACE_ERROR("Offsets are not monotonic at chunk %" PRId64 ".", i);
+      return BLOSC2_ERROR_INVALID_HEADER;
+    }
+  }
+
+  free(offsets);
+  return 0;
+}
+
+
 /* Get a super-chunk out of a frame */
 blosc2_schunk* frame_to_schunk(blosc2_frame_s* frame, bool copy, const blosc2_io *udio) {
   int32_t header_len;
@@ -1992,6 +2052,14 @@ blosc2_schunk* frame_to_schunk(blosc2_frame_s* frame, bool copy, const blosc2_io
   schunk->storage = get_new_storage(&storage, cparams, dparams, udio);
   free(cparams);
   free(dparams);
+  if (nchunks > 0) {
+    rc = validate_offsets_chunk(frame, header_len, cbytes, nchunks);
+    if (rc < 0) {
+      blosc2_schunk_free(schunk);
+      BLOSC_TRACE_ERROR("Cannot validate frame offsets.");
+      return NULL;
+    }
+  }
   if (nchunks > 0) {
     uint8_t *chunk;
     bool needs_free;

--- a/blosc/frame.c
+++ b/blosc/frame.c
@@ -1987,6 +1987,8 @@ static int validate_offsets_chunk(blosc2_frame_s* frame, int32_t header_len, int
     return BLOSC2_ERROR_DATA;
   }
 
+  int64_t prev_non_negative_offset = 0;
+  bool have_prev_non_negative_offset = false;
   for (int64_t i = 0; i < nchunks; ++i) {
     int64_t offset = offsets[i];
     if (offset < 0) {
@@ -1997,11 +1999,13 @@ static int validate_offsets_chunk(blosc2_frame_s* frame, int32_t header_len, int
       BLOSC_TRACE_ERROR("Offset for chunk %" PRId64 " is out of bounds.", i);
       return BLOSC2_ERROR_INVALID_HEADER;
     }
-    if (i > 0 && offsets[i - 1] >= 0 && offset < offsets[i - 1]) {
+    if (have_prev_non_negative_offset && offset < prev_non_negative_offset) {
       free(offsets);
       BLOSC_TRACE_ERROR("Offsets are not monotonic at chunk %" PRId64 ".", i);
       return BLOSC2_ERROR_INVALID_HEADER;
     }
+    prev_non_negative_offset = offset;
+    have_prev_non_negative_offset = true;
   }
 
   free(offsets);

--- a/blosc/schunk.c
+++ b/blosc/schunk.c
@@ -375,7 +375,6 @@ blosc2_schunk* blosc2_schunk_open_offset_udio(const char* urlpath, int64_t offse
   }
   blosc2_schunk* schunk = frame_to_schunk(frame, false, udio);
   if (schunk == NULL) {
-    frame_free(frame);
     BLOSC_TRACE_ERROR("Error converting frame to super-chunk");
     return NULL;
   }

--- a/tests/test_frame_malformed_offsets.c
+++ b/tests/test_frame_malformed_offsets.c
@@ -7,6 +7,7 @@
 #include <limits.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <string.h>
 
 #include "blosc-private.h"
 #include "frame.h"
@@ -113,9 +114,93 @@ static char* test_reject_malformed_frame_offsets(void) {
   return EXIT_SUCCESS;
 }
 
+static char* test_open_rejects_malformed_frame_offsets(void) {
+  int32_t data[CHUNKSIZE];
+  const char* path = "test_frame_malformed_offsets_open.b2frame";
+  blosc2_storage storage = {.contiguous = true};
+  blosc2_schunk *schunk = NULL;
+  FILE *fp = NULL;
+  uint8_t *filebuf = NULL;
+
+  blosc2_remove_urlpath(path);
+  blosc2_init();
+
+  schunk = blosc2_schunk_new(&storage);
+  mu_assert("Cannot create schunk", schunk != NULL);
+
+  for (int i = 0; i < CHUNKSIZE; ++i) {
+    data[i] = i;
+  }
+
+  for (int nchunk = 0; nchunk < NCHUNKS; ++nchunk) {
+    int64_t n = blosc2_schunk_append_buffer(schunk, data, (int32_t)sizeof(data));
+    mu_assert("Cannot append chunk", n >= 0);
+  }
+
+  int64_t written = blosc2_schunk_to_file(schunk, path);
+  mu_assert("Cannot write frame", written > 0);
+
+  fp = fopen(path, "rb+");
+  mu_assert("Cannot open malformed test file", fp != NULL);
+  mu_assert("Cannot seek to end", fseek(fp, 0, SEEK_END) == 0);
+  long flen = ftell(fp);
+  mu_assert("Cannot get file size", flen > 0);
+  rewind(fp);
+
+  filebuf = malloc((size_t)flen);
+  mu_assert("Cannot allocate file buffer", filebuf != NULL);
+  mu_assert("Cannot read frame file", fread(filebuf, 1, (size_t)flen, fp) == (size_t)flen);
+
+  int32_t header_len;
+  int64_t cbytes;
+  from_big(&header_len, filebuf + FRAME_HEADER_LEN, sizeof(header_len));
+  from_big(&cbytes, filebuf + FRAME_CBYTES, sizeof(cbytes));
+  mu_assert("Invalid header length", header_len >= FRAME_HEADER_MINLEN);
+  mu_assert("Invalid compressed bytes", cbytes > 0);
+
+  int64_t off_pos = header_len + cbytes;
+  mu_assert("Offset chunk position out of bounds",
+            off_pos >= 0 && off_pos + BLOSC_EXTENDED_HEADER_LENGTH <= flen);
+
+  int32_t off_nbytes;
+  int32_t off_cbytes;
+  int rc = blosc2_cbuffer_sizes(filebuf + off_pos, &off_nbytes, &off_cbytes, NULL);
+  mu_assert("Cannot parse on-disk offsets chunk", rc >= 0);
+  mu_assert("Invalid offsets cbytes",
+            off_cbytes >= BLOSC_EXTENDED_HEADER_LENGTH && off_pos + off_cbytes <= flen);
+  (void)off_nbytes;
+
+  /* Corrupt the offsets chunk payload so frame_to_schunk fails on open. */
+  memset(filebuf + off_pos + BLOSC_EXTENDED_HEADER_LENGTH, 0xFF,
+         (size_t)(off_cbytes - BLOSC_EXTENDED_HEADER_LENGTH));
+
+  rewind(fp);
+  mu_assert("Cannot write malformed frame", fwrite(filebuf, 1, (size_t)flen, fp) == (size_t)flen);
+  fclose(fp);
+  fp = NULL;
+
+  blosc2_schunk *decoded = blosc2_schunk_open(path);
+  mu_assert("Malformed frame must be rejected", decoded == NULL);
+
+  if (fp != NULL) {
+    fclose(fp);
+  }
+  if (filebuf != NULL) {
+    free(filebuf);
+  }
+  if (schunk != NULL) {
+    blosc2_schunk_free(schunk);
+  }
+  blosc2_remove_urlpath(path);
+  blosc2_destroy();
+
+  return EXIT_SUCCESS;
+}
+
 
 static char *all_tests(void) {
   mu_run_test(test_reject_malformed_frame_offsets);
+  mu_run_test(test_open_rejects_malformed_frame_offsets);
   return EXIT_SUCCESS;
 }
 


### PR DESCRIPTION
Strengthens frame parsing on the open path by validating and decompressing the offsets chunk before chunk probing so malformed offsets are rejected safely instead of causing unsafe behavior.

Also adds a regression test that corrupts on-disk offsets and verifies open rejects the frame, with Windows-safe test file handling. Includes ownership-path fix so frame resources are not double-freed when conversion fails.