### PR TITLE
Validate NDLZ decompression input references

### DIFF
--- a/plugins/codecs/ndlz/ndlz4x4.c
+++ b/plugins/codecs/ndlz/ndlz4x4.c
@@ -530,6 +530,23 @@ int ndlz4_decompress(const uint8_t *input, int32_t input_len, uint8_t *output, i
     return 0;
   }
 
+  // Reject any read whose range [p, p + n) falls outside the compressed input
+  // buffer [input, ip_limit).  A crafted token `offset` otherwise makes the
+  // back-reference `buffercpy` (and the `ip - offset` reads below) point before
+  // `input`, and the cell-fill memcpy then leaks out-of-bounds heap memory into
+  // the (attacker-visible) output buffer -- CWE-125.  The per-cell `ip > ip_limit`
+  // check is not enough because each cell reads a 2-byte offset and literal bytes
+  // past that point.  Mirrors the `ref - 1 < output` guard used by core blosclz.
+#define NDLZ4_CHECK_RANGE(p, n)                                                  \
+  do {                                                                           \
+    const uint8_t *_p = (const uint8_t *) (p);                                   \
+    int64_t _n = (int64_t) (n);                                                  \
+    if (_n < 0 || _p < (const uint8_t *) input || _p > ip_limit - _n) {          \
+      BLOSC_TRACE_ERROR("ndlz4: out-of-bounds reference in compressed stream");  \
+      return BLOSC2_ERROR_FAILURE;                                               \
+    }                                                                            \
+  } while (0)
+
   /* we start with literal copy */
   ndim = *ip;
   ip++;
@@ -583,20 +600,26 @@ int ndlz4_decompress(const uint8_t *input, int32_t input_len, uint8_t *output, i
       } else {
         padding[1] = 4;
       }
+      NDLZ4_CHECK_RANGE(ip, 1);
       token = *ip++;
       if (token == 0) {    // no match
         buffercpy = ip;
         ip += padding[0] * padding[1];
+        NDLZ4_CHECK_RANGE(buffercpy, (int64_t) padding[0] * padding[1]);
       } else if (token == (uint8_t) ((1U << 7U) | (1U << 6U))) {  // cell match
+        NDLZ4_CHECK_RANGE(ip, 2);
         uint16_t offset = *((uint16_t *) ip);
         buffercpy = ip - offset - 1;
         ip += 2;
+        NDLZ4_CHECK_RANGE(buffercpy, (int64_t) padding[0] * padding[1]);
       } else if (token == (uint8_t) (1U << 6U)) { // whole cell of same element
+        NDLZ4_CHECK_RANGE(ip, 1);
         buffercpy = cell_aux;
         memset(buffercpy, *ip, 16);
         ip++;
       } else if (token >= 224) { // three rows match
         buffercpy = local_buffer;
+        NDLZ4_CHECK_RANGE(ip, 2);
         uint16_t offset = *((uint16_t *) ip);
         offset += 3;
         ip += 2;
@@ -619,11 +642,13 @@ int ndlz4_decompress(const uint8_t *input, int32_t input_len, uint8_t *output, i
             }
           }
         }
