### PR TITLE
Fix integer overflow leading to potential heap corruption in b2nd

### DIFF
--- a/blosc/b2nd.c
+++ b/blosc/b2nd.c
@@ -14,9 +14,20 @@
 #include "blosc2.h"
 
 #include <inttypes.h>
+#include <limits.h>
 #include <stdlib.h>
 #include <stdint.h>
 #include <string.h>
+
+static bool b2nd_mul_overflow_size_t(size_t a, size_t b, size_t *out) {
+  if (a != 0 && b > SIZE_MAX / a) {
+    return true;
+  }
+  if (out != NULL) {
+    *out = a * b;
+  }
+  return false;
+}
 
 
 int b2nd_serialize_meta(int8_t ndim, const int64_t *shape, const int32_t *chunkshape,
@@ -394,7 +405,20 @@ int array_new(b2nd_context_t *ctx, int special_value, b2nd_array_t **array) {
     return BLOSC2_ERROR_FAILURE;
   }
   // Set the chunksize for the schunk, as it cannot be derived from storage
-  int32_t chunksize = (int32_t) (*array)->extchunknitems * sc->typesize;
+  if (sc->typesize <= 0 || (*array)->extchunknitems < 0) {
+    BLOSC_TRACE_ERROR("Invalid chunk parameters");
+    return BLOSC2_ERROR_INVALID_PARAM;
+  }
+  size_t chunkbytes_size = 0;
+  if (b2nd_mul_overflow_size_t((size_t)(*array)->extchunknitems, (size_t)sc->typesize, &chunkbytes_size)) {
+    BLOSC_TRACE_ERROR("Chunksize overflows size limits");
+    return BLOSC2_ERROR_INVALID_PARAM;
+  }
+  if (chunkbytes_size > BLOSC2_MAX_BUFFERSIZE || chunkbytes_size > INT32_MAX) {
+    BLOSC_TRACE_ERROR("Chunksize exceeds maximum of %d", BLOSC2_MAX_BUFFERSIZE);
+    return BLOSC2_ERROR_MAX_BUFSIZE_EXCEEDED;
+  }
+  int32_t chunksize = (int32_t)chunkbytes_size;
   sc->chunksize = chunksize;
 
   // Serialize the dimension info
@@ -431,10 +455,6 @@ int array_new(b2nd_context_t *ctx, int special_value, b2nd_array_t **array) {
     }
   }
 
