### PR TITLE
Fix integer overflow in metalayer bounds check

### DIFF
--- a/blosc/frame.c
+++ b/blosc/frame.c
@@ -1638,7 +1638,7 @@ static int get_meta_from_header(blosc2_frame_s* frame, blosc2_schunk* schunk, ui
     }
     // Go to offset and see if we have the correct marker
     uint8_t* content_marker = header + offset;
-    if (header_len < offset + 1 + 4) {
+    if (offset > header_len - 1 - 4) {
       return BLOSC2_ERROR_READ_BUFFER;
     }
     if (*content_marker != 0xc6) {
@@ -1828,7 +1828,7 @@ static int get_vlmeta_from_trailer(blosc2_frame_s* frame, blosc2_schunk* schunk,
     }
     // Go to offset and see if we have the correct marker
     uint8_t* content_marker = trailer + offset;
-    if (trailer_len < offset + 1 + 4) {
+    if (offset > trailer_len - 1 - 4) {
       return BLOSC2_ERROR_READ_BUFFER;
     }
     if (*content_marker != 0xc6) {

--- a/blosc/frame.c
+++ b/blosc/frame.c
@@ -1654,7 +1654,7 @@ static int get_meta_from_header(blosc2_frame_s* frame, blosc2_schunk* schunk, ui
     metalayer->content_len = content_len;
 
     // Finally, read the content
-    if (header_len < offset + 1 + 4 + content_len) {
+    if (content_len > header_len - offset - 5) {
       return BLOSC2_ERROR_READ_BUFFER;
     }
     char* content = malloc((size_t)content_len);
@@ -1844,7 +1844,7 @@ static int get_vlmeta_from_trailer(blosc2_frame_s* frame, blosc2_schunk* schunk,
     metalayer->content_len = content_len;
 
     // Finally, read the content
-    if (trailer_len < offset + 1 + 4 + content_len) {
+    if (content_len > trailer_len - offset - 5) {
       return BLOSC2_ERROR_READ_BUFFER;
     }
     char* content = malloc((size_t)content_len);

--- a/tests/test_frame_malformed_metalayers.c
+++ b/tests/test_frame_malformed_metalayers.c
@@ -2,8 +2,11 @@
 #include <stdlib.h>
 #include <string.h>
 #include "blosc2.h"
+#include "test_common.h"
 
-int main() {
+int tests_run = 0;
+
+static char* test_malformed_metalayers(void) {
     blosc2_init();
 
     blosc2_cparams cparams = BLOSC2_CPARAMS_DEFAULTS;
@@ -13,10 +16,7 @@ int main() {
     storage.dparams = &dparams;
 
     blosc2_schunk* schunk = blosc2_schunk_new(&storage);
-    if (!schunk) {
-        printf("Failed to create schunk\n");
-        return 1;
-    }
+    mu_assert("Failed to create schunk", schunk != NULL);
 
     // Add a metalayer
     uint8_t content[] = "This is a test content";
@@ -25,12 +25,7 @@ int main() {
     uint8_t* cframe;
     bool needs_free;
     int64_t len = blosc2_schunk_to_buffer(schunk, &cframe, &needs_free);
-    if (len < 0) {
-        printf("Failed to serialize schunk\n");
-        return 1;
-    }
-
-    printf("Serialized to buffer of length %lld\n", len);
+    mu_assert("Failed to serialize schunk", len >= 0);
 
     // Find the metalayer name to tamper with it
     const char* target = "bad_meta";
@@ -39,18 +34,13 @@ int main() {
     
     for (int64_t i = 0; i < len - target_len; i++) {
         if (memcmp(cframe + i, target, target_len) == 0) {
-            printf("Found 'bad_meta' at offset %lld\n", i);
             uint8_t* idxp = cframe + i + target_len;
             if (*idxp == 0xd2) {
                 idxp++;
-                int32_t offset;
-                // Read 4 bytes big endian
-                offset = (idxp[0] << 24) | (idxp[1] << 16) | (idxp[2] << 8) | idxp[3];
-                printf("Offset is %d\n", offset);
+                int32_t offset = (idxp[0] << 24) | (idxp[1] << 16) | (idxp[2] << 8) | idxp[3];
                 
                 uint8_t* content_marker = cframe + offset;
                 if (*content_marker == 0xc6) {
-                    printf("Found content marker 0xc6 at offset %d\n", offset);
                     // Tamper with the content length (big endian)
                     uint8_t* clen_ptr = content_marker + 1;
                     int32_t bad_len = 0x7FFFFFFF;
@@ -58,7 +48,6 @@ int main() {
                     clen_ptr[1] = (bad_len >> 16) & 0xFF;
                     clen_ptr[2] = (bad_len >> 8) & 0xFF;
                     clen_ptr[3] = bad_len & 0xFF;
-                    printf("Tampered content length to %d\n", bad_len);
                     found = 1;
                 }
             }
@@ -66,21 +55,12 @@ int main() {
         }
     }
 
-    if (!found) {
-        printf("Could not find the metalayer in the buffer.\n");
-        return 1;
-    }
+    mu_assert("Could not find the metalayer in the buffer", found == 1);
 
     // Now try to open the tampered buffer
-    printf("Attempting to parse the malformed frame...\n");
     blosc2_schunk* schunk2 = blosc2_schunk_from_buffer(cframe, len, true);
     
-    if (schunk2) {
-        printf("Parsing succeeded! (Unexpected)\n");
-        blosc2_schunk_free(schunk2);
-    } else {
-        printf("Parsing failed cleanly.\n");
-    }
+    mu_assert("Malformed frame should be rejected", schunk2 == NULL);
 
     if (needs_free) {
         free(cframe);
@@ -88,5 +68,23 @@ int main() {
     blosc2_schunk_free(schunk);
     blosc2_destroy();
 
-    return 0;
+    return EXIT_SUCCESS;
+}
+
+static char *all_tests(void) {
+    mu_run_test(test_malformed_metalayers);
+    return EXIT_SUCCESS;
+}
+
+int main(void) {
+    char *result;
+    result = all_tests();
+    if (result != EXIT_SUCCESS) {
+        printf(" (%s)\n", result);
+    } else {
+        printf(" ALL TESTS PASSED\n");
+    }
+    printf("\tTests run: %d\n", tests_run);
+
+    return result != EXIT_SUCCESS;
 }

--- a/tests/test_frame_malformed_metalayers.c
+++ b/tests/test_frame_malformed_metalayers.c
@@ -1,0 +1,92 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "blosc2.h"
+
+int main() {
+    blosc2_init();
+
+    blosc2_cparams cparams = BLOSC2_CPARAMS_DEFAULTS;
+    blosc2_dparams dparams = BLOSC2_DPARAMS_DEFAULTS;
+    blosc2_storage storage = BLOSC2_STORAGE_DEFAULTS;
+    storage.cparams = &cparams;
+    storage.dparams = &dparams;
+
+    blosc2_schunk* schunk = blosc2_schunk_new(&storage);
+    if (!schunk) {
+        printf("Failed to create schunk\n");
+        return 1;
+    }
+
+    // Add a metalayer
+    uint8_t content[] = "This is a test content";
+    blosc2_meta_add(schunk, "bad_meta", content, sizeof(content));
+
+    uint8_t* cframe;
+    bool needs_free;
+    int64_t len = blosc2_schunk_to_buffer(schunk, &cframe, &needs_free);
+    if (len < 0) {
+        printf("Failed to serialize schunk\n");
+        return 1;
+    }
+
+    printf("Serialized to buffer of length %lld\n", len);
+
+    // Find the metalayer name to tamper with it
+    const char* target = "bad_meta";
+    int target_len = strlen(target);
+    int found = 0;
+    
+    for (int64_t i = 0; i < len - target_len; i++) {
+        if (memcmp(cframe + i, target, target_len) == 0) {
+            printf("Found 'bad_meta' at offset %lld\n", i);
+            uint8_t* idxp = cframe + i + target_len;
+            if (*idxp == 0xd2) {
+                idxp++;
+                int32_t offset;
+                // Read 4 bytes big endian
+                offset = (idxp[0] << 24) | (idxp[1] << 16) | (idxp[2] << 8) | idxp[3];
+                printf("Offset is %d\n", offset);
+                
+                uint8_t* content_marker = cframe + offset;
+                if (*content_marker == 0xc6) {
+                    printf("Found content marker 0xc6 at offset %d\n", offset);
+                    // Tamper with the content length (big endian)
+                    uint8_t* clen_ptr = content_marker + 1;
+                    int32_t bad_len = 0x7FFFFFFF;
+                    clen_ptr[0] = (bad_len >> 24) & 0xFF;
+                    clen_ptr[1] = (bad_len >> 16) & 0xFF;
+                    clen_ptr[2] = (bad_len >> 8) & 0xFF;
+                    clen_ptr[3] = bad_len & 0xFF;
+                    printf("Tampered content length to %d\n", bad_len);
+                    found = 1;
+                }
+            }
+            break;
+        }
+    }
+
+    if (!found) {
+        printf("Could not find the metalayer in the buffer.\n");
+        return 1;
+    }
+
+    // Now try to open the tampered buffer
+    printf("Attempting to parse the malformed frame...\n");
+    blosc2_schunk* schunk2 = blosc2_schunk_from_buffer(cframe, len, true);
+    
+    if (schunk2) {
+        printf("Parsing succeeded! (Unexpected)\n");
+        blosc2_schunk_free(schunk2);
+    } else {
+        printf("Parsing failed cleanly.\n");
+    }
+
+    if (needs_free) {
+        free(cframe);
+    }
+    blosc2_schunk_free(schunk);
+    blosc2_destroy();
+
+    return 0;
+}


### PR DESCRIPTION
This fixes a signed integer overflow issue in metalayer parsing inside frame.c.

The previous bounds check used addition with attacker-controlled content_len values, which could overflow and bypass the validation for malformed frames with very large metadata lengths.

The fix rewrites the check using subtraction-based bounds validation, which keeps the original logic while avoiding overflow during the comparison.

The patch is intentionally minimal and only changes the affected bounds checks in:

get_meta_from_header
get_vlmeta_from_trailer