+        NDLZ4_CHECK_RANGE(ip - offset, 12);
         memcpy(&buffercpy[i * 4], ip - offset, 4);
         memcpy(&buffercpy[j * 4], ip - offset + 4, 4);
         memcpy(&buffercpy[k * 4], ip - offset + 8, 4);
         for (int l = 0; l < 4; l++) {
           if ((l != i) && (l != j) && (l != k)) {
+            NDLZ4_CHECK_RANGE(ip, 4);
             memcpy(&buffercpy[l * 4], ip, 4);
             ip += 4;
             break;
@@ -632,6 +657,7 @@ int ndlz4_decompress(const uint8_t *input, int32_t input_len, uint8_t *output, i
 
       } else if ((token >= 128) && (token <= 191)) { // rows pair match
         buffercpy = local_buffer;
+        NDLZ4_CHECK_RANGE(ip, 2);
         uint16_t offset = *((uint16_t *) ip);
         offset += 3;
         ip += 2;
@@ -643,19 +669,23 @@ int ndlz4_decompress(const uint8_t *input, int32_t input_len, uint8_t *output, i
           i = (token - 128) >> 5U;
           j = ((token - 128) >> 3U) - (i << 2U);
         }
+        NDLZ4_CHECK_RANGE(ip - offset, 8);
         memcpy(&buffercpy[i * 4], ip - offset, 4);
         memcpy(&buffercpy[j * 4], ip - offset + 4, 4);
         for (int k = 0; k < 4; k++) {
           if ((k != i) && (k != j)) {
+            NDLZ4_CHECK_RANGE(ip, 4);
             memcpy(&buffercpy[k * 4], ip, 4);
             ip += 4;
           }
         }
       } else if ((token >= 40) && (token <= 63)) {  // 2 rows pair matches
         buffercpy = local_buffer;
+        NDLZ4_CHECK_RANGE(ip, 2);
         uint16_t offset_1 = *((uint16_t *) ip);
         offset_1 += 5;
         ip += 2;
+        NDLZ4_CHECK_RANGE(ip, 2);
         uint16_t offset_2 = *((uint16_t *) ip);
         offset_2 += 5;
         ip += 2;
@@ -672,8 +702,10 @@ int ndlz4_decompress(const uint8_t *input, int32_t input_len, uint8_t *output, i
             }
           }
         }
+        NDLZ4_CHECK_RANGE(ip - offset_1, 8);
         memcpy(&buffercpy[i * 4], ip - offset_1, 4);
         memcpy(&buffercpy[j * 4], ip - offset_1 + 4, 4);
+        NDLZ4_CHECK_RANGE(ip - offset_2, 8);
         memcpy(&buffercpy[l * 4], ip - offset_2, 4);
         memcpy(&buffercpy[m * 4], ip - offset_2 + 4, 4);
 
@@ -708,4 +740,5 @@ int ndlz4_decompress(const uint8_t *input, int32_t input_len, uint8_t *output, i
   }
 
   return (int) ind;
+#undef NDLZ4_CHECK_RANGE
 }

