### PR TITLE
validate frame_len and trailer_len to prevent overflow and OOB reads

### DIFF
--- a/blosc/frame.c
+++ b/blosc/frame.c
@@ -930,6 +930,11 @@ blosc2_frame_s* frame_from_file_offset(const char* urlpath, const blosc2_io *io,
 
     urlpath = normalize_urlpath(urlpath);
 
+    if (offset < 0) {
+      BLOSC_TRACE_ERROR("Negative frame offset is not valid: %" PRId64 ".", offset);
+      return NULL;
+    }
+
     if(stat(urlpath, &path_stat) < 0) {
         BLOSC_TRACE_ERROR("Cannot get information about the path %s.", urlpath);
         return NULL;
@@ -976,6 +981,29 @@ blosc2_frame_s* frame_from_file_offset(const char* urlpath, const blosc2_io *io,
     }
     int64_t frame_len;
     to_big(&frame_len, header_ptr + FRAME_LEN, sizeof(frame_len));
+    if (frame_len < FRAME_HEADER_MINLEN + FRAME_TRAILER_MINLEN) {
+      BLOSC_TRACE_ERROR("Invalid frame length (%" PRId64 ") in file '%s'.", frame_len, urlpath);
+      io_cb->close(fp);
+      free(urlpath_cpy);
+      return NULL;
+    }
+
+    if (!sframe) {
+      int64_t file_size = (int64_t) path_stat.st_size;
+      if (offset > file_size || frame_len > file_size - offset) {
+        BLOSC_TRACE_ERROR("Frame length exceeds file boundary in file '%s'.", urlpath);
+        io_cb->close(fp);
+        free(urlpath_cpy);
+        return NULL;
+      }
+    }
+
+    if (offset > INT64_MAX - (frame_len - FRAME_TRAILER_MINLEN)) {
+      BLOSC_TRACE_ERROR("Frame offset arithmetic overflows in file '%s'.", urlpath);
+      io_cb->close(fp);
+      free(urlpath_cpy);
+      return NULL;
+    }
 
     blosc2_frame_s* frame = calloc(1, sizeof(blosc2_frame_s));
     frame->urlpath = urlpath_cpy;
@@ -1004,6 +1032,13 @@ blosc2_frame_s* frame_from_file_offset(const char* urlpath, const blosc2_io *io,
     }
     uint32_t trailer_len;
     to_big(&trailer_len, trailer_ptr + trailer_offset, sizeof(trailer_len));
+    if (trailer_len < FRAME_TRAILER_MINLEN || trailer_len > INT32_MAX || trailer_len > (uint32_t) frame_len) {
+      BLOSC_TRACE_ERROR("Invalid trailer length (%" PRIu32 ") in file '%s'.", trailer_len, urlpath);
+      io_cb->close(fp);
+      free(urlpath_cpy);
+      free(frame);
+      return NULL;
+    }
     frame->trailer_len = trailer_len;
 
     return frame;

--- a/blosc/frame.c
+++ b/blosc/frame.c
@@ -1034,7 +1034,6 @@ blosc2_frame_s* frame_from_file_offset(const char* urlpath, const blosc2_io *io,
     to_big(&trailer_len, trailer_ptr + trailer_offset, sizeof(trailer_len));
     if (trailer_len < FRAME_TRAILER_MINLEN || trailer_len > INT32_MAX || trailer_len > (uint32_t) frame_len) {
       BLOSC_TRACE_ERROR("Invalid trailer length (%" PRIu32 ") in file '%s'.", trailer_len, urlpath);
-      io_cb->close(fp);
       free(urlpath_cpy);
       free(frame);
       return NULL;

--- a/blosc/frame.c
+++ b/blosc/frame.c
@@ -1032,7 +1032,7 @@ blosc2_frame_s* frame_from_file_offset(const char* urlpath, const blosc2_io *io,
     }
     uint32_t trailer_len;
     to_big(&trailer_len, trailer_ptr + trailer_offset, sizeof(trailer_len));
-    if (trailer_len < FRAME_TRAILER_MINLEN || trailer_len > INT32_MAX || trailer_len > (uint32_t) frame_len) {
+    if (trailer_len < FRAME_TRAILER_MINLEN || trailer_len > INT32_MAX || (int64_t)trailer_len > frame_len) {
       BLOSC_TRACE_ERROR("Invalid trailer length (%" PRIu32 ") in file '%s'.", trailer_len, urlpath);
       free(urlpath_cpy);
       free(frame);

--- a/tests/test_frame_malformed_trailer_len.c
+++ b/tests/test_frame_malformed_trailer_len.c
@@ -1,0 +1,83 @@
+/*
+  Copyright (c) 2026  Blosc Development Team <blosc@blosc.org>
+  https://blosc.org
+  License: BSD 3-Clause (see LICENSE.txt)
+*/
+
+#include <stdint.h>
+#include <stdio.h>
+
+#include "blosc-private.h"
+#include "frame.h"
+#include "test_common.h"
+
+#define CHUNKSIZE (256)
+
+/* Global vars */
+int tests_run = 0;
+
+static char* test_reject_oversized_trailer_len_in_fileframe(void) {
+  int32_t data[CHUNKSIZE];
+
+  blosc2_init();
+
+  blosc2_storage storage = {.contiguous = true};
+  blosc2_schunk *schunk = blosc2_schunk_new(&storage);
+  mu_assert("Cannot create schunk", schunk != NULL);
+
+  for (int i = 0; i < CHUNKSIZE; ++i) {
+    data[i] = i;
+  }
+
+  int64_t n = blosc2_schunk_append_buffer(schunk, data, (int32_t)sizeof(data));
+  mu_assert("Cannot append chunk", n >= 0);
+
+  uint8_t *cframe = NULL;
+  bool cframe_needs_free = false;
+  int64_t cframe_len = blosc2_schunk_to_buffer(schunk, &cframe, &cframe_needs_free);
+  mu_assert("Cannot export cframe", cframe_len > FRAME_TRAILER_MINLEN && cframe != NULL);
+
+  uint32_t bad_trailer_len = UINT32_MAX;
+  to_big(cframe + cframe_len - FRAME_TRAILER_LEN_OFFSET, &bad_trailer_len, sizeof(bad_trailer_len));
+
+  const char *fname = "malformed_trailer_len.b2frame";
+  FILE *fp = fopen(fname, "wb");
+  mu_assert("Cannot create malformed frame file", fp != NULL);
+  size_t written = fwrite(cframe, 1, (size_t)cframe_len, fp);
+  fclose(fp);
+  mu_assert("Cannot write malformed frame file", written == (size_t)cframe_len);
+
+  blosc2_frame_s *frame = frame_from_file_offset(fname, &BLOSC2_IO_DEFAULTS, 0);
+  mu_assert("Malformed trailer length must be rejected", frame == NULL);
+
+  remove(fname);
+  blosc2_schunk_free(schunk);
+  if (cframe_needs_free) {
+    free(cframe);
+  }
+  blosc2_destroy();
+
+  return EXIT_SUCCESS;
+}
+
+
+static char *all_tests(void) {
+  mu_run_test(test_reject_oversized_trailer_len_in_fileframe);
+  return EXIT_SUCCESS;
+}
+
+
+int main(void) {
+  char *result;
+
+  result = all_tests();
+  if (result != EXIT_SUCCESS) {
+    printf(" (%s)\n", result);
+  }
+  else {
+    printf(" ALL TESTS PASSED");
+  }
+  printf("\tTests run: %d\n", tests_run);
+
+  return result != EXIT_SUCCESS;
+}

--- a/tests/test_frame_malformed_trailer_len.c
+++ b/tests/test_frame_malformed_trailer_len.c
@@ -61,8 +61,102 @@ static char* test_reject_oversized_trailer_len_in_fileframe(void) {
 }
 
 
+static char* test_reject_too_small_trailer_len(void) {
+  int32_t data[CHUNKSIZE];
+
+  blosc2_init();
+
+  blosc2_storage storage = {.contiguous = true};
+  blosc2_schunk *schunk = blosc2_schunk_new(&storage);
+  mu_assert("Cannot create schunk", schunk != NULL);
+
+  for (int i = 0; i < CHUNKSIZE; ++i) {
+    data[i] = i;
+  }
+
+  int64_t n = blosc2_schunk_append_buffer(schunk, data, (int32_t)sizeof(data));
+  mu_assert("Cannot append chunk", n >= 0);
+
+  uint8_t *cframe = NULL;
+  bool cframe_needs_free = false;
+  int64_t cframe_len = blosc2_schunk_to_buffer(schunk, &cframe, &cframe_needs_free);
+  mu_assert("Cannot export cframe", cframe_len > FRAME_TRAILER_MINLEN && cframe != NULL);
+
+  /* Set trailer_len to a value smaller than FRAME_TRAILER_MINLEN */
+  uint32_t bad_trailer_len = FRAME_TRAILER_MINLEN - 1;
+  to_big(cframe + cframe_len - FRAME_TRAILER_LEN_OFFSET, &bad_trailer_len, sizeof(bad_trailer_len));
+
+  const char *fname = "malformed_trailer_small.b2frame";
+  FILE *fp = fopen(fname, "wb");
+  mu_assert("Cannot create malformed frame file", fp != NULL);
+  size_t written = fwrite(cframe, 1, (size_t)cframe_len, fp);
+  fclose(fp);
+  mu_assert("Cannot write malformed frame file", written == (size_t)cframe_len);
+
+  blosc2_frame_s *frame = frame_from_file_offset(fname, &BLOSC2_IO_DEFAULTS, 0);
+  mu_assert("Too-small trailer length must be rejected", frame == NULL);
+
+  remove(fname);
+  blosc2_schunk_free(schunk);
+  if (cframe_needs_free) {
+    free(cframe);
+  }
+  blosc2_destroy();
+
+  return EXIT_SUCCESS;
+}
+
+
+static char* test_reject_trailer_len_exceeding_frame_len(void) {
+  int32_t data[CHUNKSIZE];
+
+  blosc2_init();
+
+  blosc2_storage storage = {.contiguous = true};
+  blosc2_schunk *schunk = blosc2_schunk_new(&storage);
+  mu_assert("Cannot create schunk", schunk != NULL);
+
+  for (int i = 0; i < CHUNKSIZE; ++i) {
+    data[i] = i;
+  }
+
+  int64_t n = blosc2_schunk_append_buffer(schunk, data, (int32_t)sizeof(data));
+  mu_assert("Cannot append chunk", n >= 0);
+
+  uint8_t *cframe = NULL;
+  bool cframe_needs_free = false;
+  int64_t cframe_len = blosc2_schunk_to_buffer(schunk, &cframe, &cframe_needs_free);
+  mu_assert("Cannot export cframe", cframe_len > FRAME_TRAILER_MINLEN && cframe != NULL);
+
+  /* Set trailer_len larger than frame_len but within INT32_MAX */
+  uint32_t bad_trailer_len = (uint32_t)cframe_len + 1;
+  to_big(cframe + cframe_len - FRAME_TRAILER_LEN_OFFSET, &bad_trailer_len, sizeof(bad_trailer_len));
+
+  const char *fname = "malformed_trailer_big.b2frame";
+  FILE *fp = fopen(fname, "wb");
+  mu_assert("Cannot create malformed frame file", fp != NULL);
+  size_t written = fwrite(cframe, 1, (size_t)cframe_len, fp);
+  fclose(fp);
+  mu_assert("Cannot write malformed frame file", written == (size_t)cframe_len);
+
+  blosc2_frame_s *frame = frame_from_file_offset(fname, &BLOSC2_IO_DEFAULTS, 0);
+  mu_assert("Trailer length exceeding frame length must be rejected", frame == NULL);
+
+  remove(fname);
+  blosc2_schunk_free(schunk);
+  if (cframe_needs_free) {
+    free(cframe);
+  }
+  blosc2_destroy();
+
+  return EXIT_SUCCESS;
+}
+
+
 static char *all_tests(void) {
   mu_run_test(test_reject_oversized_trailer_len_in_fileframe);
+  mu_run_test(test_reject_too_small_trailer_len);
+  mu_run_test(test_reject_trailer_len_exceeding_frame_len);
   return EXIT_SUCCESS;
 }
 


### PR DESCRIPTION
This patch strengthens input validation in `frame_from_file_offset` by enforcing strict bounds on `trailer_len` before it is used in frame processing.

## Changes introduced
- Adds strict validation for trailer_len:
  - Must be ≥ FRAME_TRAILER_MINLEN
  - Must not exceed INT32_MAX (prevents integer overflow issues)
  - Must not exceed frame_len (prevents out-of-bounds access)
- Rejects invalid frames early by returning NULL on detection of unsafe conditions

## Testing
- Added regression test covering oversized and invalid trailer length scenarios
- Verified that valid frames continue to be parsed successfully
- Confirmed that invalid inputs are safely rejected (NULL return behavior)