### PR TITLE
Harden metalayer APIs against invalid lengths and unsafe memory usage

### DIFF
--- a/blosc/schunk.c
+++ b/blosc/schunk.c
@@ -2036,9 +2036,10 @@ int blosc2_vlmeta_update(blosc2_schunk *schunk, const char *name, uint8_t *conte
   if (compressed_buf == NULL && csize > 0) {
     compressed_buf = content_buf;
   }
-  free(vlmetalayer->content);
+  uint8_t* old_content = vlmetalayer->content;
   vlmetalayer->content = compressed_buf;
   vlmetalayer->content_len = csize;
+  free(old_content);
 
   // Propagate to frames
   int rc = vlmetalayer_flush(schunk);

--- a/blosc/schunk.c
+++ b/blosc/schunk.c
@@ -1844,7 +1844,7 @@ int blosc2_vlmeta_add(blosc2_schunk *schunk, const char *name, uint8_t *content,
   }
 
   uint8_t* content_buf = malloc((size_t) content_len + BLOSC2_MAX_OVERHEAD);
-  if (content_buf == NULL && content_len > 0) {
+  if (content_buf == NULL) {
     free(vlmetalayer->name);
     free(vlmetalayer);
     BLOSC_TRACE_ERROR("Unable to allocate variable-length metalayer buffer.");

--- a/blosc/schunk.c
+++ b/blosc/schunk.c
@@ -1681,6 +1681,10 @@ int metalayer_flush(blosc2_schunk* schunk) {
  * If successful, return the index of the new metalayer.  Else, return a negative value.
  */
 int blosc2_meta_add(blosc2_schunk *schunk, const char *name, uint8_t *content, int32_t content_len) {
+  if (schunk == NULL || name == NULL) {
+    BLOSC_TRACE_ERROR("Invalid parameters.");
+    return BLOSC2_ERROR_INVALID_PARAM;
+  }
   int nmetalayer = blosc2_meta_exists(schunk, name);
   if (nmetalayer >= 0) {
     BLOSC_TRACE_ERROR("Metalayer \"%s\" already exists.", name);
@@ -1737,6 +1741,10 @@ int blosc2_meta_add(blosc2_schunk *schunk, const char *name, uint8_t *content, i
  * If successful, return the index of the new metalayer.  Else, return a negative value.
  */
 int blosc2_meta_update(blosc2_schunk *schunk, const char *name, uint8_t *content, int32_t content_len) {
+  if (schunk == NULL || name == NULL) {
+    BLOSC_TRACE_ERROR("Invalid parameters.");
+    return BLOSC2_ERROR_INVALID_PARAM;
+  }
   int nmetalayer = blosc2_meta_exists(schunk, name);
   if (nmetalayer < 0) {
     BLOSC_TRACE_ERROR("Metalayer \"%s\" not found.", name);
@@ -1819,6 +1827,10 @@ int vlmetalayer_flush(blosc2_schunk* schunk) {
  */
 int blosc2_vlmeta_add(blosc2_schunk *schunk, const char *name, uint8_t *content, int32_t content_len,
                       blosc2_cparams *cparams) {
+  if (schunk == NULL || name == NULL) {
+    BLOSC_TRACE_ERROR("Invalid parameters.");
+    return BLOSC2_ERROR_INVALID_PARAM;
+  }
   int nvlmetalayer = blosc2_vlmeta_exists(schunk, name);
   if (nvlmetalayer >= 0) {
     BLOSC_TRACE_ERROR("Variable-length metalayer \"%s\" already exists.", name);
@@ -1843,7 +1855,15 @@ int blosc2_vlmeta_add(blosc2_schunk *schunk, const char *name, uint8_t *content,
     return BLOSC2_ERROR_MEMORY_ALLOC;
   }
 
-  uint8_t* content_buf = malloc((size_t) content_len + BLOSC2_MAX_OVERHEAD);
+  int64_t destsize = (int64_t)content_len + BLOSC2_MAX_OVERHEAD;
+  if (destsize > INT32_MAX) {
+    free(vlmetalayer->name);
+    free(vlmetalayer);
+    BLOSC_TRACE_ERROR("Variable-length metalayer size is too large.");
+    return BLOSC2_ERROR_INVALID_PARAM;
+  }
+  size_t destsize_sz = (size_t)destsize;
+  uint8_t* content_buf = malloc(destsize_sz);
   if (content_buf == NULL) {
     free(vlmetalayer->name);
     free(vlmetalayer);
@@ -1865,7 +1885,7 @@ int blosc2_vlmeta_add(blosc2_schunk *schunk, const char *name, uint8_t *content,
     return BLOSC2_ERROR_NULL_POINTER;
   }
 
-  int csize = blosc2_compress_ctx(cctx, content, content_len, content_buf, content_len + BLOSC2_MAX_OVERHEAD);
+  int csize = blosc2_compress_ctx(cctx, content, content_len, content_buf, (int32_t)destsize);
   if (csize < 0) {
     blosc2_free_ctx(cctx);
     free(content_buf);
@@ -1876,7 +1896,11 @@ int blosc2_vlmeta_add(blosc2_schunk *schunk, const char *name, uint8_t *content,
   }
   blosc2_free_ctx(cctx);
 
-  vlmetalayer->content = realloc(content_buf, csize);
+  uint8_t *compressed_buf = realloc(content_buf, csize);
+  if (compressed_buf == NULL && csize > 0) {
+    compressed_buf = content_buf;
+  }
+  vlmetalayer->content = compressed_buf;
   vlmetalayer->content_len = csize;
   schunk->vlmetalayers[schunk->nvlmetalayers] = vlmetalayer;
   schunk->nvlmetalayers += 1;
@@ -1956,6 +1980,10 @@ int blosc2_vlmeta_get(blosc2_schunk *schunk, const char *name, uint8_t **content
 
 int blosc2_vlmeta_update(blosc2_schunk *schunk, const char *name, uint8_t *content, int32_t content_len,
                          blosc2_cparams *cparams) {
+  if (schunk == NULL || name == NULL) {
+    BLOSC_TRACE_ERROR("Invalid parameters.");
+    return BLOSC2_ERROR_INVALID_PARAM;
+  }
   int nvlmetalayer = blosc2_vlmeta_exists(schunk, name);
   if (nvlmetalayer < 0) {
     BLOSC_TRACE_ERROR("User vlmetalayer \"%s\" not found.", name);
@@ -1971,8 +1999,13 @@ int blosc2_vlmeta_update(blosc2_schunk *schunk, const char *name, uint8_t *conte
   }
 
   blosc2_metalayer *vlmetalayer = schunk->vlmetalayers[nvlmetalayer];
-  free(vlmetalayer->content);
-  uint8_t* content_buf = malloc((size_t) content_len + BLOSC2_MAX_OVERHEAD);
+  int64_t destsize = (int64_t)content_len + BLOSC2_MAX_OVERHEAD;
+  if (destsize > INT32_MAX) {
+    BLOSC_TRACE_ERROR("Variable-length metalayer size is too large.");
+    return BLOSC2_ERROR_INVALID_PARAM;
+  }
+  size_t destsize_sz = (size_t)destsize;
+  uint8_t* content_buf = malloc(destsize_sz);
   if (content_buf == NULL && content_len > 0) {
     BLOSC_TRACE_ERROR("Unable to allocate variable-length metalayer buffer.");
     return BLOSC2_ERROR_MEMORY_ALLOC;
@@ -1985,18 +2018,26 @@ int blosc2_vlmeta_update(blosc2_schunk *schunk, const char *name, uint8_t *conte
     cctx = blosc2_create_cctx(BLOSC2_CPARAMS_DEFAULTS);
   }
   if (cctx == NULL) {
+    free(content_buf);
     BLOSC_TRACE_ERROR("Error while creating the compression context");
     return BLOSC2_ERROR_NULL_POINTER;
   }
 
-  int csize = blosc2_compress_ctx(cctx, content, content_len, content_buf, content_len + BLOSC2_MAX_OVERHEAD);
+  int csize = blosc2_compress_ctx(cctx, content, content_len, content_buf, (int32_t)destsize);
   if (csize < 0) {
+    blosc2_free_ctx(cctx);
+    free(content_buf);
     BLOSC_TRACE_ERROR("Can not compress the `%s` variable-length metalayer.", name);
     return csize;
   }
   blosc2_free_ctx(cctx);
 
-  vlmetalayer->content = realloc(content_buf, csize);
+  uint8_t* compressed_buf = realloc(content_buf, csize);
+  if (compressed_buf == NULL && csize > 0) {
+    compressed_buf = content_buf;
+  }
+  free(vlmetalayer->content);
+  vlmetalayer->content = compressed_buf;
   vlmetalayer->content_len = csize;
 
   // Propagate to frames

--- a/blosc/schunk.c
+++ b/blosc/schunk.c
@@ -1686,14 +1686,38 @@ int blosc2_meta_add(blosc2_schunk *schunk, const char *name, uint8_t *content, i
     BLOSC_TRACE_ERROR("Metalayer \"%s\" already exists.", name);
     return BLOSC2_ERROR_INVALID_PARAM;
   }
+  if (content_len < 0) {
+    BLOSC_TRACE_ERROR("Metalayer content length must not be negative.");
+    return BLOSC2_ERROR_INVALID_PARAM;
+  }
+  if (content_len > 0 && content == NULL) {
+    BLOSC_TRACE_ERROR("Metalayer content pointer must not be NULL when content length is positive.");
+    return BLOSC2_ERROR_INVALID_PARAM;
+  }
 
   // Add the metalayer
   blosc2_metalayer *metalayer = malloc(sizeof(blosc2_metalayer));
+  BLOSC_ERROR_NULL(metalayer, BLOSC2_ERROR_MEMORY_ALLOC);
+
   char* name_ = malloc(strlen(name) + 1);
+  if (name_ == NULL) {
+    free(metalayer);
+    BLOSC_TRACE_ERROR("Unable to allocate metalayer name buffer.");
+    return BLOSC2_ERROR_MEMORY_ALLOC;
+  }
   strcpy(name_, name);
   metalayer->name = name_;
+
   uint8_t* content_buf = malloc((size_t)content_len);
-  memcpy(content_buf, content, content_len);
+  if (content_buf == NULL && content_len > 0) {
+    free(name_);
+    free(metalayer);
+    BLOSC_TRACE_ERROR("Unable to allocate metalayer content buffer.");
+    return BLOSC2_ERROR_MEMORY_ALLOC;
+  }
+  if (content_len > 0) {
+    memcpy(content_buf, content, content_len);
+  }
   metalayer->content = content_buf;
   metalayer->content_len = content_len;
   schunk->metalayers[schunk->nmetalayers] = metalayer;
@@ -1718,6 +1742,14 @@ int blosc2_meta_update(blosc2_schunk *schunk, const char *name, uint8_t *content
     BLOSC_TRACE_ERROR("Metalayer \"%s\" not found.", name);
     return nmetalayer;
   }
+  if (content_len < 0) {
+    BLOSC_TRACE_ERROR("Metalayer content length must not be negative.");
+    return BLOSC2_ERROR_INVALID_PARAM;
+  }
+  if (content_len > 0 && content == NULL) {
+    BLOSC_TRACE_ERROR("Metalayer content pointer must not be NULL when content length is positive.");
+    return BLOSC2_ERROR_INVALID_PARAM;
+  }
 
   blosc2_metalayer *metalayer = schunk->metalayers[nmetalayer];
   if (content_len > metalayer->content_len) {
@@ -1726,7 +1758,9 @@ int blosc2_meta_update(blosc2_schunk *schunk, const char *name, uint8_t *content
   }
 
   // Update the contents of the metalayer
-  memcpy(metalayer->content, content, content_len);
+  if (content_len > 0) {
+    memcpy(metalayer->content, content, content_len);
+  }
 
   // Update the metalayers in frame (as size has not changed, we don't need to update the trailer)
   blosc2_frame_s* frame = (blosc2_frame_s*)schunk->frame;
@@ -1790,11 +1824,32 @@ int blosc2_vlmeta_add(blosc2_schunk *schunk, const char *name, uint8_t *content,
     BLOSC_TRACE_ERROR("Variable-length metalayer \"%s\" already exists.", name);
     return BLOSC2_ERROR_INVALID_PARAM;
   }
+  if (content_len < 0) {
+    BLOSC_TRACE_ERROR("Variable-length metalayer content length must not be negative.");
+    return BLOSC2_ERROR_INVALID_PARAM;
+  }
+  if (content_len > 0 && content == NULL) {
+    BLOSC_TRACE_ERROR("Variable-length metalayer content pointer must not be NULL when content length is positive.");
+    return BLOSC2_ERROR_INVALID_PARAM;
+  }
 
   // Add the vlmetalayer
   blosc2_metalayer *vlmetalayer = malloc(sizeof(blosc2_metalayer));
+  BLOSC_ERROR_NULL(vlmetalayer, BLOSC2_ERROR_MEMORY_ALLOC);
   vlmetalayer->name = strdup(name);
+  if (vlmetalayer->name == NULL) {
+    free(vlmetalayer);
+    BLOSC_TRACE_ERROR("Unable to allocate variable-length metalayer name buffer.");
+    return BLOSC2_ERROR_MEMORY_ALLOC;
+  }
+
   uint8_t* content_buf = malloc((size_t) content_len + BLOSC2_MAX_OVERHEAD);
+  if (content_buf == NULL && content_len > 0) {
+    free(vlmetalayer->name);
+    free(vlmetalayer);
+    BLOSC_TRACE_ERROR("Unable to allocate variable-length metalayer buffer.");
+    return BLOSC2_ERROR_MEMORY_ALLOC;
+  }
 
   blosc2_context *cctx;
   if (cparams != NULL) {
@@ -1832,6 +1887,10 @@ int blosc2_vlmeta_add(blosc2_schunk *schunk, const char *name, uint8_t *content,
 
 int blosc2_vlmeta_get(blosc2_schunk *schunk, const char *name, uint8_t **content,
                       int32_t *content_len) {
+  if (content == NULL || content_len == NULL) {
+    BLOSC_TRACE_ERROR("Output pointers must not be NULL.");
+    return BLOSC2_ERROR_INVALID_PARAM;
+  }
   int nvlmetalayer = blosc2_vlmeta_exists(schunk, name);
   if (nvlmetalayer < 0) {
     BLOSC_TRACE_ERROR("User metalayer \"%s\" not found.", name);
@@ -1844,8 +1903,20 @@ int blosc2_vlmeta_get(blosc2_schunk *schunk, const char *name, uint8_t **content
     BLOSC_TRACE_ERROR("User metalayer \"%s\" is corrupted.", meta->name);
     return BLOSC2_ERROR_DATA;
   }
+  if (nbytes < 0) {
+    BLOSC_TRACE_ERROR("User metalayer \"%s\" has corrupted decompressed size %d.", meta->name, nbytes);
+    return BLOSC2_ERROR_DATA;
+  }
   *content_len = nbytes;
-  *content = malloc((size_t) nbytes);
+  if (nbytes == 0) {
+    *content = NULL;
+  } else {
+    *content = malloc((size_t) nbytes);
+    if (*content == NULL) {
+      BLOSC_TRACE_ERROR("Unable to allocate variable-length metalayer content buffer.");
+      return BLOSC2_ERROR_MEMORY_ALLOC;
+    }
+  }
   blosc2_context *dctx = blosc2_create_dctx(*schunk->storage->dparams);
   if (dctx == NULL) {
     BLOSC_TRACE_ERROR("Error while creating the decompression context");
@@ -1867,10 +1938,22 @@ int blosc2_vlmeta_update(blosc2_schunk *schunk, const char *name, uint8_t *conte
     BLOSC_TRACE_ERROR("User vlmetalayer \"%s\" not found.", name);
     return nvlmetalayer;
   }
+  if (content_len < 0) {
+    BLOSC_TRACE_ERROR("Variable-length metalayer content length must not be negative.");
+    return BLOSC2_ERROR_INVALID_PARAM;
+  }
+  if (content_len > 0 && content == NULL) {
+    BLOSC_TRACE_ERROR("Variable-length metalayer content pointer must not be NULL when content length is positive.");
+    return BLOSC2_ERROR_INVALID_PARAM;
+  }
 
   blosc2_metalayer *vlmetalayer = schunk->vlmetalayers[nvlmetalayer];
   free(vlmetalayer->content);
   uint8_t* content_buf = malloc((size_t) content_len + BLOSC2_MAX_OVERHEAD);
+  if (content_buf == NULL && content_len > 0) {
+    BLOSC_TRACE_ERROR("Unable to allocate variable-length metalayer buffer.");
+    return BLOSC2_ERROR_MEMORY_ALLOC;
+  }
 
   blosc2_context *cctx;
   if (cparams != NULL) {

--- a/blosc/schunk.c
+++ b/blosc/schunk.c
@@ -1858,12 +1858,19 @@ int blosc2_vlmeta_add(blosc2_schunk *schunk, const char *name, uint8_t *content,
     cctx = blosc2_create_cctx(BLOSC2_CPARAMS_DEFAULTS);
   }
   if (cctx == NULL) {
+    free(content_buf);
+    free(vlmetalayer->name);
+    free(vlmetalayer);
     BLOSC_TRACE_ERROR("Error while creating the compression context");
     return BLOSC2_ERROR_NULL_POINTER;
   }
 
   int csize = blosc2_compress_ctx(cctx, content, content_len, content_buf, content_len + BLOSC2_MAX_OVERHEAD);
   if (csize < 0) {
+    blosc2_free_ctx(cctx);
+    free(content_buf);
+    free(vlmetalayer->name);
+    free(vlmetalayer);
     BLOSC_TRACE_ERROR("Can not compress the `%s` variable-length metalayer.", name);
     return csize;
   }
@@ -1877,6 +1884,11 @@ int blosc2_vlmeta_add(blosc2_schunk *schunk, const char *name, uint8_t *content,
   // Propagate to frames
   int rc = vlmetalayer_flush(schunk);
   if (rc < 0) {
+    schunk->nvlmetalayers -= 1;
+    schunk->vlmetalayers[schunk->nvlmetalayers] = NULL;
+    free(vlmetalayer->content);
+    free(vlmetalayer->name);
+    free(vlmetalayer);
     BLOSC_TRACE_ERROR("Can not propagate de `%s` variable-length metalayer to a frame.", name);
     return rc;
   }
@@ -1887,8 +1899,8 @@ int blosc2_vlmeta_add(blosc2_schunk *schunk, const char *name, uint8_t *content,
 
 int blosc2_vlmeta_get(blosc2_schunk *schunk, const char *name, uint8_t **content,
                       int32_t *content_len) {
-  if (content == NULL || content_len == NULL) {
-    BLOSC_TRACE_ERROR("Output pointers must not be NULL.");
+  if (schunk == NULL || name == NULL || content == NULL || content_len == NULL) {
+    BLOSC_TRACE_ERROR("Invalid parameters.");
     return BLOSC2_ERROR_INVALID_PARAM;
   }
   int nvlmetalayer = blosc2_vlmeta_exists(schunk, name);
@@ -1914,17 +1926,28 @@ int blosc2_vlmeta_get(blosc2_schunk *schunk, const char *name, uint8_t **content
     *content = malloc((size_t) nbytes);
     if (*content == NULL) {
       BLOSC_TRACE_ERROR("Unable to allocate variable-length metalayer content buffer.");
+      *content_len = 0;
       return BLOSC2_ERROR_MEMORY_ALLOC;
     }
   }
   blosc2_context *dctx = blosc2_create_dctx(*schunk->storage->dparams);
   if (dctx == NULL) {
+    if (*content != NULL) {
+      free(*content);
+      *content = NULL;
+    }
+    *content_len = 0;
     BLOSC_TRACE_ERROR("Error while creating the decompression context");
     return BLOSC2_ERROR_NULL_POINTER;
   }
   int nbytes_ = blosc2_decompress_ctx(dctx, meta->content, meta->content_len, *content, nbytes);
   blosc2_free_ctx(dctx);
   if (nbytes_ != nbytes) {
+    if (*content != NULL) {
+      free(*content);
+      *content = NULL;
+    }
+    *content_len = 0;
     BLOSC_TRACE_ERROR("User metalayer \"%s\" is corrupted.", meta->name);
     return BLOSC2_ERROR_READ_BUFFER;
   }

--- a/include/blosc2.h
+++ b/include/blosc2.h
@@ -2332,6 +2332,12 @@ static inline int blosc2_meta_get(blosc2_schunk *schunk, const char *name, uint8
     BLOSC_TRACE_ERROR("Unable to allocate metalayer content buffer.");
     return BLOSC2_ERROR_MEMORY_ALLOC;
   }
+  if (len > 0 && schunk->metalayers[nmetalayer]->content == NULL) {
+    free(*content);
+    *content = NULL;
+    BLOSC_TRACE_ERROR("Metalayer \"%s\" has corrupted content pointer.", name);
+    return BLOSC2_ERROR_DATA;
+  }
   memcpy(*content, schunk->metalayers[nmetalayer]->content, (size_t)len);
   return nmetalayer;
 }

--- a/include/blosc2.h
+++ b/include/blosc2.h
@@ -2308,14 +2308,15 @@ BLOSC_EXPORT int blosc2_meta_update(blosc2_schunk *schunk, const char *name, uin
  */
 static inline int blosc2_meta_get(blosc2_schunk *schunk, const char *name, uint8_t **content,
                                   int32_t *content_len) {
+  if (schunk == NULL || name == NULL || content == NULL || content_len == NULL) {
+    BLOSC_TRACE_ERROR("Invalid parameters.");
+    return BLOSC2_ERROR_INVALID_PARAM;
+  }
+
   int nmetalayer = blosc2_meta_exists(schunk, name);
   if (nmetalayer < 0) {
     BLOSC_TRACE_WARNING("Metalayer \"%s\" not found.", name);
     return nmetalayer;
-  }
-  if (content == NULL || content_len == NULL) {
-    BLOSC_TRACE_ERROR("Output pointers must not be NULL.");
-    return BLOSC2_ERROR_INVALID_PARAM;
   }
   int32_t len = schunk->metalayers[nmetalayer]->content_len;
   if (len < 0) {
@@ -2330,11 +2331,13 @@ static inline int blosc2_meta_get(blosc2_schunk *schunk, const char *name, uint8
   *content = (uint8_t*)malloc((size_t)len);
   if (*content == NULL) {
     BLOSC_TRACE_ERROR("Unable to allocate metalayer content buffer.");
+    *content_len = 0;
     return BLOSC2_ERROR_MEMORY_ALLOC;
   }
   if (len > 0 && schunk->metalayers[nmetalayer]->content == NULL) {
     free(*content);
     *content = NULL;
+    *content_len = 0;
     BLOSC_TRACE_ERROR("Metalayer \"%s\" has corrupted content pointer.", name);
     return BLOSC2_ERROR_DATA;
   }

--- a/include/blosc2.h
+++ b/include/blosc2.h
@@ -2313,9 +2313,26 @@ static inline int blosc2_meta_get(blosc2_schunk *schunk, const char *name, uint8
     BLOSC_TRACE_WARNING("Metalayer \"%s\" not found.", name);
     return nmetalayer;
   }
-  *content_len = schunk->metalayers[nmetalayer]->content_len;
-  *content = (uint8_t*)malloc((size_t)*content_len);
-  memcpy(*content, schunk->metalayers[nmetalayer]->content, (size_t)*content_len);
+  if (content == NULL || content_len == NULL) {
+    BLOSC_TRACE_ERROR("Output pointers must not be NULL.");
+    return BLOSC2_ERROR_INVALID_PARAM;
+  }
+  int32_t len = schunk->metalayers[nmetalayer]->content_len;
+  if (len < 0) {
+    BLOSC_TRACE_ERROR("Metalayer \"%s\" has corrupted content length %d.", name, len);
+    return BLOSC2_ERROR_DATA;
+  }
+  *content_len = len;
+  if (len == 0) {
+    *content = NULL;
+    return nmetalayer;
+  }
+  *content = (uint8_t*)malloc((size_t)len);
+  if (*content == NULL) {
+    BLOSC_TRACE_ERROR("Unable to allocate metalayer content buffer.");
+    return BLOSC2_ERROR_MEMORY_ALLOC;
+  }
+  memcpy(*content, schunk->metalayers[nmetalayer]->content, (size_t)len);
   return nmetalayer;
 }
 

--- a/tests/b2nd/test_b2nd_deserialize_meta_security.c
+++ b/tests/b2nd/test_b2nd_deserialize_meta_security.c
@@ -96,6 +96,23 @@ CUTEST_TEST_TEST(deserialize_meta_security) {
   rc = b2nd_from_schunk(arr->sc, &arr_corrupt);
   CUTEST_ASSERT("corrupted blockshape/chunkshape metadata should fail", rc < 0);
 
+  // Corrupt fixed-length metalayer content length to negative; get must fail safely.
+  blosc2_metalayer *b2nd_meta_layer = arr->sc->metalayers[0];
+  int32_t saved_b2nd_meta_len = b2nd_meta_layer->content_len;
+  b2nd_meta_layer->content_len = -1;
+  uint8_t *bad_meta_content = NULL;
+  int32_t bad_meta_content_len = 0;
+  rc = blosc2_meta_get(arr->sc, "b2nd", &bad_meta_content, &bad_meta_content_len);
+  CUTEST_ASSERT("negative fixed-length metalayer length should fail", rc < 0);
+  CUTEST_ASSERT("fixed-length metalayer get must not allocate on corrupted size", bad_meta_content == NULL);
+  CUTEST_ASSERT("fixed-length metalayer length output must remain zero on failure", bad_meta_content_len == 0);
+  b2nd_meta_layer->content_len = saved_b2nd_meta_len;
+
+  rc = blosc2_meta_add(arr->sc, "bad_metalayer", NULL, -1);
+  CUTEST_ASSERT("negative fixed-length metalayer content length must be rejected", rc < 0);
+  rc = blosc2_vlmeta_add(arr->sc, "bad_vlmetalayer", NULL, -1, NULL);
+  CUTEST_ASSERT("negative variable-length metalayer content length must be rejected", rc < 0);
+
   free(b2nd_meta_bad);
   free(b2nd_meta);
   B2ND_TEST_ASSERT(b2nd_free(arr));

--- a/tests/b2nd/test_b2nd_deserialize_meta_security.c
+++ b/tests/b2nd/test_b2nd_deserialize_meta_security.c
@@ -97,7 +97,9 @@ CUTEST_TEST_TEST(deserialize_meta_security) {
   CUTEST_ASSERT("corrupted blockshape/chunkshape metadata should fail", rc < 0);
 
   // Corrupt fixed-length metalayer content length to negative; get must fail safely.
-  blosc2_metalayer *b2nd_meta_layer = arr->sc->metalayers[0];
+  int nmetalayer = blosc2_meta_exists(arr->sc, "b2nd");
+  CUTEST_ASSERT("b2nd metalayer should exist", nmetalayer >= 0);
+  blosc2_metalayer *b2nd_meta_layer = arr->sc->metalayers[nmetalayer];
   int32_t saved_b2nd_meta_len = b2nd_meta_layer->content_len;
   b2nd_meta_layer->content_len = -1;
   uint8_t *bad_meta_content = NULL;


### PR DESCRIPTION
This PR fixes multiple memory-safety issues in metalayer handling APIs.

## Security Issues Fixed
- Reject negative content_len values to prevent signed-to-size_t conversion
  leading to oversized allocations and potential heap corruption
- Validate that content is not NULL when content_len > 0
- Add malloc() failure checks before use
- Prevent unsafe memcpy() on invalid buffers
- Detect and reject corrupted internal metadata (e.g., negative stored lengths)
- Validate output pointers in *_get APIs

## Tests
- Added regression test: test_b2nd_deserialize_meta_security
- Covers:
  - negative metalayer length handling
  - invalid input rejection paths