### PR TITLE
Harden stdio backend against integer overflows

### DIFF
--- a/blosc/blosc2-stdio.c
+++ b/blosc/blosc2-stdio.c
@@ -113,6 +113,14 @@ int64_t blosc2_stdio_write(const void *ptr, int64_t size, int64_t nitems, int64_
     return 0;
   }
 
+#if !defined(_WIN32)
+  /* POSIX fseek takes long; reject offsets that would silently truncate (e.g. on 32-bit). */
+  if (position > (int64_t)LONG_MAX) {
+    BLOSC_TRACE_ERROR("stdio write position %" PRId64 " exceeds LONG_MAX for fseek.", position);
+    return 0;
+  }
+#endif
+
   int rc = fseek(my_fp->file, position, SEEK_SET);
   if (rc != 0) {
     BLOSC_TRACE_ERROR("fseek failed at position %" PRId64 " (error: %s).", position, strerror(errno));
@@ -137,19 +145,24 @@ int64_t blosc2_stdio_read(void **ptr, int64_t size, int64_t nitems, int64_t posi
   int64_t n_bytes_i64;
   if (!checked_mul_int64_nonneg(size, nitems, &n_bytes_i64)) {
     BLOSC_TRACE_ERROR("stdio read size overflow (size=%" PRId64 ", nitems=%" PRId64 ").", size, nitems);
-    *ptr = NULL;
     return 0;
   }
   if ((uint64_t)n_bytes_i64 > SIZE_MAX) {
     BLOSC_TRACE_ERROR("stdio read size does not fit in size_t (%" PRId64 ").", n_bytes_i64);
-    *ptr = NULL;
     return 0;
   }
+
+#if !defined(_WIN32)
+  /* POSIX fseek takes long; reject offsets that would silently truncate (e.g. on 32-bit). */
+  if (position > (int64_t)LONG_MAX) {
+    BLOSC_TRACE_ERROR("stdio read position %" PRId64 " exceeds LONG_MAX for fseek.", position);
+    return 0;
+  }
+#endif
 
   int rc = fseek(my_fp->file, position, SEEK_SET);
   if (rc != 0) {
     BLOSC_TRACE_ERROR("fseek failed at position %" PRId64 " (error: %s).", position, strerror(errno));
-    *ptr = NULL;
     return 0;
   }
 

--- a/blosc/blosc2-stdio.c
+++ b/blosc/blosc2-stdio.c
@@ -98,6 +98,21 @@ int64_t blosc2_stdio_size(void *stream) {
 
 int64_t blosc2_stdio_write(const void *ptr, int64_t size, int64_t nitems, int64_t position, void *stream) {
   blosc2_stdio_file *my_fp = (blosc2_stdio_file *) stream;
+  if (ptr == NULL || size < 0 || nitems < 0 || position < 0) {
+    BLOSC_TRACE_ERROR("Invalid arguments for stdio write.");
+    return 0;
+  }
+
+  int64_t n_bytes_i64;
+  if (!checked_mul_int64_nonneg(size, nitems, &n_bytes_i64)) {
+    BLOSC_TRACE_ERROR("stdio write size overflow (size=%" PRId64 ", nitems=%" PRId64 ").", size, nitems);
+    return 0;
+  }
+  if ((uint64_t)n_bytes_i64 > SIZE_MAX) {
+    BLOSC_TRACE_ERROR("stdio write size does not fit in size_t (%" PRId64 ").", n_bytes_i64);
+    return 0;
+  }
+
   int rc = fseek(my_fp->file, position, SEEK_SET);
   if (rc != 0) {
     BLOSC_TRACE_ERROR("fseek failed at position %" PRId64 " (error: %s).", position, strerror(errno));
@@ -114,9 +129,27 @@ int64_t blosc2_stdio_write(const void *ptr, int64_t size, int64_t nitems, int64_
 
 int64_t blosc2_stdio_read(void **ptr, int64_t size, int64_t nitems, int64_t position, void *stream) {
   blosc2_stdio_file *my_fp = (blosc2_stdio_file *) stream;
+  if (ptr == NULL || size < 0 || nitems < 0 || position < 0) {
+    BLOSC_TRACE_ERROR("Invalid arguments for stdio read.");
+    return 0;
+  }
+
+  int64_t n_bytes_i64;
+  if (!checked_mul_int64_nonneg(size, nitems, &n_bytes_i64)) {
+    BLOSC_TRACE_ERROR("stdio read size overflow (size=%" PRId64 ", nitems=%" PRId64 ").", size, nitems);
+    *ptr = NULL;
+    return 0;
+  }
+  if ((uint64_t)n_bytes_i64 > SIZE_MAX) {
+    BLOSC_TRACE_ERROR("stdio read size does not fit in size_t (%" PRId64 ").", n_bytes_i64);
+    *ptr = NULL;
+    return 0;
+  }
+
   int rc = fseek(my_fp->file, position, SEEK_SET);
   if (rc != 0) {
     BLOSC_TRACE_ERROR("fseek failed at position %" PRId64 " (error: %s).", position, strerror(errno));
+    *ptr = NULL;
     return 0;
   }
 

--- a/blosc/blosc2-stdio.c
+++ b/blosc/blosc2-stdio.c
@@ -97,8 +97,12 @@ int64_t blosc2_stdio_size(void *stream) {
 }
 
 int64_t blosc2_stdio_write(const void *ptr, int64_t size, int64_t nitems, int64_t position, void *stream) {
+  if (stream == NULL || ptr == NULL || size < 0 || nitems < 0 || position < 0) {
+    BLOSC_TRACE_ERROR("Invalid arguments for stdio write.");
+    return 0;
+  }
   blosc2_stdio_file *my_fp = (blosc2_stdio_file *) stream;
-  if (ptr == NULL || size < 0 || nitems < 0 || position < 0) {
+  if (my_fp->file == NULL) {
     BLOSC_TRACE_ERROR("Invalid arguments for stdio write.");
     return 0;
   }
@@ -136,8 +140,12 @@ int64_t blosc2_stdio_write(const void *ptr, int64_t size, int64_t nitems, int64_
 }
 
 int64_t blosc2_stdio_read(void **ptr, int64_t size, int64_t nitems, int64_t position, void *stream) {
+  if (stream == NULL || ptr == NULL || size < 0 || nitems < 0 || position < 0) {
+    BLOSC_TRACE_ERROR("Invalid arguments for stdio read.");
+    return 0;
+  }
   blosc2_stdio_file *my_fp = (blosc2_stdio_file *) stream;
-  if (ptr == NULL || size < 0 || nitems < 0 || position < 0) {
+  if (my_fp->file == NULL) {
     BLOSC_TRACE_ERROR("Invalid arguments for stdio read.");
     return 0;
   }
@@ -149,6 +157,12 @@ int64_t blosc2_stdio_read(void **ptr, int64_t size, int64_t nitems, int64_t posi
   }
   if ((uint64_t)n_bytes_i64 > SIZE_MAX) {
     BLOSC_TRACE_ERROR("stdio read size does not fit in size_t (%" PRId64 ").", n_bytes_i64);
+    return 0;
+  }
+  /* For allocation-necessary backends, *ptr must point at a real buffer
+     when the caller asked for any bytes. Leave *ptr untouched on failure. */
+  if (n_bytes_i64 > 0 && *ptr == NULL) {
+    BLOSC_TRACE_ERROR("stdio read called with NULL buffer for %" PRId64 " bytes.", n_bytes_i64);
     return 0;
   }
 

--- a/tests/test_stdio_validation.c
+++ b/tests/test_stdio_validation.c
@@ -1,0 +1,130 @@
+/*
+  Copyright (c) 2021  Blosc Development Team <blosc@blosc.org>
+  https://blosc.org
+  License: BSD 3-Clause (see LICENSE.txt)
+
+  Regression tests for argument validation and overflow hardening in the stdio
+  IO backend (blosc/blosc2-stdio.c). Pre-hardening, negative sizes/positions
+  and size*nitems overflow would silently propagate through (size_t) casts
+  into fread/fwrite. The contract for an is_allocation_necessary=true backend
+  also requires that *ptr is left untouched on read failure so the caller can
+  still free its own buffer.
+*/
+
+#include "test_common.h"
+#include "cutest.h"
+#include "blosc2/blosc2-stdio.h"
+
+#include <limits.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <string.h>
+
+
+CUTEST_TEST_DATA(stdio_validation) {
+  bool placeholder;
+};
+
+CUTEST_TEST_SETUP(stdio_validation) {
+  BLOSC_UNUSED_PARAM(data);
+  blosc2_init();
+}
+
+CUTEST_TEST_TEST(stdio_validation) {
+  BLOSC_UNUSED_PARAM(data);
+
+  blosc2_stdio_file fp;
+  fp.file = tmpfile();
+  CUTEST_ASSERT("tmpfile() must succeed", fp.file != NULL);
+
+  /* Baseline: a valid write/read round-trip still works. */
+  uint8_t src_ok[8] = {1, 2, 3, 4, 5, 6, 7, 8};
+  int64_t nw = blosc2_stdio_write(src_ok, 1, 8, 0, &fp);
+  CUTEST_ASSERT("valid stdio write should succeed", nw == 8);
+
+  uint8_t dst_buf[8] = {0};
+  void* read_ptr = dst_buf;
+  int64_t nr = blosc2_stdio_read(&read_ptr, 1, 8, 0, &fp);
+  CUTEST_ASSERT("valid stdio read should succeed", nr == 8);
+  CUTEST_ASSERT("valid stdio read should fill caller buffer",
+                memcmp(dst_buf, src_ok, 8) == 0);
+  CUTEST_ASSERT("valid stdio read must not change *ptr",
+                read_ptr == (void*)dst_buf);
+
+  /* Write: reject NULL data pointer. */
+  nw = blosc2_stdio_write(NULL, 1, 1, 0, &fp);
+  CUTEST_ASSERT("stdio write must reject NULL ptr", nw == 0);
+
+  /* Write: reject negative size / nitems / position. */
+  nw = blosc2_stdio_write(src_ok, -1, 1, 0, &fp);
+  CUTEST_ASSERT("stdio write must reject negative size", nw == 0);
+  nw = blosc2_stdio_write(src_ok, 1, -1, 0, &fp);
+  CUTEST_ASSERT("stdio write must reject negative nitems", nw == 0);
+  nw = blosc2_stdio_write(src_ok, 1, 1, -1, &fp);
+  CUTEST_ASSERT("stdio write must reject negative position", nw == 0);
+
+  /* Write: reject size*nitems overflow. */
+  nw = blosc2_stdio_write(src_ok, INT64_MAX, 2, 0, &fp);
+  CUTEST_ASSERT("stdio write must reject size*nitems overflow", nw == 0);
+
+  /* Read: reject NULL out-parameter. */
+  nr = blosc2_stdio_read(NULL, 1, 1, 0, &fp);
+  CUTEST_ASSERT("stdio read must reject NULL ptr argument", nr == 0);
+
+  /* Read: on every failure path, *ptr (caller-owned buffer) must be untouched.
+     This is the is_allocation_necessary=true contract: nulling it would leak
+     the caller's malloc'd buffer. */
+  void* sentinel = (void*)(uintptr_t)0xDEADBEEF;
+
+  read_ptr = sentinel;
+  nr = blosc2_stdio_read(&read_ptr, -1, 1, 0, &fp);
+  CUTEST_ASSERT("stdio read must reject negative size", nr == 0);
+  CUTEST_ASSERT("stdio read must NOT touch *ptr on negative size",
+                read_ptr == sentinel);
+
+  read_ptr = sentinel;
+  nr = blosc2_stdio_read(&read_ptr, 1, -1, 0, &fp);
+  CUTEST_ASSERT("stdio read must reject negative nitems", nr == 0);
+  CUTEST_ASSERT("stdio read must NOT touch *ptr on negative nitems",
+                read_ptr == sentinel);
+
+  read_ptr = sentinel;
+  nr = blosc2_stdio_read(&read_ptr, 1, 1, -1, &fp);
+  CUTEST_ASSERT("stdio read must reject negative position", nr == 0);
+  CUTEST_ASSERT("stdio read must NOT touch *ptr on negative position",
+                read_ptr == sentinel);
+
+  read_ptr = sentinel;
+  nr = blosc2_stdio_read(&read_ptr, INT64_MAX, 2, 0, &fp);
+  CUTEST_ASSERT("stdio read must reject size*nitems overflow", nr == 0);
+  CUTEST_ASSERT("stdio read must NOT touch *ptr on overflow",
+                read_ptr == sentinel);
+
+#if !defined(_WIN32) && (LONG_MAX < INT64_MAX)
+  /* POSIX fseek takes long; on 32-bit POSIX, positions above LONG_MAX would
+     truncate. The guard must reject such positions cleanly. */
+  read_ptr = sentinel;
+  nr = blosc2_stdio_read(&read_ptr, 1, 1, (int64_t)LONG_MAX + 1, &fp);
+  CUTEST_ASSERT("stdio read must reject position > LONG_MAX on POSIX",
+                nr == 0);
+  CUTEST_ASSERT("stdio read must NOT touch *ptr on LONG_MAX overflow",
+                read_ptr == sentinel);
+
+  nw = blosc2_stdio_write(src_ok, 1, 1, (int64_t)LONG_MAX + 1, &fp);
+  CUTEST_ASSERT("stdio write must reject position > LONG_MAX on POSIX",
+                nw == 0);
+#endif
+
+  fclose(fp.file);
+  return 0;
+}
+
+CUTEST_TEST_TEARDOWN(stdio_validation) {
+  BLOSC_UNUSED_PARAM(data);
+  blosc2_destroy();
+}
+
+
+int main(void) {
+  CUTEST_TEST_RUN(stdio_validation);
+}

--- a/tests/test_stdio_validation.c
+++ b/tests/test_stdio_validation.c
@@ -51,6 +51,13 @@ CUTEST_TEST_TEST(stdio_validation) {
   CUTEST_ASSERT("valid stdio read must not change *ptr",
                 read_ptr == (void*)dst_buf);
 
+  /* Write: reject NULL stream and NULL underlying FILE*. */
+  nw = blosc2_stdio_write(src_ok, 1, 1, 0, NULL);
+  CUTEST_ASSERT("stdio write must reject NULL stream", nw == 0);
+  blosc2_stdio_file bad_fp = { NULL };
+  nw = blosc2_stdio_write(src_ok, 1, 1, 0, &bad_fp);
+  CUTEST_ASSERT("stdio write must reject NULL my_fp->file", nw == 0);
+
   /* Write: reject NULL data pointer. */
   nw = blosc2_stdio_write(NULL, 1, 1, 0, &fp);
   CUTEST_ASSERT("stdio write must reject NULL ptr", nw == 0);
@@ -67,9 +74,23 @@ CUTEST_TEST_TEST(stdio_validation) {
   nw = blosc2_stdio_write(src_ok, INT64_MAX, 2, 0, &fp);
   CUTEST_ASSERT("stdio write must reject size*nitems overflow", nw == 0);
 
+  /* Read: reject NULL stream and NULL underlying FILE*. */
+  read_ptr = dst_buf;
+  nr = blosc2_stdio_read(&read_ptr, 1, 1, 0, NULL);
+  CUTEST_ASSERT("stdio read must reject NULL stream", nr == 0);
+  nr = blosc2_stdio_read(&read_ptr, 1, 1, 0, &bad_fp);
+  CUTEST_ASSERT("stdio read must reject NULL my_fp->file", nr == 0);
+
   /* Read: reject NULL out-parameter. */
   nr = blosc2_stdio_read(NULL, 1, 1, 0, &fp);
   CUTEST_ASSERT("stdio read must reject NULL ptr argument", nr == 0);
+
+  /* Read: reject NULL buffer (*ptr) when non-zero bytes requested. */
+  void* null_buf = NULL;
+  nr = blosc2_stdio_read(&null_buf, 1, 1, 0, &fp);
+  CUTEST_ASSERT("stdio read must reject NULL *ptr with non-zero size", nr == 0);
+  CUTEST_ASSERT("stdio read must NOT touch *ptr on NULL-buffer rejection",
+                null_buf == NULL);
 
   /* Read: on every failure path, *ptr (caller-owned buffer) must be untouched.
      This is the is_allocation_necessary=true contract: nulling it would leak


### PR DESCRIPTION
Add defensive validation and checked arithmetic to the stdio backend I/O paths.

This patch hardens low-level read/write helpers in `blosc2-stdio.c` by:

- validating size/count arguments before arithmetic
- preventing integer overflow in size multiplications
- validating offset/position calculations
- rejecting invalid seek/read/write ranges early
- centralizing boundary checks in the backend implementation
