### PR TITLE
Fix unsafe string handling to prevent overflows

### DIFF
--- a/blosc/blosc2.c
+++ b/blosc/blosc2.c
@@ -5429,7 +5429,7 @@ const char* blosc2_list_compressors(void) {
   char *_p = ret;
   /* Start with the first compressor name. */
   int _sw = snprintf(_p, _avail, "%s", BLOSC_BLOSCLZ_COMPNAME);
-  if (_ssw < 0) {
+  if (_sw < 0) {
     ret[0] = '\0';
     compressors_list_done = 1;
     return ret;

--- a/blosc/blosc2.c
+++ b/blosc/blosc2.c
@@ -5428,19 +5428,19 @@ const char* blosc2_list_compressors(void) {
   size_t _avail = sizeof(ret);
   char *_p = ret;
   /* Start with the first compressor name. */
-  int _w = snprintf(_p, _avail, "%s", BLOSC_BLOSCLZ_COMPNAME);
-  if (_w < 0) {
+  int _sw = snprintf(_p, _avail, "%s", BLOSC_BLOSCLZ_COMPNAME);
+  if (_ssw < 0) {
     ret[0] = '\0';
     compressors_list_done = 1;
     return ret;
   }
-  if ((size_t)_w >= _avail) {
+  if ((size_t)_sw >= _avail) {
     /* Truncated; ensure terminated and return */
     ret[sizeof(ret)-1] = '\0';
     compressors_list_done = 1;
     return ret;
   }
-  _p += _w; _avail -= (size_t)_w;
+  _p += _sw; _avail -= (size_t)_sw;
 
 #define APPEND_COMP(NAME) do { \
     if (_avail > 1) { \
@@ -5503,9 +5503,11 @@ int blosc2_get_complib_info(const char* compname, char** complib, char** version
 #endif /* HAVE_ZLIB */
 #if defined(HAVE_ZSTD)
   else if (clibcode == BLOSC_ZSTD_LIB) {
-    sprintf(sbuffer, "%d.%d.%d",
-            ZSTD_VERSION_MAJOR, ZSTD_VERSION_MINOR, ZSTD_VERSION_RELEASE);
-    clibversion = sbuffer;
+    int _sn_zstd = snprintf(sbuffer, sizeof(sbuffer), "%d.%d.%d",
+                            ZSTD_VERSION_MAJOR, ZSTD_VERSION_MINOR, ZSTD_VERSION_RELEASE);
+    if (_sn_zstd >= 0 && (size_t)_sn_zstd < sizeof(sbuffer)) {
+      clibversion = sbuffer;
+    }
   }
 #endif /* HAVE_ZSTD */
 

--- a/blosc/blosc2.c
+++ b/blosc/blosc2.c
@@ -5425,19 +5425,41 @@ const char* blosc2_list_compressors(void) {
 
   if (compressors_list_done) return ret;
   ret[0] = '\0';
-  strcat(ret, BLOSC_BLOSCLZ_COMPNAME);
-  strcat(ret, ",");
-  strcat(ret, BLOSC_LZ4_COMPNAME);
-  strcat(ret, ",");
-  strcat(ret, BLOSC_LZ4HC_COMPNAME);
+  size_t _avail = sizeof(ret);
+  char *_p = ret;
+  /* Start with the first compressor name. */
+  int _w = snprintf(_p, _avail, "%s", BLOSC_BLOSCLZ_COMPNAME);
+  if (_w < 0) {
+    ret[0] = '\0';
+    compressors_list_done = 1;
+    return ret;
+  }
+  if ((size_t)_w >= _avail) {
+    /* Truncated; ensure terminated and return */
+    ret[sizeof(ret)-1] = '\0';
+    compressors_list_done = 1;
+    return ret;
+  }
+  _p += _w; _avail -= (size_t)_w;
+
+#define APPEND_COMP(NAME) do { \
+    if (_avail > 1) { \
+      int __w = snprintf(_p, _avail, ",%s", (NAME)); \
+      if (__w < 0) { break; } \
+      if ((size_t)__w >= _avail) { _p += _avail - 1; _avail = 1; *_p = '\0'; break; } \
+      _p += __w; _avail -= (size_t)__w; \
+    } \
+  } while(0)
+
+  APPEND_COMP(BLOSC_LZ4_COMPNAME);
+  APPEND_COMP(BLOSC_LZ4HC_COMPNAME);
 #if defined(HAVE_ZLIB)
-  strcat(ret, ",");
-  strcat(ret, BLOSC_ZLIB_COMPNAME);
+  APPEND_COMP(BLOSC_ZLIB_COMPNAME);
 #endif /* HAVE_ZLIB */
 #if defined(HAVE_ZSTD)
-  strcat(ret, ",");
-  strcat(ret, BLOSC_ZSTD_COMPNAME);
+  APPEND_COMP(BLOSC_ZSTD_COMPNAME);
 #endif /* HAVE_ZSTD */
+#undef APPEND_COMP
   compressors_list_done = 1;
   return ret;
 }
@@ -5462,8 +5484,8 @@ int blosc2_get_complib_info(const char* compname, char** complib, char** version
     clibversion = BLOSCLZ_VERSION_STRING;
   }
   else if (clibcode == BLOSC_LZ4_LIB) {
-    sprintf(sbuffer, "%d.%d.%d",
-            LZ4_VERSION_MAJOR, LZ4_VERSION_MINOR, LZ4_VERSION_RELEASE);
+        snprintf(sbuffer, sizeof(sbuffer), "%d.%d.%d",
+           LZ4_VERSION_MAJOR, LZ4_VERSION_MINOR, LZ4_VERSION_RELEASE);
     clibversion = sbuffer;
   }
 #if defined(HAVE_ZLIB)

--- a/blosc/blosc2.c
+++ b/blosc/blosc2.c
@@ -5484,9 +5484,11 @@ int blosc2_get_complib_info(const char* compname, char** complib, char** version
     clibversion = BLOSCLZ_VERSION_STRING;
   }
   else if (clibcode == BLOSC_LZ4_LIB) {
-        snprintf(sbuffer, sizeof(sbuffer), "%d.%d.%d",
-           LZ4_VERSION_MAJOR, LZ4_VERSION_MINOR, LZ4_VERSION_RELEASE);
-    clibversion = sbuffer;
+    int _sn = snprintf(sbuffer, sizeof(sbuffer), "%d.%d.%d",
+                       LZ4_VERSION_MAJOR, LZ4_VERSION_MINOR, LZ4_VERSION_RELEASE);
+    if (_sn >= 0 && (size_t)_sn < sizeof(sbuffer)) {
+      clibversion = sbuffer;
+    }
   }
 #if defined(HAVE_ZLIB)
   else if (clibcode == BLOSC_ZLIB_LIB) {

--- a/blosc/frame.c
+++ b/blosc/frame.c
@@ -1904,8 +1904,18 @@ int frame_get_vlmetalayers(blosc2_frame_s* frame, blosc2_schunk* schunk) {
     void* fp = NULL;
     int64_t io_pos = 0;
     if (frame->sframe) {
-      char* eframe_name = malloc(strlen(frame->urlpath) + strlen("/chunks.b2frame") + 1);
-      sprintf(eframe_name, "%s/chunks.b2frame", frame->urlpath);
+      size_t _len = strlen(frame->urlpath) + strlen("/chunks.b2frame") + 1;
+      char* eframe_name = malloc(_len);
+      if (eframe_name == NULL) {
+        BLOSC_TRACE_ERROR("Unable to allocate memory for frame filename.");
+        return BLOSC2_ERROR_MEMORY_ALLOC;
+      }
+      int _w = snprintf(eframe_name, _len, "%s/chunks.b2frame", frame->urlpath);
+      if (_w < 0 || (size_t)_w >= _len) {
+        BLOSC_TRACE_ERROR("Error building frame filename");
+        free(eframe_name);
+        return BLOSC2_ERROR_FILE_OPEN;
+      }
       fp = io_cb->open(eframe_name, "rb", frame->schunk->storage->io->params);
       if (fp == NULL) {
         BLOSC_TRACE_ERROR("Error opening file in: %s", eframe_name);

--- a/blosc/frame.c
+++ b/blosc/frame.c
@@ -1904,16 +1904,24 @@ int frame_get_vlmetalayers(blosc2_frame_s* frame, blosc2_schunk* schunk) {
     void* fp = NULL;
     int64_t io_pos = 0;
     if (frame->sframe) {
+      // Check for overflow before calculating length
+      if (strlen(frame->urlpath) > SIZE_MAX - strlen("/chunks.b2frame") - 1) {
+        BLOSC_TRACE_ERROR("Path too long for frame filename.");
+        if (needs_free) free(trailer);
+        return BLOSC2_ERROR_INVALID_PARAM;
+      }
       size_t _len = strlen(frame->urlpath) + strlen("/chunks.b2frame") + 1;
       char* eframe_name = malloc(_len);
       if (eframe_name == NULL) {
         BLOSC_TRACE_ERROR("Unable to allocate memory for frame filename.");
+        if (needs_free) free(trailer);
         return BLOSC2_ERROR_MEMORY_ALLOC;
       }
       int _w = snprintf(eframe_name, _len, "%s/chunks.b2frame", frame->urlpath);
       if (_w < 0 || (size_t)_w >= _len) {
         BLOSC_TRACE_ERROR("Error building frame filename");
         free(eframe_name);
+        if (needs_free) free(trailer);
         return BLOSC2_ERROR_INVALID_PARAM;
       }
       fp = io_cb->open(eframe_name, "rb", frame->schunk->storage->io->params);

--- a/blosc/frame.c
+++ b/blosc/frame.c
@@ -1914,7 +1914,7 @@ int frame_get_vlmetalayers(blosc2_frame_s* frame, blosc2_schunk* schunk) {
       if (_w < 0 || (size_t)_w >= _len) {
         BLOSC_TRACE_ERROR("Error building frame filename");
         free(eframe_name);
-        return BLOSC2_ERROR_FILE_OPEN;
+        return BLOSC2_ERROR_INVALID_PARAM;
       }
       fp = io_cb->open(eframe_name, "rb", frame->schunk->storage->io->params);
       if (fp == NULL) {


### PR DESCRIPTION
This PR improves memory safety in string handling by replacing unsafe functions such as `strcat` and `sprintf` with bounded alternatives (`snprintf`) and introducing proper buffer size tracking and validation.

## Changes

- Replaced multiple `strcat` calls with a safer `snprintf`-based approach using explicit buffer tracking
- Introduced a bounded append pattern to safely build the compressor list
- Replaced `sprintf` with `snprintf` in version string formatting
- Added checks for:
  - write truncation
  - encoding errors (`snprintf` return value)
- Improved heap allocation handling:
  - validated `malloc` return value
  - ensured safe formatting of dynamically allocated buffers
  - added error handling for truncation cases