--- a/plugins/codecs/ndlz/ndlz4x4.c
+++ b/plugins/codecs/ndlz/ndlz4x4.c
@@ -518,7 +518,6 @@ int ndlz4_decompress(const uint8_t *input, int32_t input_len, uint8_t *output, i
   BLOSC_ERROR_NULL(output, BLOSC2_ERROR_NULL_POINTER);
 
   uint8_t *ip = (uint8_t *) input;
-  uint8_t *ip_limit = ip + input_len;
   uint8_t *op = (uint8_t *) output;
   uint8_t ndim;
   int32_t blockshape[2];
@@ -526,9 +525,15 @@ int ndlz4_decompress(const uint8_t *input, int32_t input_len, uint8_t *output, i
   uint8_t *buffercpy;
   uint8_t local_buffer[16];
   uint8_t token;
-  if (NDLZ_UNEXPECT_CONDITIONAL(input_len < 8)) {
+  // The fixed header is 1 (ndim) + 2 * int32 (blockshape) = 9 bytes.  Reject any
+  // input too short to hold it -- the previous `< 8` check let an 8-byte input
+  // through and the header parse below then read a 9th byte.  The cast keeps the
+  // comparison signed so a negative `input_len` is rejected here, before the
+  // `ip + input_len` pointer arithmetic (which would otherwise be UB) is reached.
+  if (NDLZ_UNEXPECT_CONDITIONAL(input_len < (int32_t) (1 + 2 * sizeof(int32_t)))) {
     return 0;
   }
+  uint8_t *ip_limit = ip + input_len;
 
   // Validate that a read of `len` bytes starting at byte offset `pos` (measured
   // from the start of `input`) lies fully within the compressed buffer.  A

--- a/plugins/codecs/ndlz/ndlz4x4.c
+++ b/plugins/codecs/ndlz/ndlz4x4.c
@@ -530,18 +530,20 @@ int ndlz4_decompress(const uint8_t *input, int32_t input_len, uint8_t *output, i
     return 0;
   }
 
-  // Reject any read whose range [p, p + n) falls outside the compressed input
-  // buffer [input, ip_limit).  A crafted token `offset` otherwise makes the
-  // back-reference `buffercpy` (and the `ip - offset` reads below) point before
+  // Validate that a read of `len` bytes starting at byte offset `pos` (measured
+  // from the start of `input`) lies fully within the compressed buffer.  A
+  // crafted token `offset` otherwise makes a back-reference point before
   // `input`, and the cell-fill memcpy then leaks out-of-bounds heap memory into
   // the (attacker-visible) output buffer -- CWE-125.  The per-cell `ip > ip_limit`
   // check is not enough because each cell reads a 2-byte offset and literal bytes
-  // past that point.  Mirrors the `ref - 1 < output` guard used by core blosclz.
-#define NDLZ4_CHECK_RANGE(p, n)                                                  \
+  // past that point.  All arithmetic is done on integer offsets so we never form
+  // an out-of-bounds pointer (which is undefined behaviour in C, even when the
+  // pointer is only compared and not dereferenced).
+#define NDLZ4_CHECK_RANGE(pos, len)                                              \
   do {                                                                           \
-    const uint8_t *_p = (const uint8_t *) (p);                                   \
-    int64_t _n = (int64_t) (n);                                                  \
-    if (_n < 0 || _p < (const uint8_t *) input || _p > ip_limit - _n) {          \
+    int64_t _pos = (int64_t) (pos);                                              \
+    int64_t _len = (int64_t) (len);                                              \
+    if (_pos < 0 || _len < 0 || _pos > (int64_t) input_len - _len) {             \
       BLOSC_TRACE_ERROR("ndlz4: out-of-bounds reference in compressed stream");  \
       return BLOSC2_ERROR_FAILURE;                                               \
     }                                                                            \
@@ -600,27 +602,31 @@ int ndlz4_decompress(const uint8_t *input, int32_t input_len, uint8_t *output, i
       } else {
         padding[1] = 4;
       }
-      NDLZ4_CHECK_RANGE(ip, 1);
+      int64_t cur = ip - (const uint8_t *) input;   // in-range: ip is within [input, ip_limit]
+      NDLZ4_CHECK_RANGE(cur, 1);
       token = *ip++;
       if (token == 0) {    // no match
+        NDLZ4_CHECK_RANGE(cur + 1, (int64_t) padding[0] * padding[1]);
         buffercpy = ip;
         ip += padding[0] * padding[1];
-        NDLZ4_CHECK_RANGE(buffercpy, (int64_t) padding[0] * padding[1]);
       } else if (token == (uint8_t) ((1U << 7U) | (1U << 6U))) {  // cell match
-        NDLZ4_CHECK_RANGE(ip, 2);
-        uint16_t offset = *((uint16_t *) ip);
-        buffercpy = ip - offset - 1;
+        NDLZ4_CHECK_RANGE(cur + 1, 2);
+        uint16_t offset;
+        memcpy(&offset, ip, sizeof(offset));
+        int64_t bpos = (cur + 1) - (int64_t) offset - 1;   // back-reference start offset
+        NDLZ4_CHECK_RANGE(bpos, (int64_t) padding[0] * padding[1]);
+        buffercpy = (uint8_t *) input + bpos;
         ip += 2;
-        NDLZ4_CHECK_RANGE(buffercpy, (int64_t) padding[0] * padding[1]);
       } else if (token == (uint8_t) (1U << 6U)) { // whole cell of same element
-        NDLZ4_CHECK_RANGE(ip, 1);
+        NDLZ4_CHECK_RANGE(cur + 1, 1);
         buffercpy = cell_aux;
         memset(buffercpy, *ip, 16);
         ip++;
       } else if (token >= 224) { // three rows match
         buffercpy = local_buffer;
-        NDLZ4_CHECK_RANGE(ip, 2);
-        uint16_t offset = *((uint16_t *) ip);
+        NDLZ4_CHECK_RANGE(cur + 1, 2);
+        uint16_t offset;
+        memcpy(&offset, ip, sizeof(offset));
         offset += 3;
         ip += 2;
         int i, j, k;
@@ -642,13 +648,15 @@ int ndlz4_decompress(const uint8_t *input, int32_t input_len, uint8_t *output, i
             }
           }
         }
-        NDLZ4_CHECK_RANGE(ip - offset, 12);
-        memcpy(&buffercpy[i * 4], ip - offset, 4);
-        memcpy(&buffercpy[j * 4], ip - offset + 4, 4);
-        memcpy(&buffercpy[k * 4], ip - offset + 8, 4);
+        int64_t bpos = (cur + 3) - (int64_t) offset;   // == (ip - offset) as an offset
+        NDLZ4_CHECK_RANGE(bpos, 12);
+        const uint8_t *ref = (const uint8_t *) input + bpos;
+        memcpy(&buffercpy[i * 4], ref, 4);
+        memcpy(&buffercpy[j * 4], ref + 4, 4);
+        memcpy(&buffercpy[k * 4], ref + 8, 4);
         for (int l = 0; l < 4; l++) {
           if ((l != i) && (l != j) && (l != k)) {
-            NDLZ4_CHECK_RANGE(ip, 4);
+            NDLZ4_CHECK_RANGE(ip - (const uint8_t *) input, 4);
             memcpy(&buffercpy[l * 4], ip, 4);
             ip += 4;
             break;
@@ -657,8 +665,9 @@ int ndlz4_decompress(const uint8_t *input, int32_t input_len, uint8_t *output, i
 
       } else if ((token >= 128) && (token <= 191)) { // rows pair match
         buffercpy = local_buffer;
-        NDLZ4_CHECK_RANGE(ip, 2);
-        uint16_t offset = *((uint16_t *) ip);
+        NDLZ4_CHECK_RANGE(cur + 1, 2);
+        uint16_t offset;
+        memcpy(&offset, ip, sizeof(offset));
         offset += 3;
         ip += 2;
         int i, j;
@@ -669,24 +678,28 @@ int ndlz4_decompress(const uint8_t *input, int32_t input_len, uint8_t *output, i
           i = (token - 128) >> 5U;
           j = ((token - 128) >> 3U) - (i << 2U);
         }
-        NDLZ4_CHECK_RANGE(ip - offset, 8);
-        memcpy(&buffercpy[i * 4], ip - offset, 4);
-        memcpy(&buffercpy[j * 4], ip - offset + 4, 4);
+        int64_t bpos = (cur + 3) - (int64_t) offset;
+        NDLZ4_CHECK_RANGE(bpos, 8);
+        const uint8_t *ref = (const uint8_t *) input + bpos;
+        memcpy(&buffercpy[i * 4], ref, 4);
+        memcpy(&buffercpy[j * 4], ref + 4, 4);
         for (int k = 0; k < 4; k++) {
           if ((k != i) && (k != j)) {
-            NDLZ4_CHECK_RANGE(ip, 4);
+            NDLZ4_CHECK_RANGE(ip - (const uint8_t *) input, 4);
             memcpy(&buffercpy[k * 4], ip, 4);
             ip += 4;
           }
         }
       } else if ((token >= 40) && (token <= 63)) {  // 2 rows pair matches
         buffercpy = local_buffer;
-        NDLZ4_CHECK_RANGE(ip, 2);
-        uint16_t offset_1 = *((uint16_t *) ip);
+        NDLZ4_CHECK_RANGE(cur + 1, 2);
+        uint16_t offset_1;
+        memcpy(&offset_1, ip, sizeof(offset_1));
         offset_1 += 5;
         ip += 2;
-        NDLZ4_CHECK_RANGE(ip, 2);
-        uint16_t offset_2 = *((uint16_t *) ip);
+        NDLZ4_CHECK_RANGE(cur + 3, 2);
+        uint16_t offset_2;
+        memcpy(&offset_2, ip, sizeof(offset_2));
         offset_2 += 5;
         ip += 2;
         int i, j, k, l, m;
@@ -702,12 +715,16 @@ int ndlz4_decompress(const uint8_t *input, int32_t input_len, uint8_t *output, i
             }
           }
         }
-        NDLZ4_CHECK_RANGE(ip - offset_1, 8);
-        memcpy(&buffercpy[i * 4], ip - offset_1, 4);
-        memcpy(&buffercpy[j * 4], ip - offset_1 + 4, 4);
-        NDLZ4_CHECK_RANGE(ip - offset_2, 8);
-        memcpy(&buffercpy[l * 4], ip - offset_2, 4);
-        memcpy(&buffercpy[m * 4], ip - offset_2 + 4, 4);
+        int64_t bpos1 = (cur + 5) - (int64_t) offset_1;
+        NDLZ4_CHECK_RANGE(bpos1, 8);
+        const uint8_t *ref1 = (const uint8_t *) input + bpos1;
+        memcpy(&buffercpy[i * 4], ref1, 4);
+        memcpy(&buffercpy[j * 4], ref1 + 4, 4);
+        int64_t bpos2 = (cur + 5) - (int64_t) offset_2;
+        NDLZ4_CHECK_RANGE(bpos2, 8);
+        const uint8_t *ref2 = (const uint8_t *) input + bpos2;
+        memcpy(&buffercpy[l * 4], ref2, 4);
+        memcpy(&buffercpy[m * 4], ref2 + 4, 4);
 
       } else {
         BLOSC_TRACE_ERROR("Invalid token: %u at cell [%d, %d]\n", token, ii[0], ii[1]);

--- a/plugins/codecs/ndlz/ndlz4x4.c
+++ b/plugins/codecs/ndlz/ndlz4x4.c
@@ -741,8 +741,13 @@ int ndlz4_decompress(const uint8_t *input, int32_t input_len, uint8_t *output, i
         if (i < padding[0]) {
           ind = orig + i * blockshape[1];
           memcpy(&op[ind], buffercpy, padding[1]);
+          // Only advance over rows we actually consume.  For a literal cell
+          // (token == 0) buffercpy points into the input and only holds
+          // padding[0] * padding[1] bytes; advancing unconditionally for the
+          // trailing padding rows would form an out-of-bounds pointer (UB)
+          // for the block's last cell.  The skipped rows are never read.
+          buffercpy += padding[1];
         }
-        buffercpy += padding[1];
       }
       if (ind > (uint32_t) output_len) {
         BLOSC_TRACE_ERROR("Exceeding output size");

--- a/plugins/codecs/ndlz/ndlz8x8.c
+++ b/plugins/codecs/ndlz/ndlz8x8.c
@@ -486,6 +486,26 @@ int ndlz8_decompress(const uint8_t *input, int32_t input_len, uint8_t *output, i
   int32_t ind = 0;
   uint8_t *local_buffer = malloc(cell_size);
   uint8_t *cell_aux = malloc(cell_size);
+
+  // Reject any read whose range [p, p + n) falls outside the compressed input
+  // buffer [input, ip_limit).  A crafted token `offset` otherwise makes the
+  // back-reference `buffercpy` (and the `ip - ... - offset` reads below) point
+  // before `input`, and the cell-fill memcpy then leaks out-of-bounds heap
+  // memory into the (attacker-visible) output -- CWE-125.  The per-cell
+  // `ip > ip_limit` check is not enough because each cell reads a 2-byte offset
+  // and literal bytes past that point.  Mirrors blosclz's `ref - 1 < output`.
+#define NDLZ8_CHECK_RANGE(p, n)                                                  \
+  do {                                                                           \
+    const uint8_t *_p = (const uint8_t *) (p);                                   \
+    int64_t _n = (int64_t) (n);                                                  \
+    if (_n < 0 || _p < (const uint8_t *) input || _p > ip_limit - _n) {          \
+      free(local_buffer);                                                        \
+      free(cell_aux);                                                            \
+      BLOSC_TRACE_ERROR("ndlz8: out-of-bounds reference in compressed stream");  \
+      return BLOSC2_ERROR_FAILURE;                                               \
+    }                                                                            \
+  } while (0)
+
   for (ii[0] = 0; ii[0] < i_stop[0]; ++ii[0]) {
     for (ii[1] = 0; ii[1] < i_stop[1]; ++ii[1]) {      // for each cell
       if (NDLZ_UNEXPECT_CONDITIONAL(ip > ip_limit)) {
@@ -504,16 +524,21 @@ int ndlz8_decompress(const uint8_t *input, int32_t input_len, uint8_t *output, i
       } else {
         padding[1] = cell_shape;
       }
+      NDLZ8_CHECK_RANGE(ip, 1);
       token = *ip++;
       uint8_t match_type = (token >> 3U);
       if (token == 0) {    // no match
         buffercpy = ip;
         ip += padding[0] * padding[1];
+        NDLZ8_CHECK_RANGE(buffercpy, (int64_t) padding[0] * padding[1]);
       } else if (token == (uint8_t) ((1U << 7U) | (1U << 6U))) {  // cell match
+        NDLZ8_CHECK_RANGE(ip, 2);
         uint16_t offset = *((uint16_t *) ip);
         buffercpy = ip - offset - 1;
         ip += 2;
+        NDLZ8_CHECK_RANGE(buffercpy, (int64_t) padding[0] * padding[1]);
       } else if (token == (uint8_t) (1U << 6U)) { // whole cell of same element
+        NDLZ8_CHECK_RANGE(ip, 1);
         buffercpy = cell_aux;
         memset(buffercpy, *ip, cell_size);
         ip++;
@@ -526,14 +551,17 @@ int ndlz8_decompress(const uint8_t *input, int32_t input_len, uint8_t *output, i
           BLOSC_TRACE_ERROR("Triple match row out of bounds");
           return BLOSC2_ERROR_FAILURE;
         }
+        NDLZ8_CHECK_RANGE(ip, 2);
         uint16_t offset = *((uint16_t *) ip);
         ip += 2;
+        NDLZ8_CHECK_RANGE(ip - sizeof(token) - sizeof(offset) - offset, 3 * cell_shape);
         for (int l = 0; l < 3; l++) {
           memcpy(&buffercpy[(row + l) * cell_shape],
                  ip - sizeof(token) - sizeof(offset) - offset + l * cell_shape, cell_shape);
         }
         for (int l = 0; l < cell_shape; l++) {
           if ((l < row) || (l > row + 2)) {
+            NDLZ8_CHECK_RANGE(ip, cell_shape);
             memcpy(&buffercpy[l * cell_shape], ip, cell_shape);
             ip += cell_shape;
           }
@@ -547,14 +575,17 @@ int ndlz8_decompress(const uint8_t *input, int32_t input_len, uint8_t *output, i
           BLOSC_TRACE_ERROR("Pair match row out of bounds");
           return BLOSC2_ERROR_FAILURE;
         }
+        NDLZ8_CHECK_RANGE(ip, 2);
         uint16_t offset = *((uint16_t *) ip);
         ip += 2;
+        NDLZ8_CHECK_RANGE(ip - sizeof(token) - sizeof(offset) - offset, 2 * cell_shape);
         for (int l = 0; l < 2; l++) {
           memcpy(&buffercpy[(row + l) * cell_shape],
                  ip - sizeof(token) - sizeof(offset) - offset + l * cell_shape, cell_shape);
         }
         for (int l = 0; l < cell_shape; l++) {
           if ((l < row) || (l > row + 1)) {
+            NDLZ8_CHECK_RANGE(ip, cell_shape);
             memcpy(&buffercpy[l * cell_shape], ip, cell_shape);
             ip += cell_shape;
           }
@@ -597,4 +628,5 @@ int ndlz8_decompress(const uint8_t *input, int32_t input_len, uint8_t *output, i
   }
 
   return (int) ind;
+#undef NDLZ8_CHECK_RANGE
 }

--- a/plugins/codecs/ndlz/ndlz8x8.c
+++ b/plugins/codecs/ndlz/ndlz8x8.c
@@ -437,16 +437,21 @@ int ndlz8_decompress(const uint8_t *input, int32_t input_len, uint8_t *output, i
   const int cell_shape = 8;
   const int cell_size = 64;
   uint8_t *ip = (uint8_t *) input;
-  uint8_t *ip_limit = ip + input_len;
   uint8_t *op = (uint8_t *) output;
   uint8_t ndim;
   int32_t blockshape[2];
   int32_t eshape[2];
   uint8_t *buffercpy;
   uint8_t token;
-  if (NDLZ_UNEXPECT_CONDITIONAL(input_len < 8)) {
+  // The fixed header is 1 (ndim) + 2 * int32 (blockshape) = 9 bytes.  Reject any
+  // input too short to hold it -- the previous `< 8` check let an 8-byte input
+  // through and the header parse below then read a 9th byte.  The cast keeps the
+  // comparison signed so a negative `input_len` is rejected here, before the
+  // `ip + input_len` pointer arithmetic (which would otherwise be UB) is reached.
+  if (NDLZ_UNEXPECT_CONDITIONAL(input_len < (int32_t) (1 + 2 * sizeof(int32_t)))) {
     return 0;
   }
+  uint8_t *ip_limit = ip + input_len;
 
   /* we start with literal copy */
   ndim = *ip;

--- a/plugins/codecs/ndlz/ndlz8x8.c
+++ b/plugins/codecs/ndlz/ndlz8x8.c
@@ -619,8 +619,13 @@ int ndlz8_decompress(const uint8_t *input, int32_t input_len, uint8_t *output, i
         if (i < padding[0]) {
           ind = orig + i * blockshape[1];
           memcpy(&op[ind], buffercpy, padding[1]);
+          // Only advance over rows we actually consume.  For a literal cell
+          // (token == 0) buffercpy points into the input and only holds
+          // padding[0] * padding[1] bytes; advancing unconditionally for the
+          // trailing padding rows would form an out-of-bounds pointer (UB)
+          // for the block's last cell.  The skipped rows are never read.
+          buffercpy += padding[1];
         }
-        buffercpy += padding[1];
       }
       if (ind > output_len) {
         free(local_buffer);

--- a/plugins/codecs/ndlz/ndlz8x8.c
+++ b/plugins/codecs/ndlz/ndlz8x8.c
@@ -487,18 +487,20 @@ int ndlz8_decompress(const uint8_t *input, int32_t input_len, uint8_t *output, i
   uint8_t *local_buffer = malloc(cell_size);
   uint8_t *cell_aux = malloc(cell_size);
 
-  // Reject any read whose range [p, p + n) falls outside the compressed input
-  // buffer [input, ip_limit).  A crafted token `offset` otherwise makes the
-  // back-reference `buffercpy` (and the `ip - ... - offset` reads below) point
-  // before `input`, and the cell-fill memcpy then leaks out-of-bounds heap
-  // memory into the (attacker-visible) output -- CWE-125.  The per-cell
-  // `ip > ip_limit` check is not enough because each cell reads a 2-byte offset
-  // and literal bytes past that point.  Mirrors blosclz's `ref - 1 < output`.
-#define NDLZ8_CHECK_RANGE(p, n)                                                  \
+  // Validate that a read of `len` bytes starting at byte offset `pos` (measured
+  // from the start of `input`) lies fully within the compressed buffer.  A
+  // crafted token `offset` otherwise makes a back-reference point before
+  // `input`, and the cell-fill memcpy then leaks out-of-bounds heap memory into
+  // the (attacker-visible) output -- CWE-125.  The per-cell `ip > ip_limit`
+  // check is not enough because each cell reads a 2-byte offset and literal
+  // bytes past that point.  All arithmetic is done on integer offsets so we
+  // never form an out-of-bounds pointer (undefined behaviour in C, even when the
+  // pointer is only compared and not dereferenced).
+#define NDLZ8_CHECK_RANGE(pos, len)                                              \
   do {                                                                           \
-    const uint8_t *_p = (const uint8_t *) (p);                                   \
-    int64_t _n = (int64_t) (n);                                                  \
-    if (_n < 0 || _p < (const uint8_t *) input || _p > ip_limit - _n) {          \
+    int64_t _pos = (int64_t) (pos);                                              \
+    int64_t _len = (int64_t) (len);                                              \
+    if (_pos < 0 || _len < 0 || _pos > (int64_t) input_len - _len) {             \
       free(local_buffer);                                                        \
       free(cell_aux);                                                            \
       BLOSC_TRACE_ERROR("ndlz8: out-of-bounds reference in compressed stream");  \
@@ -524,21 +526,24 @@ int ndlz8_decompress(const uint8_t *input, int32_t input_len, uint8_t *output, i
       } else {
         padding[1] = cell_shape;
       }
-      NDLZ8_CHECK_RANGE(ip, 1);
+      int64_t cur = ip - (const uint8_t *) input;   // in-range: ip is within [input, ip_limit]
+      NDLZ8_CHECK_RANGE(cur, 1);
       token = *ip++;
       uint8_t match_type = (token >> 3U);
       if (token == 0) {    // no match
+        NDLZ8_CHECK_RANGE(cur + 1, (int64_t) padding[0] * padding[1]);
         buffercpy = ip;
         ip += padding[0] * padding[1];
-        NDLZ8_CHECK_RANGE(buffercpy, (int64_t) padding[0] * padding[1]);
       } else if (token == (uint8_t) ((1U << 7U) | (1U << 6U))) {  // cell match
-        NDLZ8_CHECK_RANGE(ip, 2);
-        uint16_t offset = *((uint16_t *) ip);
-        buffercpy = ip - offset - 1;
+        NDLZ8_CHECK_RANGE(cur + 1, 2);
+        uint16_t offset;
+        memcpy(&offset, ip, sizeof(offset));
+        int64_t bpos = (cur + 1) - (int64_t) offset - 1;
+        NDLZ8_CHECK_RANGE(bpos, (int64_t) padding[0] * padding[1]);
+        buffercpy = (uint8_t *) input + bpos;
         ip += 2;
-        NDLZ8_CHECK_RANGE(buffercpy, (int64_t) padding[0] * padding[1]);
       } else if (token == (uint8_t) (1U << 6U)) { // whole cell of same element
-        NDLZ8_CHECK_RANGE(ip, 1);
+        NDLZ8_CHECK_RANGE(cur + 1, 1);
         buffercpy = cell_aux;
         memset(buffercpy, *ip, cell_size);
         ip++;
@@ -551,17 +556,21 @@ int ndlz8_decompress(const uint8_t *input, int32_t input_len, uint8_t *output, i
           BLOSC_TRACE_ERROR("Triple match row out of bounds");
           return BLOSC2_ERROR_FAILURE;
         }
-        NDLZ8_CHECK_RANGE(ip, 2);
-        uint16_t offset = *((uint16_t *) ip);
+        NDLZ8_CHECK_RANGE(cur + 1, 2);
+        uint16_t offset;
+        memcpy(&offset, ip, sizeof(offset));
         ip += 2;
-        NDLZ8_CHECK_RANGE(ip - sizeof(token) - sizeof(offset) - offset, 3 * cell_shape);
+        // back-reference base == ip - sizeof(token) - sizeof(offset) - offset,
+        // i.e. (cur + 3) - 3 - offset == cur - offset, expressed as an offset.
+        int64_t bpos = cur - (int64_t) offset;
+        NDLZ8_CHECK_RANGE(bpos, 3 * cell_shape);
+        const uint8_t *ref = (const uint8_t *) input + bpos;
         for (int l = 0; l < 3; l++) {
-          memcpy(&buffercpy[(row + l) * cell_shape],
-                 ip - sizeof(token) - sizeof(offset) - offset + l * cell_shape, cell_shape);
+          memcpy(&buffercpy[(row + l) * cell_shape], ref + l * cell_shape, cell_shape);
         }
         for (int l = 0; l < cell_shape; l++) {
           if ((l < row) || (l > row + 2)) {
-            NDLZ8_CHECK_RANGE(ip, cell_shape);
+            NDLZ8_CHECK_RANGE(ip - (const uint8_t *) input, cell_shape);
             memcpy(&buffercpy[l * cell_shape], ip, cell_shape);
             ip += cell_shape;
           }
@@ -575,17 +584,20 @@ int ndlz8_decompress(const uint8_t *input, int32_t input_len, uint8_t *output, i
           BLOSC_TRACE_ERROR("Pair match row out of bounds");
           return BLOSC2_ERROR_FAILURE;
         }
-        NDLZ8_CHECK_RANGE(ip, 2);
-        uint16_t offset = *((uint16_t *) ip);
+        NDLZ8_CHECK_RANGE(cur + 1, 2);
+        uint16_t offset;
+        memcpy(&offset, ip, sizeof(offset));
         ip += 2;
-        NDLZ8_CHECK_RANGE(ip - sizeof(token) - sizeof(offset) - offset, 2 * cell_shape);
+        // back-reference base == cur - offset (see triple-match note above).
+        int64_t bpos = cur - (int64_t) offset;
+        NDLZ8_CHECK_RANGE(bpos, 2 * cell_shape);
+        const uint8_t *ref = (const uint8_t *) input + bpos;
         for (int l = 0; l < 2; l++) {
-          memcpy(&buffercpy[(row + l) * cell_shape],
-                 ip - sizeof(token) - sizeof(offset) - offset + l * cell_shape, cell_shape);
+          memcpy(&buffercpy[(row + l) * cell_shape], ref + l * cell_shape, cell_shape);
         }
         for (int l = 0; l < cell_shape; l++) {
           if ((l < row) || (l > row + 1)) {
-            NDLZ8_CHECK_RANGE(ip, cell_shape);
+            NDLZ8_CHECK_RANGE(ip - (const uint8_t *) input, cell_shape);
             memcpy(&buffercpy[l * cell_shape], ip, cell_shape);
             ip += cell_shape;
           }


### PR DESCRIPTION
Add bounds validation for compressed-input reads and back-references in the NDLZ decompression codecs.

Malformed NDLZ streams can supply crafted offsets that cause back-references to read outside the compressed input buffer. These out-of-bounds bytes are subsequently copied into the decompressed output, resulting in a potential information disclosure vulnerability and AddressSanitizer-detected heap-buffer-overflow reads.

## Changes

### ndlz4x4.c

* Added `NDLZ4_CHECK_RANGE()` helper to validate compressed-input accesses.
* Added validation before:

  * Token reads
  * Offset reads
  * Literal copies
  * Cell-match back-references
  * Multi-row match references

### ndlz8x8.c

* Added `NDLZ8_CHECK_RANGE()` helper to validate compressed-input accesses.
* Added validation before:

  * Token reads
  * Offset reads
  * Literal copies
  * Cell-match back-references
  * Pair-match and triple-match reference reads
* Added cleanup of temporary buffers on newly introduced error paths.