### PR TITLE
Get sparse coords

### DIFF
--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -15,6 +15,7 @@ set(SOURCES_SUM_OPENMP sum_openmp.c)
 set(SOURCES_ZERO_RUNLEN zero_runlen.c)
 set(SOURCES_CFRAME create_frame.c)
 set(SOURCES_SFRAME sframe_bench.c)
+set(SOURCES_GET_SPARSE get_sparse.c)
 
 add_subdirectory(b2nd)
 
@@ -26,6 +27,7 @@ add_executable(sum_openmp ${SOURCES_SUM_OPENMP})
 add_executable(zero_runlen ${SOURCES_ZERO_RUNLEN})
 add_executable(create_frame ${SOURCES_CFRAME})
 add_executable(sframe_bench ${SOURCES_SFRAME})
+add_executable(get_sparse ${SOURCES_GET_SPARSE})
 if(UNIX AND NOT APPLE)
     # cmake is complaining about LINK_PRIVATE in original PR
     # and removing it does not seem to hurt, so be it.
@@ -37,6 +39,7 @@ if(UNIX AND NOT APPLE)
     target_link_libraries(zero_runlen rt)
     target_link_libraries(create_frame rt)
     target_link_libraries(sframe_bench rt)
+    target_link_libraries(get_sparse rt)
 endif()
 if(UNIX)
     if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
@@ -51,6 +54,7 @@ target_link_libraries(sum_openmp blosc_testing)
 target_link_libraries(zero_runlen blosc_testing)
 target_link_libraries(create_frame blosc_testing)
 target_link_libraries(sframe_bench blosc_testing)
+target_link_libraries(get_sparse blosc_testing)
 
 # tests
 if(BUILD_TESTS)

