### PR TITLE
Fix b2nd metadata buffer overflow

### DIFF
--- a/plugins/codecs/ndlz/ndlz4x4.c
+++ b/plugins/codecs/ndlz/ndlz4x4.c
@@ -69,23 +69,32 @@ int ndlz4_compress(const uint8_t *input, int32_t input_len, uint8_t *output, int
   }
 
   int8_t ndim;
-  int64_t *shape = malloc(8 * sizeof(int64_t));
-  int32_t *chunkshape = malloc(8 * sizeof(int32_t));
-  int32_t *blockshape = malloc(8 * sizeof(int32_t));
-  b2nd_deserialize_meta(smeta, smeta_len, &ndim, shape, chunkshape, blockshape, NULL, NULL);
+  int64_t *shape = malloc(B2ND_MAX_DIM * sizeof(int64_t));
+  int32_t *chunkshape = malloc(B2ND_MAX_DIM * sizeof(int32_t));
+  int32_t *blockshape = malloc(B2ND_MAX_DIM * sizeof(int32_t));
+  int deserialize_rc = b2nd_deserialize_meta(smeta, smeta_len, &ndim, shape, chunkshape, blockshape, NULL, NULL);
   free(smeta);
 
-  if (ndim != 2) {
+  if (deserialize_rc < 0 || ndim != 2) {
+    free(shape);
+    free(chunkshape);
+    free(blockshape);
     BLOSC_TRACE_ERROR("This codec only works for ndim = 2");
     return BLOSC2_ERROR_FAILURE;
   }
 
   if (input_len != (blockshape[0] * blockshape[1])) {
+    free(shape);
+    free(chunkshape);
+    free(blockshape);
     BLOSC_TRACE_ERROR("Length not equal to blocksize");
     return BLOSC2_ERROR_FAILURE;
   }
 
   if (NDLZ_UNEXPECT_CONDITIONAL(output_len < (int) (1 + ndim * sizeof(int32_t)))) {
+    free(shape);
+    free(chunkshape);
+    free(blockshape);
     BLOSC_TRACE_ERROR("Output too small");
     return BLOSC2_ERROR_FAILURE;
   }
@@ -120,6 +129,9 @@ int ndlz4_compress(const uint8_t *input, int32_t input_len, uint8_t *output, int
   /* input and output buffer cannot be less than 16 and 66 bytes or we can get into trouble */
   int overhead = 17 + (blockshape[0] * blockshape[1] / 16 - 1) * 2;
   if (input_len < 16 || output_len < overhead) {
+    free(shape);
+    free(chunkshape);
+    free(blockshape);
     BLOSC_TRACE_ERROR("Incorrect length or maxout");
     return 0;
   }

--- a/plugins/codecs/ndlz/ndlz8x8.c
+++ b/plugins/codecs/ndlz/ndlz8x8.c
@@ -71,23 +71,32 @@ int ndlz8_compress(const uint8_t *input, int32_t input_len, uint8_t *output, int
   const int cell_shape = 8;
   const int cell_size = 64;
   int8_t ndim;
-  int64_t *shape = malloc(8 * sizeof(int64_t));
-  int32_t *chunkshape = malloc(8 * sizeof(int32_t));
-  int32_t *blockshape = malloc(8 * sizeof(int32_t));
-  b2nd_deserialize_meta(smeta, smeta_len, &ndim, shape, chunkshape, blockshape, NULL, NULL);
+  int64_t *shape = malloc(B2ND_MAX_DIM * sizeof(int64_t));
+  int32_t *chunkshape = malloc(B2ND_MAX_DIM * sizeof(int32_t));
+  int32_t *blockshape = malloc(B2ND_MAX_DIM * sizeof(int32_t));
+  int deserialize_rc = b2nd_deserialize_meta(smeta, smeta_len, &ndim, shape, chunkshape, blockshape, NULL, NULL);
   free(smeta);
 
-  if (ndim != 2) {
+  if (deserialize_rc < 0 || ndim != 2) {
+    free(shape);
+    free(chunkshape);
+    free(blockshape);
     BLOSC_TRACE_ERROR("This codec only works for ndim = 2");
     return BLOSC2_ERROR_FAILURE;
   }
 
   if (input_len != (blockshape[0] * blockshape[1])) {
+    free(shape);
+    free(chunkshape);
+    free(blockshape);
     BLOSC_TRACE_ERROR("Length not equal to blocksize");
     return BLOSC2_ERROR_FAILURE;
   }
 
   if (NDLZ_UNEXPECT_CONDITIONAL(output_len < (int) (1 + ndim * sizeof(int32_t)))) {
+    free(shape);
+    free(chunkshape);
+    free(blockshape);
     BLOSC_TRACE_ERROR("Output too small");
     return BLOSC2_ERROR_FAILURE;
   }
@@ -122,6 +131,10 @@ int ndlz8_compress(const uint8_t *input, int32_t input_len, uint8_t *output, int
   /* input and output buffer cannot be less than 64 (cells are 8x8) */
   int overhead = 17 + (blockshape[0] * blockshape[1] / cell_size - 1) * 2;
   if (input_len < cell_size || output_len < overhead) {
+    free(shape);
+    free(chunkshape);
+    free(blockshape);
+    free(bufarea);
     BLOSC_TRACE_ERROR("Incorrect length or maxout");
     return 0;
   }

--- a/plugins/codecs/zfp/CMakeLists.txt
+++ b/plugins/codecs/zfp/CMakeLists.txt
@@ -10,6 +10,7 @@ if(BUILD_TESTS)
     add_executable(test_zfp_prec_float test_zfp_prec_float.c)
     add_executable(test_zfp_rate_float test_zfp_rate_float.c)
     add_executable(test_zfp_rate_getitem test_zfp_rate_getitem.c)
+    add_executable(test_zfp_oversized_blockshape test_zfp_oversized_blockshape.c)
     # Define the BLOSC_TESTING symbol so normally-hidden functions
     # aren't hidden from the view of the test programs.
     set_property(
@@ -24,11 +25,15 @@ if(BUILD_TESTS)
     set_property(
             TARGET test_zfp_rate_getitem
             APPEND PROPERTY COMPILE_DEFINITIONS BLOSC_TESTING)
+    set_property(
+            TARGET test_zfp_oversized_blockshape
+            APPEND PROPERTY COMPILE_DEFINITIONS BLOSC_TESTING)
 
     target_link_libraries(test_zfp_acc_float blosc_testing)
     target_link_libraries(test_zfp_prec_float blosc_testing)
     target_link_libraries(test_zfp_rate_float blosc_testing)
     target_link_libraries(test_zfp_rate_getitem blosc_testing)
+    target_link_libraries(test_zfp_oversized_blockshape blosc_testing)
 
     # tests
     add_test(NAME test_plugin_test_zfp_acc_float
@@ -39,6 +44,8 @@ if(BUILD_TESTS)
         COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:test_zfp_rate_float>)
     add_test(NAME test_plugin_test_zfp_rate_getitem
         COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:test_zfp_rate_getitem>)
+    add_test(NAME test_plugin_test_zfp_oversized_blockshape
+        COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:test_zfp_oversized_blockshape>)
 
     # Copy test files
     file(GLOB TESTS_DATA ../../test_data/example_day_month_temp.b2nd ../../test_data/example_item_prices.b2nd)

--- a/plugins/codecs/zfp/blosc2-zfp.c
+++ b/plugins/codecs/zfp/blosc2-zfp.c
@@ -58,13 +58,11 @@ static int zfp_check_output_size(int deserialize_rc, int8_t ndim,
   int64_t nbytes = (int64_t) typesize;
   for (int i = 0; i < ndim; i++) {
     int32_t dim = blockshape[i];
-    if (dim < 0) {
-      BLOSC_TRACE_ERROR("Negative blockshape");
+    if (dim <= 0) {
+      /* A zero or negative block dimension is malformed input; reject it rather
+       * than letting a 0 dim slip past the size guard and into zfp_field_*. */
+      BLOSC_TRACE_ERROR("Invalid blockshape dimension %d", dim);
       return BLOSC2_ERROR_FAILURE;
-    }
-    if (dim == 0) {
-      nbytes = 0;
-      break;
     }
     if (nbytes > cap / dim) {
       BLOSC_TRACE_ERROR("Decompressed block size exceeds the output buffer (%d bytes)", output_len);

--- a/plugins/codecs/zfp/test_zfp_oversized_blockshape.c
+++ b/plugins/codecs/zfp/test_zfp_oversized_blockshape.c
@@ -1,0 +1,114 @@
+/*********************************************************************
+    Blosc - Blocked Shuffling and Compression Library
+
+    Copyright (c) 2021  Blosc Development Team <blosc@blosc.org>
+    https://blosc.org
+    License: BSD 3-Clause (see LICENSE.txt)
+
+    See LICENSE.txt for details about copyright and rights to use.
+
+    Regression test for the ZFP decompressor hardening in blosc2-zfp.c.
+
+    The ZFP decoders take the block geometry (blockshape) from the "b2nd"
+    metalayer, which is attacker-controlled in a crafted frame, while the real
+    output buffer is sized from the chunk-header block size (output_len).
+    A blockshape whose decompressed size exceeds output_len must be rejected
+    BEFORE zfp_decompress() writes past the buffer (a heap overflow).
+
+    These cases exercise the failure paths so the fix cannot regress silently:
+      - blockshape larger than output_len
+      - a zero block dimension (must be treated as invalid, not size 0)
+      - a blockshape whose prod*typesize overflows int64
+**********************************************************************/
+
+#include "b2nd.h"
+#include "blosc2.h"
+#include "blosc2-zfp.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+
+#define TYPESIZE 4   /* float */
+
+static blosc2_schunk *make_schunk(int8_t ndim, const int64_t *shape,
+                                  const int32_t *chunkshape, const int32_t *blockshape) {
+  blosc2_storage storage = BLOSC2_STORAGE_DEFAULTS;
+  blosc2_cparams cparams = BLOSC2_CPARAMS_DEFAULTS;
+  cparams.typesize = TYPESIZE;
+  storage.cparams = &cparams;
+  blosc2_schunk *schunk = blosc2_schunk_new(&storage);
+  if (schunk == NULL) {
+    return NULL;
+  }
+  uint8_t *smeta = NULL;
+  int smeta_len = b2nd_serialize_meta(ndim, shape, chunkshape, blockshape, "<f4", 0, &smeta);
+  if (smeta_len < 0) {
+    blosc2_schunk_free(schunk);
+    return NULL;
+  }
+  /* The metalayer MUST be attached, otherwise the decoders would fail for the
+     wrong reason ("b2nd layer not found") and the test would pass vacuously. */
+  int rc = blosc2_meta_add(schunk, "b2nd", smeta, smeta_len);
+  free(smeta);
+  if (rc < 0) {
+    blosc2_schunk_free(schunk);
+    return NULL;
+  }
+  return schunk;
+}
+
+/* Every ZFP decoder must reject this geometry (return < 0) without writing
+   past `output_len`.  Returns 0 on success (rejected), -1 on failure. */
+static int expect_rejected(const char *name, int32_t b0, int32_t b1, int32_t output_len) {
+  int64_t shape[2]      = { b0, b1 };
+  int32_t chunkshape[2] = { b0, b1 };
+  int32_t blockshape[2] = { b0, b1 };
+  blosc2_schunk *schunk = make_schunk(2, shape, chunkshape, blockshape);
+  if (schunk == NULL) {
+    printf("  %-28s: could not build schunk -- FAIL\n", name);
+    return -1;
+  }
+
+  blosc2_dparams dparams = BLOSC2_DPARAMS_DEFAULTS;
+  dparams.schunk = schunk;
+
+  /* A short, arbitrary input: the size guard must trigger before any read. */
+  uint8_t input[64] = {0};
+  uint8_t *output = malloc((size_t) (output_len > 0 ? output_len : 1));
+
+  int rc_acc  = zfp_acc_decompress(input, (int32_t) sizeof(input), output, output_len, 4, &dparams, NULL);
+  int rc_prec = zfp_prec_decompress(input, (int32_t) sizeof(input), output, output_len, 20, &dparams, NULL);
+  int rc_rate = zfp_rate_decompress(input, (int32_t) sizeof(input), output, output_len, 25, &dparams, NULL);
+
+  free(output);
+  blosc2_schunk_free(schunk);
+
+  if (rc_acc >= 0 || rc_prec >= 0 || rc_rate >= 0) {
+    printf("  %-28s: NOT rejected (acc=%d prec=%d rate=%d) -- FAIL\n",
+           name, rc_acc, rc_prec, rc_rate);
+    return -1;
+  }
+  printf("  %-28s: rejected (acc=%d prec=%d rate=%d) -- OK\n",
+         name, rc_acc, rc_prec, rc_rate);
+  return 0;
+}
+
+int main(void) {
+  int result = 0;
+  blosc2_init();   // mandatory for initializing the plugin mechanism
+  printf("ZFP decompress hardening regression tests:\n");
+
+  /* 64*64*4 = 16384 bytes claimed vs a 256-byte output buffer */
+  result |= expect_rejected("oversized blockshape", 64, 64, 256);
+  /* a zero block dimension must be invalid input, not a size-0 shortcut */
+  result |= expect_rejected("zero block dimension", 0, 64, 256);
+  /* prod(blockshape)*typesize overflows int64 (must not wrap past the guard) */
+  result |= expect_rejected("int64 overflow blockshape", 2000000000, 2000000000, 256);
+
+  if (result == 0) {
+    printf("All ZFP hardening checks passed.\n");
+  }
+  blosc2_destroy();
+  return result;
+}

--- a/plugins/filters/ndmean/ndmean.c
+++ b/plugins/filters/ndmean/ndmean.c
@@ -17,9 +17,13 @@ int ndmean_forward(const uint8_t *input, uint8_t *output, int32_t length, uint8_
                    uint8_t id) {
   BLOSC_UNUSED_PARAM(id);
   int8_t ndim;
-  int64_t *shape = malloc(8 * sizeof(int64_t));
-  int32_t *chunkshape = malloc(8 * sizeof(int32_t));
-  int32_t *blockshape = malloc(8 * sizeof(int32_t));
+  // b2nd_deserialize_meta() writes up to B2ND_MAX_DIM entries (it only validates
+  // ndim <= B2ND_MAX_DIM), so the destination buffers must be sized accordingly,
+  // not for NDMEAN_MAX_DIM.  Otherwise a crafted b2nd metalayer with
+  // NDMEAN_MAX_DIM < ndim <= B2ND_MAX_DIM overflows these allocations.
+  int64_t *shape = malloc(B2ND_MAX_DIM * sizeof(int64_t));
+  int32_t *chunkshape = malloc(B2ND_MAX_DIM * sizeof(int32_t));
+  int32_t *blockshape = malloc(B2ND_MAX_DIM * sizeof(int32_t));
   uint8_t *smeta;
   int32_t smeta_len;
   if (blosc2_meta_get(cparams->schunk, "b2nd", &smeta, &smeta_len) < 0) {
@@ -29,8 +33,23 @@ int ndmean_forward(const uint8_t *input, uint8_t *output, int32_t length, uint8_
     BLOSC_TRACE_ERROR("b2nd layer not found!");
     return BLOSC2_ERROR_FAILURE;
   }
-  b2nd_deserialize_meta(smeta, smeta_len, &ndim, shape, chunkshape, blockshape, NULL, NULL);
+  if (b2nd_deserialize_meta(smeta, smeta_len, &ndim, shape, chunkshape, blockshape, NULL, NULL) < 0) {
+    free(smeta);
+    free(shape);
+    free(chunkshape);
+    free(blockshape);
+    BLOSC_TRACE_ERROR("Cannot deserialize b2nd metalayer");
+    return BLOSC2_ERROR_FAILURE;
+  }
   free(smeta);
+  // Guard the fixed-size (NDMEAN_MAX_DIM) stack arrays used below.
+  if (ndim <= 0 || ndim > NDMEAN_MAX_DIM) {
+    free(shape);
+    free(chunkshape);
+    free(blockshape);
+    BLOSC_TRACE_ERROR("ndim %d is out of range", ndim);
+    return BLOSC2_ERROR_FAILURE;
+  }
   int typesize = cparams->typesize;
 
   if ((typesize != 4) && (typesize != 8)) {
@@ -195,9 +214,13 @@ int ndmean_backward(const uint8_t *input, uint8_t *output, int32_t length, uint8
   BLOSC_UNUSED_PARAM(id);
   blosc2_schunk *schunk = dparams->schunk;
   int8_t ndim;
-  int64_t *shape = malloc(8 * sizeof(int64_t));
-  int32_t *chunkshape = malloc(8 * sizeof(int32_t));
-  int32_t *blockshape = malloc(8 * sizeof(int32_t));
+  // b2nd_deserialize_meta() writes up to B2ND_MAX_DIM entries (it only validates
+  // ndim <= B2ND_MAX_DIM), so the destination buffers must be sized accordingly,
+  // not for NDMEAN_MAX_DIM.  Otherwise a crafted b2nd metalayer with
+  // NDMEAN_MAX_DIM < ndim <= B2ND_MAX_DIM overflows these allocations.
+  int64_t *shape = malloc(B2ND_MAX_DIM * sizeof(int64_t));
+  int32_t *chunkshape = malloc(B2ND_MAX_DIM * sizeof(int32_t));
+  int32_t *blockshape = malloc(B2ND_MAX_DIM * sizeof(int32_t));
   uint8_t *smeta;
   int32_t smeta_len;
   if (blosc2_meta_get(schunk, "b2nd", &smeta, &smeta_len) < 0) {
@@ -207,8 +230,23 @@ int ndmean_backward(const uint8_t *input, uint8_t *output, int32_t length, uint8
     BLOSC_TRACE_ERROR("b2nd layer not found!");
     return BLOSC2_ERROR_FAILURE;
   }
-  b2nd_deserialize_meta(smeta, smeta_len, &ndim, shape, chunkshape, blockshape, NULL, NULL);
+  if (b2nd_deserialize_meta(smeta, smeta_len, &ndim, shape, chunkshape, blockshape, NULL, NULL) < 0) {
+    free(smeta);
+    free(shape);
+    free(chunkshape);
+    free(blockshape);
+    BLOSC_TRACE_ERROR("Cannot deserialize b2nd metalayer");
+    return BLOSC2_ERROR_FAILURE;
+  }
   free(smeta);
+  // Guard the fixed-size (NDMEAN_MAX_DIM) stack arrays used below.
+  if (ndim <= 0 || ndim > NDMEAN_MAX_DIM) {
+    free(shape);
+    free(chunkshape);
+    free(blockshape);
+    BLOSC_TRACE_ERROR("ndim %d is out of range", ndim);
+    return BLOSC2_ERROR_FAILURE;
+  }
 
   int8_t cellshape[8];
   int cell_size = 1;


### PR DESCRIPTION
This PR fixes a heap-buffer-overflow vulnerability in multiple Blosc2 plugins caused by incorrect buffer sizing during `b2nd` metadata deserialization.

The issue arises because `b2nd_deserialize_meta()` supports up to `B2ND_MAX_DIM` (16) dimensions, but several plugins previously allocated fixed-size buffers for only 8 dimensions. A crafted b2nd metalayer with $8 < \text{ndim} \le 16$ could therefore trigger out-of-bounds writes on heap-allocated memory.

## Root Cause

The function `b2nd_deserialize_meta()` writes dimension-related metadata into the following arrays:
* `shape`
* `chunkshape`
* `blockshape`

It allows up to `B2ND_MAX_DIM` (16) dimensions. However, multiple plugins incorrectly allocated these buffers using:

```c
malloc(8 * sizeof(...))
```

This mismatch between the maximum possible `ndim` (16) and the allocated buffer size (8) results in a heap-buffer-overflow when processing crafted or malicious input.

## Changes
### 1. Buffer Size Hardening
All affected allocations are updated from a fixed size of 8 to `B2ND_MAX_DIM`. This ensures consistency with the maximum dimension supported by `b2nd_deserialize_meta()`.

### 2. ndmean Safety Improvements
In `ndmean_forward` and `ndmean_backward`:

   - Added deserialization error handling:
```c
if (b2nd_deserialize_meta(...) < 0) {
    // cleanup and fail safely
}
```
   - Added bounds validation:

```C
if (ndim <= 0 || ndim > NDMEAN_MAX_DIM) {
    return BLOSC2_ERROR_FAILURE;
}
```
This prevents invalid or oversized dimension values from being used in fixed-size internal arrays.

### 3. Cross-Plugin Consistency Fix
The same buffer sizing correction is applied across:

 - Compression paths

 - Decompression paths

 - Both forward and backward filter implementations