### PR TITLE
Validate negative indices in reorder_offsets

### DIFF
--- a/blosc/schunk.c
+++ b/blosc/schunk.c
@@ -1594,8 +1594,8 @@ int blosc2_schunk_reorder_offsets(blosc2_schunk *schunk, int64_t *offsets_order)
   bool *index_check = (bool *) calloc(schunk->nchunks, sizeof(bool));
   for (int i = 0; i < schunk->nchunks; ++i) {
     int64_t index = offsets_order[i];
-    if (index >= schunk->nchunks) {
-      BLOSC_TRACE_ERROR("Index is bigger than the number of chunks.");
+    if (index < 0 || index >= schunk->nchunks) {
+      BLOSC_TRACE_ERROR("Index is bigger than the number of chunks or negative.");
       free(index_check);
       return BLOSC2_ERROR_DATA;
     }

--- a/blosc/schunk.c
+++ b/blosc/schunk.c
@@ -1595,7 +1595,7 @@ int blosc2_schunk_reorder_offsets(blosc2_schunk *schunk, int64_t *offsets_order)
   for (int i = 0; i < schunk->nchunks; ++i) {
     int64_t index = offsets_order[i];
     if (index < 0 || index >= schunk->nchunks) {
-      BLOSC_TRACE_ERROR("Index is bigger than the number of chunks or negative.");
+      BLOSC_TRACE_ERROR("Index is out of range (negative or >= number of chunks).");
       free(index_check);
       return BLOSC2_ERROR_DATA;
     }

--- a/tests/test_reorder_offsets_negative.c
+++ b/tests/test_reorder_offsets_negative.c
@@ -1,0 +1,35 @@
+
+#include <stdio.h>
+#include "test_common.h"
+
+#define CHUNKSIZE (100)
+#define NTHREADS (1)
+
+int main(void) {
+  blosc2_init();
+
+  blosc2_cparams cparams = BLOSC2_CPARAMS_DEFAULTS;
+  blosc2_dparams dparams = BLOSC2_DPARAMS_DEFAULTS;
+  cparams.typesize = sizeof(int32_t);
+  
+  blosc2_storage storage = {.contiguous=false, .urlpath=NULL, .cparams=&cparams, .dparams=&dparams};
+  blosc2_schunk* schunk = blosc2_schunk_new(&storage);
+
+  int32_t data[CHUNKSIZE];
+  for (int i = 0; i < CHUNKSIZE; i++) data[i] = i;
+  
+  blosc2_schunk_append_buffer(schunk, data, sizeof(data));
+  blosc2_schunk_append_buffer(schunk, data, sizeof(data));
+
+  printf("nchunks: %lld\n", (long long)schunk->nchunks);
+
+  int64_t offsets_order[2] = {0, -1};
+  printf("Calling blosc2_schunk_reorder_offsets with negative index...\n");
+  int err = blosc2_schunk_reorder_offsets(schunk, offsets_order);
+  printf("Return code: %d\n", err);
+
+  blosc2_schunk_free(schunk);
+  blosc2_destroy();
+
+  return 0;
+}

--- a/tests/test_reorder_offsets_negative.c
+++ b/tests/test_reorder_offsets_negative.c
@@ -1,3 +1,10 @@
+/*
+  Copyright (c) 2021  Blosc Development Team <blosc@blosc.org>
+  https://blosc.org
+  License: BSD 3-Clause (see LICENSE.txt)
+
+  See LICENSE.txt for details about copyright and rights to use.
+*/
 
 #include <stdio.h>
 #include "test_common.h"
@@ -11,15 +18,27 @@ int main(void) {
   blosc2_cparams cparams = BLOSC2_CPARAMS_DEFAULTS;
   blosc2_dparams dparams = BLOSC2_DPARAMS_DEFAULTS;
   cparams.typesize = sizeof(int32_t);
+  cparams.nthreads = NTHREADS;
+  dparams.nthreads = NTHREADS;
   
   blosc2_storage storage = {.contiguous=false, .urlpath=NULL, .cparams=&cparams, .dparams=&dparams};
   blosc2_schunk* schunk = blosc2_schunk_new(&storage);
+  if (schunk == NULL) {
+    fprintf(stderr, "Error creating schunk\n");
+    return 1;
+  }
 
   int32_t data[CHUNKSIZE];
   for (int i = 0; i < CHUNKSIZE; i++) data[i] = i;
   
-  blosc2_schunk_append_buffer(schunk, data, sizeof(data));
-  blosc2_schunk_append_buffer(schunk, data, sizeof(data));
+  if (blosc2_schunk_append_buffer(schunk, data, sizeof(data)) <= 0) {
+    fprintf(stderr, "Error appending first chunk\n");
+    return 1;
+  }
+  if (blosc2_schunk_append_buffer(schunk, data, sizeof(data)) <= 0) {
+    fprintf(stderr, "Error appending second chunk\n");
+    return 1;
+  }
 
   printf("nchunks: %lld\n", (long long)schunk->nchunks);
 
@@ -30,6 +49,11 @@ int main(void) {
 
   blosc2_schunk_free(schunk);
   blosc2_destroy();
+
+  if (err != BLOSC2_ERROR_DATA) {
+    fprintf(stderr, "Expected BLOSC2_ERROR_DATA (%d), got %d\n", BLOSC2_ERROR_DATA, err);
+    return 1;
+  }
 
   return 0;
 }


### PR DESCRIPTION
This patch fixes an out-of-bounds heap access in `blosc2_schunk_reorder_offsets`.

The function validated indices larger than `nchunks`, but did not reject negative indices from the user-provided `offsets_order` array.

As a result, negative values could be used to index heap-allocated buffers out of bounds during offset reordering.

The fix adds a lower-bound validation check to ensure indices remain within the valid range:

c id="r4vrho"
0 <= index < schunk->nchunks


A regression test was also added to verify malformed negative indices are rejected correctly.