--- a/bench/get_sparse.c
+++ b/bench/get_sparse.c
@@ -164,7 +164,7 @@ int main(int argc, char **argv) {
 
   if (new_first || new_only) {
     blosc_set_timestamp(&t0);
-    int rc = blosc2_schunk_get_sparse_coords(array->sc, ncoords, coords, data_new);
+    int rc = blosc2_schunk_get_sparse_buffer(array->sc, ncoords, coords, data_new);
     blosc_set_timestamp(&t1);
     new_time = blosc_elapsed_secs(t0, t1);
     if (rc < 0) {
@@ -192,7 +192,7 @@ int main(int argc, char **argv) {
   }
   if (!new_first && !getitem_only && !new_only) {
     blosc_set_timestamp(&t0);
-    int rc = blosc2_schunk_get_sparse_coords(array->sc, ncoords, coords, data_new);
+    int rc = blosc2_schunk_get_sparse_buffer(array->sc, ncoords, coords, data_new);
     blosc_set_timestamp(&t1);
     new_time = blosc_elapsed_secs(t0, t1);
     if (rc < 0) {

--- a/bench/get_sparse.c
+++ b/bench/get_sparse.c
@@ -164,7 +164,7 @@ int main(int argc, char **argv) {
 
   if (new_first || new_only) {
     blosc_set_timestamp(&t0);
-    int rc = blosc2_schunk_get_sparse(array->sc, ncoords, coords, data_new);
+    int rc = blosc2_schunk_get_sparse_coords(array->sc, ncoords, coords, data_new);
     blosc_set_timestamp(&t1);
     new_time = blosc_elapsed_secs(t0, t1);
     if (rc < 0) {
@@ -192,7 +192,7 @@ int main(int argc, char **argv) {
   }
   if (!new_first && !getitem_only && !new_only) {
     blosc_set_timestamp(&t0);
-    int rc = blosc2_schunk_get_sparse(array->sc, ncoords, coords, data_new);
+    int rc = blosc2_schunk_get_sparse_coords(array->sc, ncoords, coords, data_new);
     blosc_set_timestamp(&t1);
     new_time = blosc_elapsed_secs(t0, t1);
     if (rc < 0) {

--- a/bench/get_sparse.c
+++ b/bench/get_sparse.c
@@ -1,0 +1,244 @@
+/*
+  Copyright (c) 2026  Blosc Development Team <blosc@blosc.org>
+  https://blosc.org
+  License: BSD 3-Clause (see LICENSE.txt)
+
+  Benchmark for reading individual coordinates from a 1-D b2nd array.
+
+  To run from the repository root:
+
+  $ ./build/bench/read-coords bench/sin-1d.b2nd [ncoords]
+*/
+
+/*
+Use:
+
+import numpy as np
+
+import blosc2
+
+N = 24_000_000
+a = blosc2.linspace(0., 1., N, dtype=np.float32)
+b = blosc2.sin(a).compute(urlpath="sin-1d.b2nd", mode="w")
+print(b[:])
+
+for generating the data file.
+
+*/
+#include <inttypes.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <b2nd.h>
+#include <blosc2.h>
+
+#define DEFAULT_NCOORDS 100
+#define NPRINT 10
+#define NTHREADS 4
+
+static void fill_random_coords(int64_t *coords, int64_t ncoords, int64_t nitems) {
+  uint64_t state = UINT64_C(0x20260522);
+
+  for (int64_t i = 0; i < ncoords; ++i) {
+    /* xorshift64*: deterministic and good enough for benchmark coordinates. */
+    state ^= state >> 12;
+    state ^= state << 25;
+    state ^= state >> 27;
+    uint64_t r = state * UINT64_C(2685821657736338717);
+    coords[i] = (int64_t)(r % (uint64_t)nitems);
+  }
+}
+
+static int open_array(const char **urlpath, bool use_fallbacks, b2nd_array_t **array) {
+  int rc = b2nd_open(*urlpath, array);
+  if (rc >= 0 || *array != NULL || !use_fallbacks) {
+    if (rc < 0) {
+      fprintf(stderr, "Cannot open %s (error %d)\n", *urlpath, rc);
+    }
+    return rc;
+  }
+
+  const char *fallbacks[] = {"../bench/sin-1d.b2nd", "../../bench/sin-1d.b2nd"};
+  for (size_t i = 0; i < sizeof(fallbacks) / sizeof(fallbacks[0]); ++i) {
+    *urlpath = fallbacks[i];
+    rc = b2nd_open(*urlpath, array);
+    if (rc >= 0) {
+      return rc;
+    }
+  }
+
+  fprintf(stderr, "Cannot open sin-1d.b2nd (last error %d)\n", rc);
+  return rc;
+}
+
+static int getitem_sparse(const b2nd_array_t *array, const int64_t *coords, int64_t ncoords, float *data) {
+  int64_t chunk_nitems = array->sc->chunksize / array->sc->typesize;
+
+  for (int64_t i = 0; i < ncoords; ++i) {
+    int64_t coord = coords[i];
+    int64_t nchunk = coord / chunk_nitems;
+    int start = (int)(coord % chunk_nitems);
+    uint8_t *chunk = NULL;
+    bool needs_free = false;
+
+    int cbytes = blosc2_schunk_get_lazychunk(array->sc, nchunk, &chunk, &needs_free);
+    if (cbytes <= 0) {
+      fprintf(stderr, "Cannot get chunk %" PRId64 " for coordinate %" PRId64 " (error %d)\n",
+              nchunk, coord, cbytes);
+      return cbytes < 0 ? cbytes : -1;
+    }
+
+    int nbytes = blosc2_getitem_ctx(array->sc->dctx, chunk, cbytes, start, 1, &data[i], sizeof(float));
+    if (needs_free) {
+      free(chunk);
+    }
+    if (nbytes != (int)sizeof(float)) {
+      fprintf(stderr, "Cannot get coordinate %" PRId64 " from chunk %" PRId64 " (error %d)\n",
+              coord, nchunk, nbytes);
+      return nbytes < 0 ? nbytes : -1;
+    }
+  }
+
+  return 0;
+}
+
+int main(int argc, char **argv) {
+  const char *urlpath = (argc > 1) ? argv[1] : "bench/sin-1d.b2nd";
+  int64_t ncoords = (argc > 2) ? strtoll(argv[2], NULL, 10) : DEFAULT_NCOORDS;
+  bool new_first = (argc > 3) && (strcmp(argv[3], "new-first") == 0);
+  bool getitem_only = (argc > 3) && (strcmp(argv[3], "getitem-only") == 0);
+  bool new_only = (argc > 3) && (strcmp(argv[3], "new-only") == 0);
+  b2nd_array_t *array = NULL;
+  int64_t *coords = NULL;
+  float *data_getitem = NULL;
+  float *data_new = NULL;
+  blosc_timestamp_t t0, t1;
+  double getitem_time;
+  double new_time;
+
+  blosc2_init();
+  blosc2_set_nthreads(NTHREADS);
+
+  if (ncoords <= 0) {
+    fprintf(stderr, "ncoords must be positive\n");
+    blosc2_destroy();
+    return EXIT_FAILURE;
+  }
+
+  if (open_array(&urlpath, argc == 1, &array) < 0) {
+    blosc2_destroy();
+    return EXIT_FAILURE;
+  }
+
+  if (array->ndim != 1) {
+    fprintf(stderr, "Expected a 1-D array, got %d dimensions\n", array->ndim);
+    b2nd_free(array);
+    blosc2_destroy();
+    return EXIT_FAILURE;
+  }
+  if (array->sc->typesize != (int32_t)sizeof(float)) {
+    fprintf(stderr, "Expected float elements (typesize %zu), got typesize %d\n",
+            sizeof(float), array->sc->typesize);
+    b2nd_free(array);
+    blosc2_destroy();
+    return EXIT_FAILURE;
+  }
+
+  coords = malloc((size_t)ncoords * sizeof(int64_t));
+  data_getitem = malloc((size_t)ncoords * sizeof(float));
+  data_new = malloc((size_t)ncoords * sizeof(float));
+  if (coords == NULL || data_getitem == NULL || data_new == NULL) {
+    fprintf(stderr, "Cannot allocate benchmark buffers\n");
+    free(coords);
+    free(data_getitem);
+    free(data_new);
+    b2nd_free(array);
+    blosc2_destroy();
+    return EXIT_FAILURE;
+  }
+
+  fill_random_coords(coords, ncoords, array->shape[0]);
+
+  if (new_first || new_only) {
+    blosc_set_timestamp(&t0);
+    int rc = blosc2_schunk_get_sparse(array->sc, ncoords, coords, data_new);
+    blosc_set_timestamp(&t1);
+    new_time = blosc_elapsed_secs(t0, t1);
+    if (rc < 0) {
+      fprintf(stderr, "blosc2_schunk_get_sparse failed (error %d)\n", rc);
+      free(coords);
+      free(data_getitem);
+      free(data_new);
+      b2nd_free(array);
+      blosc2_destroy();
+      return EXIT_FAILURE;
+    }
+  }
+  if (!new_only) {
+    blosc_set_timestamp(&t0);
+    if (getitem_sparse(array, coords, ncoords, data_getitem) < 0) {
+      free(coords);
+      free(data_getitem);
+      free(data_new);
+      b2nd_free(array);
+      blosc2_destroy();
+      return EXIT_FAILURE;
+    }
+    blosc_set_timestamp(&t1);
+    getitem_time = blosc_elapsed_secs(t0, t1);
+  }
+  if (!new_first && !getitem_only && !new_only) {
+    blosc_set_timestamp(&t0);
+    int rc = blosc2_schunk_get_sparse(array->sc, ncoords, coords, data_new);
+    blosc_set_timestamp(&t1);
+    new_time = blosc_elapsed_secs(t0, t1);
+    if (rc < 0) {
+      fprintf(stderr, "blosc2_schunk_get_sparse failed (error %d)\n", rc);
+      free(coords);
+      free(data_getitem);
+      free(data_new);
+      b2nd_free(array);
+      blosc2_destroy();
+      return EXIT_FAILURE;
+    }
+  }
+
+  if (!getitem_only && !new_only) {
+  for (int64_t i = 0; i < ncoords; ++i) {
+    if (data_getitem[i] != data_new[i]) {
+      fprintf(stderr, "Mismatched result at %" PRId64 ": getitem_sparse=%.9g, new_sparse=%.9g\n",
+              i, data_getitem[i], data_new[i]);
+      free(coords);
+      free(data_getitem);
+      free(data_new);
+      b2nd_free(array);
+      blosc2_destroy();
+      return EXIT_FAILURE;
+    }
+  }
+  }
+
+  printf("Read %" PRId64 " random coordinates from %s (%d threads)\n", ncoords, urlpath, NTHREADS);
+  int64_t nprint = ncoords < NPRINT ? ncoords : NPRINT;
+  printf("First %" PRId64 " retrieved elements:\n", nprint);
+  for (int64_t i = 0; i < nprint; ++i) {
+    printf("  coord[%" PRId64 "] = %" PRId64 ", value = %.9g\n", i, coords[i], data_new[i]);
+  }
+  if (!new_only) {
+    printf("getitem_sparse: %.9f s\n", getitem_time);
+  }
+  if (!getitem_only) {
+    printf("new_sparse:     %.9f s\n", new_time);
+  }
+
+  free(coords);
+  free(data_getitem);
+  free(data_new);
+  b2nd_free(array);
+  blosc2_destroy();
+
+  return EXIT_SUCCESS;
+}

--- a/blosc/b2nd.c
+++ b/blosc/b2nd.c
@@ -783,6 +783,86 @@ int b2nd_to_cbuffer(const b2nd_array_t *array, void *buffer,
   return BLOSC2_ERROR_SUCCESS;
 }
 
+int b2nd_get_sparse_cbuffer(const b2nd_array_t *array, int64_t ncoords,
+                            const int64_t *coords, void *buffer, int64_t buffersize) {
+  BLOSC_ERROR_NULL(array, BLOSC2_ERROR_NULL_POINTER);
+  if (ncoords < 0) {
+    BLOSC_TRACE_ERROR("ncoords must be non-negative");
+    BLOSC_ERROR(BLOSC2_ERROR_INVALID_PARAM);
+  }
+  if (ncoords == 0) {
+    return BLOSC2_ERROR_SUCCESS;
+  }
+  BLOSC_ERROR_NULL(coords, BLOSC2_ERROR_NULL_POINTER);
+  BLOSC_ERROR_NULL(buffer, BLOSC2_ERROR_NULL_POINTER);
+  if (buffersize < ncoords * array->sc->typesize) {
+    BLOSC_TRACE_ERROR("Buffer is smaller than expected");
+    BLOSC_ERROR(BLOSC2_ERROR_INVALID_PARAM);
+  }
+  if (array->ndim == 0) {
+    BLOSC_TRACE_ERROR("Sparse indexing is not supported for 0-dimensional arrays");
+    BLOSC_ERROR(BLOSC2_ERROR_INVALID_PARAM);
+  }
+
+  int64_t chunks_in_array[B2ND_MAX_DIM] = {0};
+  int64_t chunks_in_array_strides[B2ND_MAX_DIM] = {0};
+  chunks_in_array_strides[array->ndim - 1] = 1;
+  for (int j = 0; j < array->ndim; ++j) {
+    chunks_in_array[j] = array->chunkshape[j] == 0 ? 0 : array->extshape[j] / array->chunkshape[j];
+  }
+  for (int j = array->ndim - 2; j >= 0; --j) {
+    chunks_in_array_strides[j] = chunks_in_array_strides[j + 1] * chunks_in_array[j + 1];
+  }
+
+  int64_t *storage_coords = malloc((size_t)ncoords * sizeof(int64_t));
+  BLOSC_ERROR_NULL(storage_coords, BLOSC2_ERROR_MEMORY_ALLOC);
+
+  int rc = BLOSC2_ERROR_SUCCESS;
+  for (int64_t i = 0; i < ncoords; ++i) {
+    int64_t coord = coords[i];
+    if (coord < 0 || coord >= array->nitems) {
+      BLOSC_TRACE_ERROR("Coordinate out of bounds");
+      rc = BLOSC2_ERROR_INVALID_PARAM;
+      goto cleanup;
+    }
+
+    int64_t logical_index[B2ND_MAX_DIM] = {0};
+    int64_t nchunk_ndim[B2ND_MAX_DIM] = {0};
+    int64_t item_in_chunk[B2ND_MAX_DIM] = {0};
+    int64_t nblock_ndim[B2ND_MAX_DIM] = {0};
+    int64_t item_in_block[B2ND_MAX_DIM] = {0};
+    blosc2_unidim_to_multidim(array->ndim, (int64_t *)array->shape, coord, logical_index);
+    for (int j = 0; j < array->ndim; ++j) {
+      nchunk_ndim[j] = logical_index[j] / array->chunkshape[j];
+      item_in_chunk[j] = logical_index[j] % array->chunkshape[j];
+      nblock_ndim[j] = item_in_chunk[j] / array->blockshape[j];
+      item_in_block[j] = item_in_chunk[j] % array->blockshape[j];
+    }
+
+    int64_t nchunk;
+    blosc2_multidim_to_unidim(nchunk_ndim, array->ndim, chunks_in_array_strides, &nchunk);
+
+    int64_t nblock;
+    blosc2_multidim_to_unidim(nblock_ndim, array->ndim, array->block_chunk_strides, &nblock);
+    int64_t storage_item_in_block;
+    blosc2_multidim_to_unidim(item_in_block, array->ndim, array->item_block_strides, &storage_item_in_block);
+    storage_coords[i] = nchunk * array->extchunknitems + nblock * array->blocknitems + storage_item_in_block;
+  }
+
+  rc = blosc2_schunk_get_sparse(array->sc, ncoords, storage_coords, buffer);
+
+cleanup:
+  free(storage_coords);
+  BLOSC_ERROR(rc);
+  return BLOSC2_ERROR_SUCCESS;
+}
+
+int b2nd_get_sparse(const b2nd_array_t *array, int64_t ncoords,
+                    const int64_t *coords, void *buffer) {
+  BLOSC_ERROR_NULL(array, BLOSC2_ERROR_NULL_POINTER);
+  return b2nd_get_sparse_cbuffer(array, ncoords, coords, buffer, ncoords * array->sc->typesize);
+}
+
 int64_t b2nd_get_slice_nchunks(const b2nd_array_t *array, const int64_t *start, const int64_t *stop, int64_t **chunks_idx) {
   BLOSC_ERROR_NULL(array, BLOSC2_ERROR_NULL_POINTER);
   BLOSC_ERROR_NULL(start, BLOSC2_ERROR_NULL_POINTER);

--- a/blosc/b2nd.c
+++ b/blosc/b2nd.c
@@ -849,7 +849,7 @@ int b2nd_get_sparse_cbuffer(const b2nd_array_t *array, int64_t ncoords,
     storage_coords[i] = nchunk * array->extchunknitems + nblock * array->blocknitems + storage_item_in_block;
   }
 
-  rc = blosc2_schunk_get_sparse(array->sc, ncoords, storage_coords, buffer);
+  rc = blosc2_schunk_get_sparse_coords(array->sc, ncoords, storage_coords, buffer);
 
 cleanup:
   free(storage_coords);
@@ -857,7 +857,7 @@ cleanup:
   return BLOSC2_ERROR_SUCCESS;
 }
 
-int b2nd_get_sparse(const b2nd_array_t *array, int64_t ncoords,
+int b2nd_get_sparse_coords(const b2nd_array_t *array, int64_t ncoords,
                     const int64_t *coords, void *buffer) {
   BLOSC_ERROR_NULL(array, BLOSC2_ERROR_NULL_POINTER);
   return b2nd_get_sparse_cbuffer(array, ncoords, coords, buffer, ncoords * array->sc->typesize);

--- a/blosc/b2nd.c
+++ b/blosc/b2nd.c
@@ -849,7 +849,7 @@ int b2nd_get_sparse_cbuffer(const b2nd_array_t *array, int64_t ncoords,
     storage_coords[i] = nchunk * array->extchunknitems + nblock * array->blocknitems + storage_item_in_block;
   }
 
-  rc = blosc2_schunk_get_sparse_coords(array->sc, ncoords, storage_coords, buffer);
+  rc = blosc2_schunk_get_sparse_buffer(array->sc, ncoords, storage_coords, buffer);
 
 cleanup:
   free(storage_coords);
@@ -857,11 +857,7 @@ cleanup:
   return BLOSC2_ERROR_SUCCESS;
 }
 
-int b2nd_get_sparse_coords(const b2nd_array_t *array, int64_t ncoords,
-                    const int64_t *coords, void *buffer) {
-  BLOSC_ERROR_NULL(array, BLOSC2_ERROR_NULL_POINTER);
-  return b2nd_get_sparse_cbuffer(array, ncoords, coords, buffer, ncoords * array->sc->typesize);
-}
+
 
 int64_t b2nd_get_slice_nchunks(const b2nd_array_t *array, const int64_t *start, const int64_t *stop, int64_t **chunks_idx) {
   BLOSC_ERROR_NULL(array, BLOSC2_ERROR_NULL_POINTER);

--- a/blosc/blosc-private.h
+++ b/blosc/blosc-private.h
@@ -26,6 +26,12 @@
 
 *********************************************************************/
 
+int blosc2_decompress_block_ctx(blosc2_context* context, const void* src,
+                                int32_t srcsize, int32_t nblock, void* dest,
+                                int32_t destsize);
+int blosc2_run_parallel(int16_t nthreads, void (*dojob)(void *),
+                        size_t jobdata_elsize, void *jobdata);
+
 #define to_little(dest, src, itemsize)    endian_handler(true, dest, src, itemsize)
 #define from_little(dest, src, itemsize)  endian_handler(true, dest, src, itemsize)
 #define to_big(dest, src, itemsize)       endian_handler(false, dest, src, itemsize)

--- a/blosc/blosc2.c
+++ b/blosc/blosc2.c
@@ -184,6 +184,60 @@ void blosc2_set_threads_callback(blosc_threads_callback callback, void *callback
   threads_callback_data = callback_data;
 }
 
+typedef struct {
+  void (*dojob)(void *);
+  void *jobdata;
+} blosc2_parallel_job_data;
+
+static void *blosc2_parallel_pthread_entry(void *arg) {
+  blosc2_parallel_job_data *job = (blosc2_parallel_job_data *)arg;
+  job->dojob(job->jobdata);
+  return NULL;
+}
+
+int blosc2_run_parallel(int16_t nthreads, void (*dojob)(void *),
+                        size_t jobdata_elsize, void *jobdata) {
+  if (nthreads <= 0 || dojob == NULL || jobdata == NULL || jobdata_elsize == 0) {
+    return BLOSC2_ERROR_INVALID_PARAM;
+  }
+
+  if (nthreads == 1) {
+    dojob(jobdata);
+    return BLOSC2_ERROR_SUCCESS;
+  }
+
+  if (threads_callback != NULL) {
+    threads_callback(threads_callback_data, dojob, nthreads, jobdata_elsize, jobdata);
+    return BLOSC2_ERROR_SUCCESS;
+  }
+
+  blosc2_pthread_t *threads = malloc((size_t)nthreads * sizeof(blosc2_pthread_t));
+  blosc2_parallel_job_data *jobs = malloc((size_t)nthreads * sizeof(blosc2_parallel_job_data));
+  if (threads == NULL || jobs == NULL) {
+    free(threads);
+    free(jobs);
+    return BLOSC2_ERROR_MEMORY_ALLOC;
+  }
+
+  int16_t started = 0;
+  for (int16_t i = 0; i < nthreads; ++i) {
+    jobs[i].dojob = dojob;
+    jobs[i].jobdata = (uint8_t *)jobdata + (size_t)i * jobdata_elsize;
+    int err = blosc2_pthread_create(&threads[i], NULL, blosc2_parallel_pthread_entry, &jobs[i]);
+    if (err != 0) {
+      break;
+    }
+    ++started;
+  }
+  for (int16_t i = 0; i < started; ++i) {
+    blosc2_pthread_join(threads[i], NULL);
+  }
+  free(threads);
+  free(jobs);
+
+  return started == nthreads ? BLOSC2_ERROR_SUCCESS : BLOSC2_ERROR_THREAD_CREATE;
+}
+
 
 /* A function for aligned malloc that is portable */
 static uint8_t* my_malloc(size_t size) {
@@ -4465,6 +4519,115 @@ int blosc2_getitem_ctx(blosc2_context* context, const void* src, int32_t srcsize
   result = _blosc_getitem(context, &header, src, srcsize, start, nitems, dest, destsize);
 
   return result;
+}
+
+int blosc2_decompress_block_ctx(blosc2_context* context, const void* src,
+                                int32_t srcsize, int32_t nblock, void* dest,
+                                int32_t destsize) {
+  blosc_header header;
+  int result = read_chunk_header((uint8_t *)src, srcsize, true, &header);
+  if (result < 0) {
+    return result;
+  }
+  if (header.blosc2_flags2 & BLOSC2_VL_BLOCKS) {
+    BLOSC_TRACE_ERROR("block decompression is not supported for VL-block chunks.");
+    return BLOSC2_ERROR_INVALID_PARAM;
+  }
+
+  context->do_compress = 0;
+  context->src = src;
+  context->srcsize = srcsize;
+  context->dest = dest;
+  context->destsize = destsize;
+  context->output_bytes = 0;
+  context->vlblock_sources = NULL;
+  context->vlblock_dests = NULL;
+  if (context->blocknbytes != NULL) {
+    free(context->blocknbytes);
+    context->blocknbytes = NULL;
+  }
+  if (context->blockoffsets != NULL) {
+    free(context->blockoffsets);
+    context->blockoffsets = NULL;
+  }
+  if (context->blockcbytes != NULL) {
+    free(context->blockcbytes);
+    context->blockcbytes = NULL;
+  }
+
+  result = blosc2_initialize_context_from_header(context, &header);
+  if (result < 0) {
+    return result;
+  }
+  clear_context_decompression_dict(context);
+
+  context->special_type = (header.blosc2_flags >> 4) & BLOSC2_SPECIAL_MASK;
+  if (context->special_type > BLOSC2_SPECIAL_LASTID) {
+    BLOSC_TRACE_ERROR("Unknown special values ID (%d) ", context->special_type);
+    return BLOSC2_ERROR_DATA;
+  }
+  if (nblock < 0 || nblock >= context->nblocks) {
+    BLOSC_TRACE_ERROR("`nblock` out of bounds.");
+    return BLOSC2_ERROR_INVALID_PARAM;
+  }
+
+  bool memcpyed = (header.flags & (uint8_t)BLOSC_MEMCPYED) != 0;
+  if (context->special_type) {
+    memcpyed = true;
+  }
+  if (!context->special_type && !memcpyed) {
+    size_t bstarts_nbytes;
+    size_t bstarts_end;
+    if (context->nblocks < 0 ||
+        !checked_mul_size((size_t)context->nblocks, sizeof(int32_t), &bstarts_nbytes) ||
+        !checked_add_size((size_t)context->header_overhead, bstarts_nbytes, &bstarts_end) ||
+        bstarts_end > (size_t)srcsize) {
+      BLOSC_TRACE_ERROR("`bstarts` out of bounds.");
+      return BLOSC2_ERROR_READ_BUFFER;
+    }
+  }
+
+  int32_t bsize = context->blocksize;
+  int32_t leftoverblock = 0;
+  if ((nblock == context->nblocks - 1) && (context->leftover > 0)) {
+    bsize = context->leftover;
+    leftoverblock = 1;
+  }
+  if (destsize < bsize) {
+    BLOSC_TRACE_ERROR("Destination is too small for block.");
+    return BLOSC2_ERROR_WRITE_BUFFER;
+  }
+
+  if (context->serial_context == NULL) {
+    context->serial_context = create_thread_context(context, 0);
+  }
+  BLOSC_ERROR_NULL(context->serial_context, BLOSC2_ERROR_THREAD_CREATE);
+  context->serial_context->parent_context = context;
+
+  int32_t ebsize = context->blocksize + context->typesize * (int32_t)sizeof(int32_t);
+  if (context->blocksize > context->serial_context->tmp_blocksize) {
+    my_free(context->serial_context->tmp);
+    context->serial_context->tmp_nbytes = (size_t)4 * ebsize;
+    context->serial_context->tmp = my_malloc(context->serial_context->tmp_nbytes);
+    BLOSC_ERROR_NULL(context->serial_context->tmp, BLOSC2_ERROR_MEMORY_ALLOC);
+    context->serial_context->tmp2 = context->serial_context->tmp + ebsize;
+    context->serial_context->tmp3 = context->serial_context->tmp2 + ebsize;
+    context->serial_context->tmp4 = context->serial_context->tmp3 + ebsize;
+    context->serial_context->tmp_blocksize = context->blocksize;
+  }
+
+  int32_t* bstarts = (int32_t*)((uint8_t*)src + context->header_overhead);
+  int32_t src_offset = memcpyed ?
+      context->header_overhead + nblock * context->blocksize : sw32_(bstarts + nblock);
+  int nbytes = blosc_d(context->serial_context, bsize, leftoverblock, memcpyed,
+                       src, srcsize, src_offset, nblock,
+                       (uint8_t*)dest, 0,
+                       context->serial_context->tmp,
+                       context->serial_context->tmp3);
+  if (nbytes < 0) {
+    return nbytes;
+  }
+  return bsize;
 }
 
 /* execute single compression/decompression job for a single thread_context */

--- a/blosc/schunk.c
+++ b/blosc/schunk.c
@@ -11,6 +11,7 @@
 #include "frame.h"
 #include "stune.h"
 #include "blosc-private.h"
+#include "context.h"
 #include "blosc2/tuners-registry.h"
 #include "blosc2.h"
 
@@ -24,6 +25,7 @@
 #include <sys/stat.h>
 
 #include <inttypes.h>
+#include <limits.h>
 #include <stdio.h>
 #include <stdint.h>
 #include <stdlib.h>
@@ -1496,6 +1498,363 @@ int blosc2_schunk_get_slice_buffer(blosc2_schunk *schunk, int64_t start, int64_t
   }
 
   return BLOSC2_ERROR_SUCCESS;
+}
+
+
+typedef struct {
+  int64_t coord;
+  int64_t out_index;
+} sparse_coord_entry;
+
+typedef struct {
+  int64_t nchunk;
+  uint8_t *chunk;
+  int cbytes;
+  bool needs_free;
+} sparse_chunk_entry;
+
+typedef struct {
+  int64_t first;
+  int64_t count;
+  int64_t chunk_index;
+  int32_t nblock;
+} sparse_block_task;
+
+typedef struct {
+  const sparse_coord_entry *entries;
+  const sparse_block_task *tasks;
+  const sparse_chunk_entry *chunks;
+  int64_t ntasks;
+  uint8_t *buffer;
+  int32_t typesize;
+  int32_t blocksize;
+  int64_t chunk_nitems;
+  int64_t next_task;
+  int error;
+  blosc2_pthread_mutex_t mutex;
+} sparse_work;
+
+typedef struct {
+  sparse_work *work;
+  blosc2_context *dctx;
+  uint8_t *block;
+} sparse_worker;
+
+static int sparse_coord_entry_cmp(const void *a, const void *b) {
+  const sparse_coord_entry *ea = (const sparse_coord_entry *)a;
+  const sparse_coord_entry *eb = (const sparse_coord_entry *)b;
+  if (ea->coord < eb->coord) return -1;
+  if (ea->coord > eb->coord) return 1;
+  if (ea->out_index < eb->out_index) return -1;
+  if (ea->out_index > eb->out_index) return 1;
+  return 0;
+}
+
+static void sparse_work_set_error(sparse_work *work, int error) {
+  blosc2_pthread_mutex_lock(&work->mutex);
+  if (work->error == 0) {
+    work->error = error;
+  }
+  blosc2_pthread_mutex_unlock(&work->mutex);
+}
+
+static void sparse_worker_func(void *arg) {
+  sparse_worker *worker = (sparse_worker *)arg;
+  sparse_work *work = worker->work;
+
+  while (true) {
+    blosc2_pthread_mutex_lock(&work->mutex);
+    if (work->error < 0 || work->next_task >= work->ntasks) {
+      blosc2_pthread_mutex_unlock(&work->mutex);
+      break;
+    }
+    int64_t task_index = work->next_task++;
+    blosc2_pthread_mutex_unlock(&work->mutex);
+
+    const sparse_block_task *task = &work->tasks[task_index];
+    const sparse_chunk_entry *chunk_entry = &work->chunks[task->chunk_index];
+    int nbytes = blosc2_decompress_block_ctx(worker->dctx, chunk_entry->chunk, chunk_entry->cbytes,
+                                             task->nblock, worker->block, work->blocksize);
+    if (nbytes < 0) {
+      sparse_work_set_error(work, nbytes);
+      break;
+    }
+
+    for (int64_t i = task->first; i < task->first + task->count; ++i) {
+      const sparse_coord_entry *entry = &work->entries[i];
+      int64_t item_in_chunk = entry->coord % work->chunk_nitems;
+      int64_t byte_in_chunk = item_in_chunk * work->typesize;
+      int32_t block_offset = (int32_t)(byte_in_chunk % work->blocksize);
+      if (block_offset < 0 || block_offset > nbytes - work->typesize) {
+        sparse_work_set_error(work, BLOSC2_ERROR_DATA);
+        return;
+      }
+      memcpy(work->buffer + entry->out_index * work->typesize,
+             worker->block + block_offset,
+             (size_t)work->typesize);
+    }
+  }
+
+  return;
+}
+
+static int schunk_get_sparse_getitem(blosc2_schunk *schunk, int64_t ncoords, const int64_t* coords, void *buffer) {
+  int64_t nitems = schunk->nbytes / schunk->typesize;
+  int64_t chunk_nitems = schunk->chunksize / schunk->typesize;
+  uint8_t *dst_ptr = (uint8_t *)buffer;
+
+  for (int64_t i = 0; i < ncoords; ++i) {
+    int64_t coord = coords[i];
+    if (coord < 0 || coord >= nitems) {
+      BLOSC_TRACE_ERROR("Coordinate out of bounds.");
+      return BLOSC2_ERROR_INVALID_PARAM;
+    }
+
+    int64_t nchunk = coord / chunk_nitems;
+    int start = (int)(coord % chunk_nitems);
+    uint8_t *chunk = NULL;
+    bool needs_free = false;
+    int cbytes = blosc2_schunk_get_lazychunk(schunk, nchunk, &chunk, &needs_free);
+    if (cbytes <= 0) {
+      BLOSC_TRACE_ERROR("Cannot get lazychunk ('%" PRId64 "').", nchunk);
+      return BLOSC2_ERROR_FAILURE;
+    }
+
+    int nbytes = blosc2_getitem_ctx(schunk->dctx, chunk, cbytes, start, 1, dst_ptr, schunk->typesize);
+    if (needs_free) {
+      free(chunk);
+    }
+    if (nbytes != schunk->typesize) {
+      BLOSC_TRACE_ERROR("Cannot get item from ('%" PRId64 "') chunk.", nchunk);
+      return BLOSC2_ERROR_FAILURE;
+    }
+    dst_ptr += schunk->typesize;
+  }
+
+  return BLOSC2_ERROR_SUCCESS;
+}
+
+int blosc2_schunk_get_sparse(blosc2_schunk *schunk, int64_t ncoords, const int64_t* coords, void *buffer) {
+  if (schunk == NULL) {
+    BLOSC_TRACE_ERROR("schunk must not be NULL.");
+    return BLOSC2_ERROR_INVALID_PARAM;
+  }
+  if (ncoords < 0) {
+    BLOSC_TRACE_ERROR("ncoords must be non-negative.");
+    return BLOSC2_ERROR_INVALID_PARAM;
+  }
+  if (ncoords == 0) {
+    return BLOSC2_ERROR_SUCCESS;
+  }
+  if (coords == NULL || buffer == NULL) {
+    BLOSC_TRACE_ERROR("coords and buffer must not be NULL when ncoords > 0.");
+    return BLOSC2_ERROR_INVALID_PARAM;
+  }
+  if (schunk->typesize <= 0) {
+    BLOSC_TRACE_ERROR("schunk must have a positive typesize.");
+    return BLOSC2_ERROR_INVALID_PARAM;
+  }
+  if (schunk->chunksize <= 0) {
+    BLOSC_TRACE_ERROR("blosc2_schunk_get_sparse does not support variable-length chunks yet.");
+    return BLOSC2_ERROR_INVALID_PARAM;
+  }
+  if (schunk->blocksize <= 0 || (schunk->flags2 & BLOSC2_VL_BLOCKS)) {
+    BLOSC_TRACE_ERROR("blosc2_schunk_get_sparse does not support variable-length blocks yet.");
+    return BLOSC2_ERROR_INVALID_PARAM;
+  }
+  if ((schunk->chunksize % schunk->typesize) != 0 || (schunk->blocksize % schunk->typesize) != 0) {
+    BLOSC_TRACE_ERROR("chunksize and blocksize must be multiples of typesize.");
+    return BLOSC2_ERROR_INVALID_PARAM;
+  }
+
+  for (int i = 0; i < BLOSC2_MAX_FILTERS; ++i) {
+    if (schunk->filters[i] == BLOSC_DELTA) {
+      return schunk_get_sparse_getitem(schunk, ncoords, coords, buffer);
+    }
+  }
+  if (schunk->dctx != NULL && schunk->dctx->postfilter != NULL) {
+    return schunk_get_sparse_getitem(schunk, ncoords, coords, buffer);
+  }
+  if (ncoords <= 1) {
+    return schunk_get_sparse_getitem(schunk, ncoords, coords, buffer);
+  }
+
+  int rc = BLOSC2_ERROR_SUCCESS;
+  int64_t nitems = schunk->nbytes / schunk->typesize;
+  int64_t chunk_nitems = schunk->chunksize / schunk->typesize;
+  sparse_coord_entry *entries = NULL;
+  sparse_block_task *tasks = NULL;
+  sparse_chunk_entry *chunks = NULL;
+  sparse_worker *workers = NULL;
+  int16_t nthreads = 1;
+  int64_t ntasks = 0;
+  int64_t nchunks = 0;
+  sparse_work work;
+  memset(&work, 0, sizeof(work));
+
+  if (chunk_nitems <= 0 || chunk_nitems > INT32_MAX) {
+    BLOSC_TRACE_ERROR("Invalid chunk item count.");
+    return BLOSC2_ERROR_INVALID_PARAM;
+  }
+
+  entries = calloc((size_t)ncoords, sizeof(sparse_coord_entry));
+  if (entries == NULL) {
+    rc = BLOSC2_ERROR_MEMORY_ALLOC;
+    goto cleanup;
+  }
+
+  for (int64_t i = 0; i < ncoords; ++i) {
+    int64_t coord = coords[i];
+    if (coord < 0 || coord >= nitems) {
+      BLOSC_TRACE_ERROR("Coordinate out of bounds.");
+      rc = BLOSC2_ERROR_INVALID_PARAM;
+      goto cleanup;
+    }
+    entries[i].coord = coord;
+    entries[i].out_index = i;
+  }
+
+  qsort(entries, (size_t)ncoords, sizeof(sparse_coord_entry), sparse_coord_entry_cmp);
+
+  /* First pass over sorted entries: count touched chunks and selected block tasks. */
+  for (int64_t i = 0; i < ncoords;) {
+    int64_t nchunk = entries[i].coord / chunk_nitems;
+    ++nchunks;
+    while (i < ncoords && entries[i].coord / chunk_nitems == nchunk) {
+      int64_t item_in_chunk = entries[i].coord % chunk_nitems;
+      int64_t byte_in_chunk = item_in_chunk * schunk->typesize;
+      int32_t nblock = (int32_t)(byte_in_chunk / schunk->blocksize);
+      while (i < ncoords &&
+             entries[i].coord / chunk_nitems == nchunk &&
+             (int32_t)(((entries[i].coord % chunk_nitems) * schunk->typesize) / schunk->blocksize) == nblock) {
+        ++i;
+      }
+      ++ntasks;
+    }
+  }
+
+  tasks = calloc((size_t)ntasks, sizeof(sparse_block_task));
+  chunks = calloc((size_t)nchunks, sizeof(sparse_chunk_entry));
+  if (tasks == NULL || chunks == NULL) {
+    rc = BLOSC2_ERROR_MEMORY_ALLOC;
+    goto cleanup;
+  }
+
+  /* Second pass: fetch touched chunks and build one task per selected block. */
+  int64_t chunk_index = 0;
+  int64_t task_index = 0;
+  for (int64_t i = 0; i < ncoords;) {
+    int64_t nchunk = entries[i].coord / chunk_nitems;
+    uint8_t *chunk = NULL;
+    bool needs_free = false;
+    int cbytes = blosc2_schunk_get_lazychunk(schunk, nchunk, &chunk, &needs_free);
+    if (cbytes <= 0) {
+      BLOSC_TRACE_ERROR("Cannot get lazychunk ('%" PRId64 "').", nchunk);
+      rc = BLOSC2_ERROR_FAILURE;
+      goto cleanup;
+    }
+    chunks[chunk_index].nchunk = nchunk;
+    chunks[chunk_index].chunk = chunk;
+    chunks[chunk_index].cbytes = cbytes;
+    chunks[chunk_index].needs_free = needs_free;
+
+    while (i < ncoords && entries[i].coord / chunk_nitems == nchunk) {
+      int64_t item_in_chunk = entries[i].coord % chunk_nitems;
+      int64_t byte_in_chunk = item_in_chunk * schunk->typesize;
+      int32_t nblock = (int32_t)(byte_in_chunk / schunk->blocksize);
+      int64_t first = i;
+      while (i < ncoords &&
+             entries[i].coord / chunk_nitems == nchunk &&
+             (int32_t)(((entries[i].coord % chunk_nitems) * schunk->typesize) / schunk->blocksize) == nblock) {
+        ++i;
+      }
+      tasks[task_index].first = first;
+      tasks[task_index].count = i - first;
+      tasks[task_index].chunk_index = chunk_index;
+      tasks[task_index].nblock = nblock;
+      ++task_index;
+    }
+    ++chunk_index;
+  }
+
+  nthreads = schunk->dctx != NULL ? schunk->dctx->nthreads : blosc2_get_nthreads();
+  if (nthreads < 1) {
+    nthreads = 1;
+  }
+  if ((int64_t)nthreads > ntasks) {
+    nthreads = (int16_t)ntasks;
+  }
+
+  workers = calloc((size_t)nthreads, sizeof(sparse_worker));
+  if (workers == NULL) {
+    rc = BLOSC2_ERROR_MEMORY_ALLOC;
+    goto cleanup;
+  }
+
+  work.entries = entries;
+  work.tasks = tasks;
+  work.chunks = chunks;
+  work.ntasks = ntasks;
+  work.buffer = (uint8_t *)buffer;
+  work.typesize = schunk->typesize;
+  work.blocksize = schunk->blocksize;
+  work.chunk_nitems = chunk_nitems;
+  work.next_task = 0;
+  work.error = 0;
+  blosc2_pthread_mutex_init(&work.mutex, NULL);
+
+  for (int16_t i = 0; i < nthreads; ++i) {
+    blosc2_dparams dparams = BLOSC2_DPARAMS_DEFAULTS;
+    dparams.nthreads = 1;
+    dparams.schunk = schunk;
+    workers[i].work = &work;
+    workers[i].dctx = blosc2_create_dctx(dparams);
+    workers[i].block = malloc((size_t)schunk->blocksize);
+    if (workers[i].dctx == NULL || workers[i].block == NULL) {
+      rc = BLOSC2_ERROR_MEMORY_ALLOC;
+      goto cleanup_work_mutex;
+    }
+  }
+
+  if (nthreads == 1) {
+    sparse_worker_func(&workers[0]);
+  }
+  else {
+    int err = blosc2_run_parallel(nthreads, sparse_worker_func, sizeof(sparse_worker), workers);
+    if (err < 0) {
+      sparse_work_set_error(&work, err);
+    }
+  }
+
+  if (work.error < 0) {
+    rc = work.error;
+  }
+
+cleanup_work_mutex:
+  blosc2_pthread_mutex_destroy(&work.mutex);
+cleanup:
+  if (workers != NULL) {
+    int16_t nworkers = nthreads > 0 ? nthreads : 1;
+    for (int16_t i = 0; i < nworkers; ++i) {
+      if (workers[i].dctx != NULL) {
+        blosc2_free_ctx(workers[i].dctx);
+      }
+      free(workers[i].block);
+    }
+  }
+  if (chunks != NULL) {
+    for (int64_t i = 0; i < nchunks; ++i) {
+      if (chunks[i].needs_free) {
+        free(chunks[i].chunk);
+      }
+    }
+  }
+  free(workers);
+  free(chunks);
+  free(tasks);
+  free(entries);
+
+  return rc;
 }
 
 

--- a/blosc/schunk.c
+++ b/blosc/schunk.c
@@ -1634,7 +1634,7 @@ static int schunk_get_sparse_getitem(blosc2_schunk *schunk, int64_t ncoords, con
   return BLOSC2_ERROR_SUCCESS;
 }
 
-int blosc2_schunk_get_sparse_coords(blosc2_schunk *schunk, int64_t ncoords, const int64_t* coords, void *buffer) {
+int blosc2_schunk_get_sparse_buffer(blosc2_schunk *schunk, int64_t ncoords, const int64_t* coords, void *buffer) {
   if (schunk == NULL) {
     BLOSC_TRACE_ERROR("schunk must not be NULL.");
     return BLOSC2_ERROR_INVALID_PARAM;

--- a/blosc/schunk.c
+++ b/blosc/schunk.c
@@ -1634,7 +1634,7 @@ static int schunk_get_sparse_getitem(blosc2_schunk *schunk, int64_t ncoords, con
   return BLOSC2_ERROR_SUCCESS;
 }
 
-int blosc2_schunk_get_sparse(blosc2_schunk *schunk, int64_t ncoords, const int64_t* coords, void *buffer) {
+int blosc2_schunk_get_sparse_coords(blosc2_schunk *schunk, int64_t ncoords, const int64_t* coords, void *buffer) {
   if (schunk == NULL) {
     BLOSC_TRACE_ERROR("schunk must not be NULL.");
     return BLOSC2_ERROR_INVALID_PARAM;

--- a/include/b2nd.h
+++ b/include/b2nd.h
@@ -336,21 +336,29 @@ BLOSC_EXPORT int b2nd_from_cbuffer(b2nd_context_t *ctx, b2nd_array_t **array, co
 BLOSC_EXPORT int b2nd_to_cbuffer(const b2nd_array_t *array, void *buffer, int64_t buffersize);
 
 /**
- * @brief Gather items from a b2nd array by flat logical coordinates.
+ * @brief Gather items from a b2nd array of any dimensionality by flat logical coordinates.
  *
- * Coordinates are expressed in the logical, C-order flattened b2nd array domain
- * (that is, in the range ``[0, array->nitems)``), not in the padded SChunk
- * storage domain.  The function translates logical coordinates to the padded
- * storage coordinates used internally by b2nd and then gathers the requested
- * items into ``buffer`` in the same order as ``coords``.  Repeated and unsorted
- * coordinates are allowed.
+ * Fully supports arrays of any number of dimensions (1-D, 2-D, ... N-D).
+ * Regardless of the array's dimensionality, every element is addressed by a
+ * single flat, C-order logical index in the range ``[0, array->nitems)``
+ * -- the same linearisation used by ``b2nd_from_cbuffer`` / ``b2nd_to_cbuffer``.
+ * For example, element ``(i, j)`` of a 2-D array with shape ``(R, C)`` has
+ * flat index ``i * C + j``; element ``(i, j, k)`` of a 3-D array with shape
+ * ``(A, B, C)`` has flat index ``i * B * C + j * C + k``; and so on for
+ * higher dimensions.
  *
- * This is a low-level sparse gather primitive.  It is most useful for 1-D fancy
+ * The function translates each flat logical coordinate to the padded storage
+ * coordinate used internally by b2nd (chunk → block → item within block) and
+ * then gathers the requested items into ``buffer`` in the same order as
+ * ``coords``.  Repeated and unsorted coordinates are allowed.
+ *
+ * This is a low-level sparse gather primitive.  It is most useful for fancy
  * indexing and as a building block for higher-level ``take`` operations.
  *
- * @param array The source b2nd array.
+ * @param array The source b2nd array (any ndim).
  * @param ncoords Number of coordinates to gather.  May be zero.
- * @param coords Flat logical coordinates.  Must not be NULL when ``ncoords > 0``.
+ * @param coords Flat C-order logical coordinates in ``[0, array->nitems)``.
+ *               Must not be NULL when ``ncoords > 0``.
  * @param buffer Destination buffer.  Must have room for at least
  *               ``ncoords * array->sc->typesize`` bytes and must not be NULL
  *               when ``ncoords > 0``.
@@ -361,21 +369,6 @@ BLOSC_EXPORT int b2nd_to_cbuffer(const b2nd_array_t *array, void *buffer, int64_
 BLOSC_EXPORT int b2nd_get_sparse_cbuffer(const b2nd_array_t *array, int64_t ncoords,
                                          const int64_t *coords, void *buffer, int64_t buffersize);
 
-/**
- * @brief Gather items from a b2nd array by flat logical coordinates.
- *
- * Convenience wrapper around #b2nd_get_sparse_cbuffer for callers that already
- * know ``buffer`` has room for at least ``ncoords * array->sc->typesize`` bytes.
- *
- * @param array The source b2nd array.
- * @param ncoords Number of coordinates to gather.  May be zero.
- * @param coords Flat logical coordinates.  Must not be NULL when ``ncoords > 0``.
- * @param buffer Destination buffer.  Must not be NULL when ``ncoords > 0``.
- *
- * @return A non-negative value on success, a negative error code otherwise.
- */
-BLOSC_EXPORT int b2nd_get_sparse_coords(const b2nd_array_t *array, int64_t ncoords,
-                                        const int64_t *coords, void *buffer);
 
 /**
  * @brief Get a slice from an array and store it into a new array.

--- a/include/b2nd.h
+++ b/include/b2nd.h
@@ -336,6 +336,48 @@ BLOSC_EXPORT int b2nd_from_cbuffer(b2nd_context_t *ctx, b2nd_array_t **array, co
 BLOSC_EXPORT int b2nd_to_cbuffer(const b2nd_array_t *array, void *buffer, int64_t buffersize);
 
 /**
+ * @brief Gather items from a b2nd array by flat logical coordinates.
+ *
+ * Coordinates are expressed in the logical, C-order flattened b2nd array domain
+ * (that is, in the range ``[0, array->nitems)``), not in the padded SChunk
+ * storage domain.  The function translates logical coordinates to the padded
+ * storage coordinates used internally by b2nd and then gathers the requested
+ * items into ``buffer`` in the same order as ``coords``.  Repeated and unsorted
+ * coordinates are allowed.
+ *
+ * This is a low-level sparse gather primitive.  It is most useful for 1-D fancy
+ * indexing and as a building block for higher-level ``take`` operations.
+ *
+ * @param array The source b2nd array.
+ * @param ncoords Number of coordinates to gather.  May be zero.
+ * @param coords Flat logical coordinates.  Must not be NULL when ``ncoords > 0``.
+ * @param buffer Destination buffer.  Must have room for at least
+ *               ``ncoords * array->sc->typesize`` bytes and must not be NULL
+ *               when ``ncoords > 0``.
+ * @param buffersize Destination buffer size in bytes.
+ *
+ * @return A non-negative value on success, a negative error code otherwise.
+ */
+BLOSC_EXPORT int b2nd_get_sparse_cbuffer(const b2nd_array_t *array, int64_t ncoords,
+                                         const int64_t *coords, void *buffer, int64_t buffersize);
+
+/**
+ * @brief Gather items from a b2nd array by flat logical coordinates.
+ *
+ * Convenience wrapper around #b2nd_get_sparse_cbuffer for callers that already
+ * know ``buffer`` has room for at least ``ncoords * array->sc->typesize`` bytes.
+ *
+ * @param array The source b2nd array.
+ * @param ncoords Number of coordinates to gather.  May be zero.
+ * @param coords Flat logical coordinates.  Must not be NULL when ``ncoords > 0``.
+ * @param buffer Destination buffer.  Must not be NULL when ``ncoords > 0``.
+ *
+ * @return A non-negative value on success, a negative error code otherwise.
+ */
+BLOSC_EXPORT int b2nd_get_sparse(const b2nd_array_t *array, int64_t ncoords,
+                                 const int64_t *coords, void *buffer);
+
+/**
  * @brief Get a slice from an array and store it into a new array.
  *
  * @param ctx The b2nd context for the new array.

--- a/include/b2nd.h
+++ b/include/b2nd.h
@@ -374,8 +374,8 @@ BLOSC_EXPORT int b2nd_get_sparse_cbuffer(const b2nd_array_t *array, int64_t ncoo
  *
  * @return A non-negative value on success, a negative error code otherwise.
  */
-BLOSC_EXPORT int b2nd_get_sparse(const b2nd_array_t *array, int64_t ncoords,
-                                 const int64_t *coords, void *buffer);
+BLOSC_EXPORT int b2nd_get_sparse_coords(const b2nd_array_t *array, int64_t ncoords,
+                                        const int64_t *coords, void *buffer);
 
 /**
  * @brief Get a slice from an array and store it into a new array.

--- a/include/blosc2.h
+++ b/include/blosc2.h
@@ -2159,6 +2159,21 @@ BLOSC_EXPORT int blosc2_schunk_get_vlblock(blosc2_schunk *schunk, int64_t nchunk
 BLOSC_EXPORT int blosc2_schunk_get_slice_buffer(blosc2_schunk *schunk, int64_t start, int64_t stop, void *buffer);
 
 /**
+ * @brief Fill buffer with elements from coords in schunk.
+ *
+ * @param schunk The super-chunk from where to extract elements.
+ * @param ncoords The number of coordinates.
+ * @param coords The coordinates of the elements to be extracted.
+ * @param buffer The buffer where the data will be stored.
+ *
+ * @warning You must make sure that you have enough space in buffer to store the
+ * uncompressed data.
+ *
+ * @return An error code.
+ */
+BLOSC_EXPORT int blosc2_schunk_get_sparse(blosc2_schunk *schunk, int64_t ncoords, const int64_t* coords, void *buffer);
+
+/**
  * @brief Update a schunk slice from buffer.
  *
  * @param schunk The super-chunk where to set the slice.

--- a/include/blosc2.h
+++ b/include/blosc2.h
@@ -2171,7 +2171,8 @@ BLOSC_EXPORT int blosc2_schunk_get_slice_buffer(blosc2_schunk *schunk, int64_t s
  *
  * @return An error code.
  */
-BLOSC_EXPORT int blosc2_schunk_get_sparse(blosc2_schunk *schunk, int64_t ncoords, const int64_t* coords, void *buffer);
+BLOSC_EXPORT int blosc2_schunk_get_sparse_coords(blosc2_schunk *schunk, int64_t ncoords,
+                                                 const int64_t* coords, void *buffer);
 
 /**
  * @brief Update a schunk slice from buffer.

--- a/include/blosc2.h
+++ b/include/blosc2.h
@@ -2159,7 +2159,7 @@ BLOSC_EXPORT int blosc2_schunk_get_vlblock(blosc2_schunk *schunk, int64_t nchunk
 BLOSC_EXPORT int blosc2_schunk_get_slice_buffer(blosc2_schunk *schunk, int64_t start, int64_t stop, void *buffer);
 
 /**
- * @brief Fill buffer with elements from coords in schunk.
+ * @brief Fill buffer with elements at the given coordinates from a schunk.
  *
  * @param schunk The super-chunk from where to extract elements.
  * @param ncoords The number of coordinates.
@@ -2171,7 +2171,7 @@ BLOSC_EXPORT int blosc2_schunk_get_slice_buffer(blosc2_schunk *schunk, int64_t s
  *
  * @return An error code.
  */
-BLOSC_EXPORT int blosc2_schunk_get_sparse_coords(blosc2_schunk *schunk, int64_t ncoords,
+BLOSC_EXPORT int blosc2_schunk_get_sparse_buffer(blosc2_schunk *schunk, int64_t ncoords,
                                                  const int64_t* coords, void *buffer);
 
 /**

--- a/tests/b2nd/test_b2nd_get_sparse.c
+++ b/tests/b2nd/test_b2nd_get_sparse.c
@@ -1,0 +1,136 @@
+/*********************************************************************
+  Blosc - Blocked Shuffling and Compression Library
+
+  Copyright (c) 2026  Blosc Development Team <blosc@blosc.org>
+  https://blosc.org
+  License: BSD 3-Clause (see LICENSE.txt)
+
+  See LICENSE.txt for details about copyright and rights to use.
+**********************************************************************/
+
+#include "test_common.h"
+
+
+typedef struct {
+  int32_t a;
+  int32_t b;
+} pair_t;
+
+static int check_pair_selection(b2nd_array_t *array, const pair_t *src,
+                                const int64_t *coords, int64_t ncoords) {
+  pair_t *out = calloc((size_t)ncoords, sizeof(pair_t));
+  CUTEST_ASSERT("Allocation failed", out != NULL);
+  B2ND_TEST_ASSERT(b2nd_get_sparse_cbuffer(array, ncoords, coords, out,
+                                           ncoords * (int64_t)sizeof(pair_t)));
+  for (int64_t i = 0; i < ncoords; ++i) {
+    CUTEST_ASSERT("Field a mismatch", out[i].a == src[coords[i]].a);
+    CUTEST_ASSERT("Field b mismatch", out[i].b == src[coords[i]].b);
+  }
+  free(out);
+  return 0;
+}
+
+static int check_1d_non_behaved(void) {
+  const int8_t ndim = 1;
+  const int64_t shape[] = {100};
+  const int32_t chunkshape[] = {44};
+  const int32_t blockshape[] = {33};
+
+  pair_t src[100];
+  for (int64_t i = 0; i < 100; ++i) {
+    src[i].a = (int32_t)(i + 1);
+    src[i].b = (int32_t)(200 - i);
+  }
+
+  blosc2_cparams cparams = BLOSC2_CPARAMS_DEFAULTS;
+  cparams.typesize = sizeof(pair_t);
+  cparams.nthreads = 1;
+  blosc2_dparams dparams = BLOSC2_DPARAMS_DEFAULTS;
+  dparams.nthreads = 1;
+  blosc2_storage storage = BLOSC2_STORAGE_DEFAULTS;
+  storage.cparams = &cparams;
+  storage.dparams = &dparams;
+
+  b2nd_context_t *ctx = b2nd_create_ctx(&storage, ndim, shape, chunkshape, blockshape,
+                                        NULL, 0, NULL, 0);
+  CUTEST_ASSERT("Could not create context", ctx != NULL);
+  b2nd_array_t *array = NULL;
+  B2ND_TEST_ASSERT(b2nd_from_cbuffer(ctx, &array, src, sizeof(src)));
+
+  int64_t sorted[98];
+  for (int64_t i = 0; i < 98; ++i) {
+    sorted[i] = i + 2;
+  }
+  check_pair_selection(array, src, sorted, 98);
+
+  int64_t reversed[98];
+  for (int64_t i = 0; i < 98; ++i) {
+    reversed[i] = 99 - i;
+  }
+  check_pair_selection(array, src, reversed, 98);
+
+  const int64_t repeated[] = {5, 1, 5, 99, 0, 44, 43};
+  check_pair_selection(array, src, repeated, 7);
+
+  b2nd_free(array);
+  b2nd_free_ctx(ctx);
+  return 0;
+}
+
+static int check_2d_flat_logical_coords(void) {
+  const int8_t ndim = 2;
+  const int64_t shape[] = {6, 7};
+  const int32_t chunkshape[] = {4, 5};
+  const int32_t blockshape[] = {3, 4};
+  const int64_t nitems = shape[0] * shape[1];
+
+  int32_t src[42];
+  for (int64_t i = 0; i < nitems; ++i) {
+    src[i] = (int32_t)(i + 10);
+  }
+
+  blosc2_cparams cparams = BLOSC2_CPARAMS_DEFAULTS;
+  cparams.typesize = sizeof(int32_t);
+  cparams.nthreads = 1;
+  blosc2_dparams dparams = BLOSC2_DPARAMS_DEFAULTS;
+  dparams.nthreads = 1;
+  blosc2_storage storage = BLOSC2_STORAGE_DEFAULTS;
+  storage.cparams = &cparams;
+  storage.dparams = &dparams;
+
+  b2nd_context_t *ctx = b2nd_create_ctx(&storage, ndim, shape, chunkshape, blockshape,
+                                        NULL, 0, NULL, 0);
+  CUTEST_ASSERT("Could not create context", ctx != NULL);
+  b2nd_array_t *array = NULL;
+  B2ND_TEST_ASSERT(b2nd_from_cbuffer(ctx, &array, src, nitems * (int64_t)sizeof(int32_t)));
+
+  const int64_t coords[] = {0, 6, 7, 13, 20, 41, 20, 5};
+  const int64_t ncoords = (int64_t)(sizeof(coords) / sizeof(coords[0]));
+  int32_t out[8] = {0};
+  B2ND_TEST_ASSERT(b2nd_get_sparse_cbuffer(array, ncoords, coords, out, sizeof(out)));
+  for (int64_t i = 0; i < ncoords; ++i) {
+    CUTEST_ASSERT("2-D sparse value mismatch", out[i] == src[coords[i]]);
+  }
+
+  b2nd_free(array);
+  b2nd_free_ctx(ctx);
+  return 0;
+}
+
+CUTEST_TEST_SETUP(get_sparse) {
+  blosc2_init();
+}
+
+CUTEST_TEST_TEST(get_sparse) {
+  CUTEST_ASSERT("1-D sparse check failed", check_1d_non_behaved() == 0);
+  CUTEST_ASSERT("2-D sparse check failed", check_2d_flat_logical_coords() == 0);
+  return 0;
+}
+
+CUTEST_TEST_TEARDOWN(get_sparse) {
+  blosc2_destroy();
+}
+
+int main() {
+  CUTEST_TEST_RUN(get_sparse);
+}

--- a/tests/b2nd/test_b2nd_get_sparse.c
+++ b/tests/b2nd/test_b2nd_get_sparse.c
@@ -117,6 +117,59 @@ static int check_2d_flat_logical_coords(void) {
   return 0;
 }
 
+static int check_4d_flat_logical_coords(void) {
+  /* shape 3×4×5×6 = 360 items; C-order strides are {120, 30, 6, 1}.
+   * chunkshape 2×3×4×5 and blockshape 2×2×3×4 are chosen so that several
+   * of the probed coordinates fall in different chunks AND different blocks,
+   * exercising the full multi-dimensional address translation. */
+  const int8_t ndim = 4;
+  const int64_t shape[]      = {3, 4, 5, 6};
+  const int32_t chunkshape[] = {2, 3, 4, 5};
+  const int32_t blockshape[] = {2, 2, 3, 4};
+  const int64_t nitems = 3 * 4 * 5 * 6;  /* 360 */
+
+  int32_t src[360];
+  for (int64_t i = 0; i < nitems; ++i) {
+    src[i] = (int32_t)(i + 1);
+  }
+
+  blosc2_cparams cparams = BLOSC2_CPARAMS_DEFAULTS;
+  cparams.typesize = sizeof(int32_t);
+  cparams.nthreads = 1;
+  blosc2_dparams dparams = BLOSC2_DPARAMS_DEFAULTS;
+  dparams.nthreads = 1;
+  blosc2_storage storage = BLOSC2_STORAGE_DEFAULTS;
+  storage.cparams = &cparams;
+  storage.dparams = &dparams;
+
+  b2nd_context_t *ctx = b2nd_create_ctx(&storage, ndim, shape, chunkshape, blockshape,
+                                        NULL, 0, NULL, 0);
+  CUTEST_ASSERT("Could not create context", ctx != NULL);
+  b2nd_array_t *array = NULL;
+  B2ND_TEST_ASSERT(b2nd_from_cbuffer(ctx, &array, src, nitems * (int64_t)sizeof(int32_t)));
+
+  /* Flat coords and their expected (i0,i1,i2,i3) for documentation:
+   *   0   -> (0,0,0,0)  first element
+   *   359 -> (2,3,4,5)  last element
+   *   202 -> (1,2,3,4)  mid-array, crosses chunk & block boundaries
+   *   120 -> (1,0,0,0)  first element of second "row" in dim-0
+   *   35  -> (0,1,0,5)  crosses a chunk boundary in dim-1
+   *   210 -> (1,3,0,0)  corner of a chunk in dims 1-3
+   *   202 repeated to verify repeated coords are handled correctly */
+  const int64_t coords[] = {0, 359, 202, 120, 35, 210, 202};
+  const int64_t ncoords = (int64_t)(sizeof(coords) / sizeof(coords[0]));
+  int32_t out[7] = {0};
+  B2ND_TEST_ASSERT(b2nd_get_sparse_cbuffer(array, ncoords, coords, out, sizeof(out)));
+  for (int64_t i = 0; i < ncoords; ++i) {
+    CUTEST_ASSERT("4-D sparse value mismatch", out[i] == src[coords[i]]);
+  }
+
+  b2nd_free(array);
+  b2nd_free_ctx(ctx);
+  return 0;
+}
+
+
 CUTEST_TEST_SETUP(get_sparse) {
   blosc2_init();
 }
@@ -124,6 +177,7 @@ CUTEST_TEST_SETUP(get_sparse) {
 CUTEST_TEST_TEST(get_sparse) {
   CUTEST_ASSERT("1-D sparse check failed", check_1d_non_behaved() == 0);
   CUTEST_ASSERT("2-D sparse check failed", check_2d_flat_logical_coords() == 0);
+  CUTEST_ASSERT("4-D sparse check failed", check_4d_flat_logical_coords() == 0);
   return 0;
 }
 


### PR DESCRIPTION
This adds two new functions:

```
int blosc2_schunk_get_sparse_buffer(blosc2_schunk *schunk, int64_t ncoords, const int64_t* coords, void *buffer);
int b2nd_get_sparse_cbuffer(const b2nd_array_t *array, int64_t ncoords, const int64_t *coords, void *buffer, int64_t buffersize);
```

that allows to get a set of sparse coordinates into a buffer.

It is very efficient, as it can decompress blocks in parallel, even if in different chunks.  See this small bench:

```
faltet@Mac-mini-de-Francesc ~/b/c/build (get-sparse)> bench/get_sparse                                                                                        (base)
Read 100 random coordinates from bench/sin-1d.b2nd (4 threads)
First 10 retrieved elements:
  coord[0] = 7268094, value = 0.291540831
  coord[1] = 7397386, value = 0.296689749
  coord[2] = 17061456, value = 0.640304029
  coord[3] = 17020819, value = 0.639002562
  coord[4] = 13256959, value = 0.514456153
  coord[5] = 11830938, value = 0.463513047
  coord[6] = 17450754, value = 0.651920795
  coord[7] = 19701906, value = 0.718687415
  coord[8] = 10697444, value = 0.42206946
  coord[9] = 8429253, value = 0.336519986
getitem_sparse: 0.010102062 s
new_sparse:     0.002997918 s
```

In this case, a 3x speedup has been achieved, but larger arrays/coords can lead to larger accelerations.