-  if ((*array)->extchunknitems * sc->typesize > BLOSC2_MAX_BUFFERSIZE){
-    BLOSC_TRACE_ERROR("Chunksize exceeds maximum of %d", BLOSC2_MAX_BUFFERSIZE);
-    return BLOSC2_ERROR_MAX_BUFSIZE_EXCEEDED;
-  }
   // Fill schunk with uninit values
   if ((*array)->nitems != 0) {
     int64_t nchunks = (*array)->extnitems / (*array)->chunknitems;
@@ -501,7 +521,20 @@ int b2nd_full(b2nd_context_t *ctx, b2nd_array_t **array, const void *fill_value)
 
   BLOSC_ERROR(b2nd_empty(ctx, array));
 
-  int32_t chunkbytes = (int32_t) (*array)->extchunknitems * (*array)->sc->typesize;
+  if ((*array)->sc->typesize <= 0 || (*array)->extchunknitems < 0) {
+    BLOSC_TRACE_ERROR("Invalid chunk parameters");
+    return BLOSC2_ERROR_INVALID_PARAM;
+  }
+  size_t chunkbytes_size = 0;
+  if (b2nd_mul_overflow_size_t((size_t)(*array)->extchunknitems, (size_t)(*array)->sc->typesize, &chunkbytes_size)) {
+    BLOSC_TRACE_ERROR("Chunk bytes overflows size limits");
+    return BLOSC2_ERROR_INVALID_PARAM;
+  }
+  if (chunkbytes_size > BLOSC2_MAX_BUFFERSIZE || chunkbytes_size > INT32_MAX) {
+    BLOSC_TRACE_ERROR("Chunk bytes exceeds maximum of %d", BLOSC2_MAX_BUFFERSIZE);
+    return BLOSC2_ERROR_MAX_BUFSIZE_EXCEEDED;
+  }
+  int32_t chunkbytes = (int32_t)chunkbytes_size;
 
   blosc2_cparams *cparams;
   if (blosc2_schunk_get_cparams((*array)->sc, &cparams) != 0) {
@@ -1250,15 +1283,32 @@ int b2nd_get_slice(b2nd_context_t *ctx, b2nd_array_t **array, const b2nd_array_t
       src_start[i] = chunk_start[i] + start[i];
       src_stop[i] = chunk_stop[i] + start[i];
     }
-    int64_t buffersize = ctx->b2_storage->cparams->typesize;
+    if (ctx->b2_storage->cparams->typesize <= 0) {
+      BLOSC_TRACE_ERROR("Invalid typesize");
+      return BLOSC2_ERROR_INVALID_PARAM;
+    }
+    size_t buffersize = (size_t)ctx->b2_storage->cparams->typesize;
     for (int i = 0; i < ndim; ++i) {
-      buffersize *= chunk_shape[i];
+      if (chunk_shape[i] < 0) {
+        BLOSC_TRACE_ERROR("Invalid chunk shape");
+        return BLOSC2_ERROR_INVALID_PARAM;
+      }
+      if (b2nd_mul_overflow_size_t(buffersize, (size_t)chunk_shape[i], &buffersize)) {
+        BLOSC_TRACE_ERROR("Buffer size overflows size limits");
+        return BLOSC2_ERROR_INVALID_PARAM;
+      }
+    }
+    if (buffersize == 0 || buffersize > (size_t)INT64_MAX) {
+      BLOSC_TRACE_ERROR("Buffer size is out of range");
+      return BLOSC2_ERROR_INVALID_PARAM;
     }
     uint8_t *buffer = malloc(buffersize);
-    BLOSC_ERROR_NULL(buffer, BLOSC2_ERROR_MEMORY_ALLOC);
+    if (buffer == NULL) {
+      BLOSC_ERROR(BLOSC2_ERROR_MEMORY_ALLOC);
+    }
     BLOSC_ERROR(b2nd_get_slice_cbuffer(src, src_start, src_stop, buffer, chunk_shape,
-                                       buffersize));
-    BLOSC_ERROR(b2nd_set_slice_cbuffer(buffer, chunk_shape, buffersize, chunk_start,
+                                       (int64_t)buffersize));
+    BLOSC_ERROR(b2nd_set_slice_cbuffer(buffer, chunk_shape, (int64_t)buffersize, chunk_start,
                                        chunk_stop, *array));
     free(buffer);
   }

--- a/blosc/b2nd.c
+++ b/blosc/b2nd.c
@@ -405,17 +405,45 @@ int array_new(b2nd_context_t *ctx, int special_value, b2nd_array_t **array) {
     return BLOSC2_ERROR_FAILURE;
   }
   // Set the chunksize for the schunk, as it cannot be derived from storage
-  if (sc->typesize <= 0 || (*array)->extchunknitems < 0) {
+  if (sc->typesize <= 0) {
     BLOSC_TRACE_ERROR("Invalid chunk parameters");
+    blosc2_schunk_free(sc);
+    free((*array)->dtype);
+    free(*array);
+    *array = NULL;
+    return BLOSC2_ERROR_INVALID_PARAM;
+  }
+  if ((*array)->extchunknitems < 0) {
+    BLOSC_TRACE_ERROR("Invalid chunk parameters");
+    blosc2_schunk_free(sc);
+    free((*array)->dtype);
+    free(*array);
+    *array = NULL;
+    return BLOSC2_ERROR_INVALID_PARAM;
+  }
+  if ((uint64_t)(*array)->extchunknitems > (uint64_t)SIZE_MAX) {
+    BLOSC_TRACE_ERROR("extchunknitems too large");
+    blosc2_schunk_free(sc);
+    free((*array)->dtype);
+    free(*array);
+    *array = NULL;
     return BLOSC2_ERROR_INVALID_PARAM;
   }
   size_t chunkbytes_size = 0;
   if (b2nd_mul_overflow_size_t((size_t)(*array)->extchunknitems, (size_t)sc->typesize, &chunkbytes_size)) {
     BLOSC_TRACE_ERROR("Chunksize overflows size limits");
+    blosc2_schunk_free(sc);
+    free((*array)->dtype);
+    free(*array);
+    *array = NULL;
     return BLOSC2_ERROR_INVALID_PARAM;
   }
   if (chunkbytes_size > BLOSC2_MAX_BUFFERSIZE || chunkbytes_size > INT32_MAX) {
     BLOSC_TRACE_ERROR("Chunksize exceeds maximum of %d", BLOSC2_MAX_BUFFERSIZE);
+    blosc2_schunk_free(sc);
+    free((*array)->dtype);
+    free(*array);
+    *array = NULL;
     return BLOSC2_ERROR_MAX_BUFSIZE_EXCEEDED;
   }
   int32_t chunksize = (int32_t)chunkbytes_size;
@@ -424,6 +452,10 @@ int array_new(b2nd_context_t *ctx, int special_value, b2nd_array_t **array) {
   // Serialize the dimension info
   if (sc->nmetalayers >= BLOSC2_MAX_METALAYERS) {
     BLOSC_TRACE_ERROR("the number of metalayers for this schunk has been exceeded");
+    blosc2_schunk_free(sc);
+    free((*array)->dtype);
+    free(*array);
+    *array = NULL;
     return BLOSC2_ERROR_FAILURE;
   }
   uint8_t *smeta = NULL;
@@ -436,11 +468,20 @@ int array_new(b2nd_context_t *ctx, int special_value, b2nd_array_t **array) {
                                           &smeta);
   if (smeta_len < 0) {
     BLOSC_TRACE_ERROR("error during serializing dims info for Blosc2 NDim");
+    blosc2_schunk_free(sc);
+    free((*array)->dtype);
+    free(*array);
+    *array = NULL;
     return BLOSC2_ERROR_FAILURE;
   }
 
   // And store it in b2nd metalayer
   if (blosc2_meta_add(sc, "b2nd", smeta, smeta_len) < 0) {
+    free(smeta);
+    blosc2_schunk_free(sc);
+    free((*array)->dtype);
+    free(*array);
+    *array = NULL;
     return BLOSC2_ERROR_FAILURE;
   }
 
@@ -451,7 +492,11 @@ int array_new(b2nd_context_t *ctx, int special_value, b2nd_array_t **array) {
     uint8_t *data = ctx->metalayers[i].content;
     int32_t size = ctx->metalayers[i].content_len;
     if (blosc2_meta_add(sc, name, data, size) < 0) {
-      BLOSC_ERROR(BLOSC2_ERROR_FAILURE);
+      blosc2_schunk_free(sc);
+      free((*array)->dtype);
+      free(*array);
+      *array = NULL;
+      return BLOSC2_ERROR_FAILURE;
     }
   }
 
@@ -459,7 +504,13 @@ int array_new(b2nd_context_t *ctx, int special_value, b2nd_array_t **array) {
   if ((*array)->nitems != 0) {
     int64_t nchunks = (*array)->extnitems / (*array)->chunknitems;
     int64_t nitems = nchunks * (*array)->extchunknitems;
-    BLOSC_ERROR(blosc2_schunk_fill_special(sc, nitems, special_value, chunksize));
+    if (blosc2_schunk_fill_special(sc, nitems, special_value, chunksize) < 0) {
+      blosc2_schunk_free(sc);
+      free((*array)->dtype);
+      free(*array);
+      *array = NULL;
+      BLOSC_ERROR(BLOSC2_ERROR_FAILURE);
+    }
   }
   (*array)->sc = sc;
 
@@ -521,8 +572,16 @@ int b2nd_full(b2nd_context_t *ctx, b2nd_array_t **array, const void *fill_value)
 
   BLOSC_ERROR(b2nd_empty(ctx, array));
 
-  if ((*array)->sc->typesize <= 0 || (*array)->extchunknitems < 0) {
+  if ((*array)->sc->typesize <= 0) {
     BLOSC_TRACE_ERROR("Invalid chunk parameters");
+    return BLOSC2_ERROR_INVALID_PARAM;
+  }
+  if ((*array)->extchunknitems < 0) {
+    BLOSC_TRACE_ERROR("Invalid chunk parameters");
+    return BLOSC2_ERROR_INVALID_PARAM;
+  }
+  if ((uint64_t)(*array)->extchunknitems > (uint64_t)SIZE_MAX) {
+    BLOSC_TRACE_ERROR("extchunknitems too large");
     return BLOSC2_ERROR_INVALID_PARAM;
   }
   size_t chunkbytes_size = 0;

--- a/blosc/blosc-private.h
+++ b/blosc/blosc-private.h
@@ -309,6 +309,10 @@ static inline int get_libpath(char *plugin_name, char *libpath, char *python_ver
 }
 
 static inline void* load_lib(char *plugin_name, char *libpath) {
+  if (!blosc2_valid_plugin_name(plugin_name)) {
+    BLOSC_TRACE_ERROR("Invalid plugin name");
+    return NULL;
+  }
     // Attempt to directly load the library by name
 #if defined(_WIN32)
     // Windows dynamic library (DLL) format

--- a/blosc/blosc-private.h
+++ b/blosc/blosc-private.h
@@ -18,6 +18,7 @@
 #include <stdbool.h>
 #include <stdlib.h>
 #include <stdint.h>
+#include <ctype.h>
 
 /*********************************************************************
 
@@ -255,7 +256,7 @@ static inline int dlclose(void *handle) {
 static inline const char *dlerror (void) {
   static char errstr [88];
   if (var.lasterror) {
-      sprintf (errstr, "%s error #%ld", var.err_rutin, var.lasterror);
+      snprintf(errstr, sizeof(errstr), "%s error #%ld", var.err_rutin, var.lasterror);
       return errstr;
   } else {
       return NULL;
@@ -265,11 +266,33 @@ static inline const char *dlerror (void) {
 #include <dlfcn.h>
 #endif
 
+static inline bool blosc2_valid_plugin_name(const char *plugin_name) {
+  if (plugin_name == NULL || plugin_name[0] == '\0') {
+    return false;
+  }
+  for (const unsigned char *p = (const unsigned char *)plugin_name; *p != '\0'; ++p) {
+    if (!isalnum(*p) && *p != '_') {
+      return false;
+    }
+  }
+  return true;
+}
+
 
 static inline int get_libpath(char *plugin_name, char *libpath, char *python_version) {
   BLOSC_TRACE_INFO("Trying to get plugin path with python%s\n", python_version);
   char python_cmd[PATH_MAX] = {0};
-  sprintf(python_cmd, "python%s -c \"import blosc2_%s; blosc2_%s.print_libpath()\"", python_version, plugin_name, plugin_name);
+  if (!blosc2_valid_plugin_name(plugin_name)) {
+    BLOSC_TRACE_ERROR("Invalid plugin name");
+    return BLOSC2_ERROR_INVALID_PARAM;
+  }
+  int written = snprintf(python_cmd, sizeof(python_cmd),
+                         "python%s -c \"import blosc2_%s; blosc2_%s.print_libpath()\"",
+                         python_version, plugin_name, plugin_name);
+  if (written < 0 || (size_t)written >= sizeof(python_cmd)) {
+    BLOSC_TRACE_ERROR("Python command is too long");
+    return BLOSC2_ERROR_FAILURE;
+  }
   FILE *fp = popen(python_cmd, "r");
   if (fp == NULL) {
     BLOSC_TRACE_ERROR("Could not run python");

--- a/blosc/directories.c
+++ b/blosc/directories.c
@@ -26,6 +26,10 @@
 
   int blosc2_remove_dir(const char* dir_path) {
     char* path;
+    if (dir_path == NULL || dir_path[0] == '\0') {
+      BLOSC_TRACE_ERROR("Invalid directory path");
+      return BLOSC2_ERROR_INVALID_PARAM;
+    }
     size_t dir_len = strlen(dir_path);
     char last_char = dir_path[dir_len - 1];
     size_t path_len = 0;
@@ -108,7 +112,15 @@
 
 /* Return the directory path with the '/' at the end */
 char* blosc2_normalize_dirpath(const char* dir_path) {
+  if (dir_path == NULL || dir_path[0] == '\0') {
+    errno = EINVAL;
+    return NULL;
+  }
   size_t dir_len = strlen(dir_path);
+  if (dir_len == 0) {
+    errno = EINVAL;
+    return NULL;
+  }
   char last_char = dir_path[dir_len - 1];
   char* path;
   if (last_char != '\\' && last_char != '/') {
@@ -140,7 +152,10 @@ char* blosc2_normalize_dirpath(const char* dir_path) {
 int blosc2_remove_dir(const char* dir_path) {
   char* path = blosc2_normalize_dirpath(dir_path);
   if (path == NULL) {
-    return BLOSC2_ERROR_MEMORY_ALLOC;
+    if (errno == ENOMEM) {
+      return BLOSC2_ERROR_MEMORY_ALLOC;
+    }
+    return BLOSC2_ERROR_INVALID_PARAM;
   }
 
   DIR* dr = opendir(path);

--- a/blosc/directories.c
+++ b/blosc/directories.c
@@ -16,6 +16,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#include <limits.h>
 
 #if defined(_WIN32) || defined(__MINGW32__)
   #include <windows.h>
@@ -25,15 +26,32 @@
 
   int blosc2_remove_dir(const char* dir_path) {
     char* path;
-    char last_char = dir_path[strlen(dir_path) - 1];
+    size_t dir_len = strlen(dir_path);
+    char last_char = dir_path[dir_len - 1];
+    size_t path_len = 0;
     if (last_char != '\\' && last_char != '/') {
-      path = malloc(strlen(dir_path) + 2 + 1);
-      sprintf(path, "%s\\*", dir_path);
+      if (dir_len > SIZE_MAX - 3) {
+        BLOSC_TRACE_ERROR("Directory path is too long");
+        return BLOSC2_ERROR_INVALID_PARAM;
+      }
+      path_len = dir_len + 3;
+      path = malloc(path_len);
+      if (path == NULL) {
+        return BLOSC2_ERROR_MEMORY_ALLOC;
+      }
+      snprintf(path, path_len, "%s\\*", dir_path);
     }
     else {
-      path = malloc(strlen(dir_path) + 1 + 1);
-      strcpy(path, dir_path);
-      strcat(path, "*");
+      if (dir_len > SIZE_MAX - 2) {
+        BLOSC_TRACE_ERROR("Directory path is too long");
+        return BLOSC2_ERROR_INVALID_PARAM;
+      }
+      path_len = dir_len + 2;
+      path = malloc(path_len);
+      if (path == NULL) {
+        return BLOSC2_ERROR_MEMORY_ALLOC;
+      }
+      snprintf(path, path_len, "%s*", dir_path);
     }
     char* fname;
     struct _finddata_t cfile;
@@ -51,12 +69,23 @@
       if (strcmp(".", cfile.name) == 0 || strcmp("..", cfile.name) == 0) {
         continue;
       }
-      fname = malloc(strlen(dir_path) + 1 + strlen(cfile.name) + 1);
-      sprintf(fname, "%s\\%s", dir_path, cfile.name);
+      size_t name_len = strlen(cfile.name);
+      if (dir_len > SIZE_MAX - name_len - 2) {
+        BLOSC_TRACE_ERROR("File path is too long");
+        _findclose(file);
+        return BLOSC2_ERROR_INVALID_PARAM;
+      }
+      fname = malloc(dir_len + name_len + 2);
+      if (fname == NULL) {
+        _findclose(file);
+        return BLOSC2_ERROR_MEMORY_ALLOC;
+      }
+      snprintf(fname, dir_len + name_len + 2, "%s\\%s", dir_path, cfile.name);
 
       ret = remove(fname);
       if (ret < 0) {
         BLOSC_TRACE_ERROR("Could not remove file %s", fname);
+        free(fname);
         _findclose(file);
         return BLOSC2_ERROR_FAILURE;
       }
@@ -79,15 +108,30 @@
 
 /* Return the directory path with the '/' at the end */
 char* blosc2_normalize_dirpath(const char* dir_path) {
-  char last_char = dir_path[strlen(dir_path) - 1];
+  size_t dir_len = strlen(dir_path);
+  char last_char = dir_path[dir_len - 1];
   char* path;
   if (last_char != '\\' && last_char != '/') {
-    path = malloc(strlen(dir_path) + 1 + 1);
-    sprintf(path, "%s/", dir_path);
+    if (dir_len > SIZE_MAX - 2) {
+      BLOSC_TRACE_ERROR("Directory path is too long");
+      return NULL;
+    }
+    path = malloc(dir_len + 2);
+    if (path == NULL) {
+      return NULL;
+    }
+    snprintf(path, dir_len + 2, "%s/", dir_path);
   }
   else {
-    path = malloc(strlen(dir_path) + 1);
-    strcpy(path, dir_path);
+    if (dir_len > SIZE_MAX - 1) {
+      BLOSC_TRACE_ERROR("Directory path is too long");
+      return NULL;
+    }
+    path = malloc(dir_len + 1);
+    if (path == NULL) {
+      return NULL;
+    }
+    snprintf(path, dir_len + 1, "%s", dir_path);
   }
   return path;
 }
@@ -95,6 +139,9 @@ char* blosc2_normalize_dirpath(const char* dir_path) {
 /* Function needed for removing each time the directory */
 int blosc2_remove_dir(const char* dir_path) {
   char* path = blosc2_normalize_dirpath(dir_path);
+  if (path == NULL) {
+    return BLOSC2_ERROR_MEMORY_ALLOC;
+  }
 
   DIR* dr = opendir(path);
   struct stat statbuf;
@@ -107,13 +154,21 @@ int blosc2_remove_dir(const char* dir_path) {
   int ret;
   char* fname;
   while ((de = readdir(dr)) != NULL) {
-    fname = malloc(strlen(path) + strlen(de->d_name) + 1);
-    if (path != NULL) {
-      sprintf(fname, "%s%s", path, de->d_name);
+    size_t path_len = strlen(path);
+    size_t name_len = strlen(de->d_name);
+    if (path_len > SIZE_MAX - name_len - 1) {
+      BLOSC_TRACE_ERROR("File path is too long");
+      closedir(dr);
+      free(path);
+      return BLOSC2_ERROR_INVALID_PARAM;
     }
-    else {
-      sprintf(fname, "%s", de->d_name);
+    fname = malloc(path_len + name_len + 1);
+    if (fname == NULL) {
+      closedir(dr);
+      free(path);
+      return BLOSC2_ERROR_MEMORY_ALLOC;
     }
+    snprintf(fname, path_len + name_len + 1, "%s%s", path, de->d_name);
     if (!strcmp(de->d_name, ".") || !strcmp(de->d_name, "..")) {
       free(fname);
       continue;

--- a/tests/b2nd/test_b2nd_chunk_overflow.c
+++ b/tests/b2nd/test_b2nd_chunk_overflow.c
@@ -1,0 +1,54 @@
+/*********************************************************************
+  Blosc - Blocked Shuffling and Compression Library
+
+  Copyright (c) 2021  Blosc Development Team <blosc@blosc.org>
+  https://blosc.org
+  License: BSD 3-Clause (see LICENSE.txt)
+
+  See LICENSE.txt for details about copyright and rights to use.
+**********************************************************************/
+
+#include "test_common.h"
+#include <limits.h>
+
+
+CUTEST_TEST_SETUP(chunk_overflow) {
+  blosc2_init();
+}
+
+
+CUTEST_TEST_TEST(chunk_overflow) {
+  blosc2_cparams cparams = BLOSC2_CPARAMS_DEFAULTS;
+  cparams.typesize = 1;
+  blosc2_storage b2_storage = {.cparams = &cparams};
+  b2_storage.contiguous = false;
+
+  int64_t shape[1] = {(int64_t)INT_MAX};
+  int32_t chunkshape[1] = {INT_MAX};
+  int32_t blockshape[1] = {1};
+
+  b2nd_context_t *ctx = b2nd_create_ctx(&b2_storage, 1, shape, chunkshape, blockshape,
+                                        NULL, 0, NULL, 0);
+  CUTEST_ASSERT("ctx should not be NULL", ctx != NULL);
+
+  b2nd_array_t *array = NULL;
+  int rc = b2nd_empty(ctx, &array);
+  CUTEST_ASSERT("expected max buffer size error", rc == BLOSC2_ERROR_MAX_BUFSIZE_EXCEEDED);
+
+  if (array != NULL) {
+    B2ND_TEST_ASSERT(b2nd_free(array));
+  }
+  B2ND_TEST_ASSERT(b2nd_free_ctx(ctx));
+
+  return 0;
+}
+
+
+CUTEST_TEST_TEARDOWN(chunk_overflow) {
+  blosc2_destroy();
+}
+
+
+int main() {
+  CUTEST_TEST_RUN(chunk_overflow);
+}


### PR DESCRIPTION
This PR fixes an integer overflow vulnerability in b2nd that can lead to heap corruption.

Several size calculations were performed without overflow checks. These values can originate from serialized metadata or array shapes making them attacker-influenced.

If the multiplication overflows, it results in an undersized allocation. Subsequent operations (such as slice copy routines) assume the correct size and may write out-of-bounds, leading to memory corruption.

### Fixes:
- Added checked multiplication helper for size_t arithmetic
- Validated typesize and chunk dimensions before use
- Enforced upper bounds (BLOSC2_MAX_BUFFERSIZE, INT32_MAX)
- Updated slice buffer size computation to prevent overflow

### Additional hardening:
- Replaced unsafe string operations (sprintf/strcpy/strcat) with bounded snprintf in directory handling
- Added path length validation to prevent buffer overflows
- Validated plugin names and bounded command construction to reduce command injection risk
