### PR TITLE
zfp: validate output buffer size before decompression

### DIFF
--- a/plugins/codecs/zfp/blosc2-zfp.c
+++ b/plugins/codecs/zfp/blosc2-zfp.c
@@ -43,19 +43,36 @@ static int zfp_check_output_size(int deserialize_rc, int8_t ndim,
     BLOSC_TRACE_ERROR("ndim %d is out of range for ZFP", ndim);
     return BLOSC2_ERROR_FAILURE;
   }
+  if (typesize <= 0) {
+    BLOSC_TRACE_ERROR("Invalid typesize %d", typesize);
+    return BLOSC2_ERROR_FAILURE;
+  }
   if (output_len < 0) {
     BLOSC_TRACE_ERROR("Negative output length");
     return BLOSC2_ERROR_FAILURE;
   }
-  int64_t nbytes = typesize;
+  /* Compute prod(blockshape) * typesize and compare against output_len without
+   * ever overflowing int64_t: keep nbytes bounded by `cap` at every step, so a
+   * crafted (large) blockshape cannot wrap the product past the guard. */
+  const int64_t cap = (int64_t) output_len;
+  int64_t nbytes = (int64_t) typesize;
   for (int i = 0; i < ndim; i++) {
-    if (blockshape[i] < 0) {
+    int32_t dim = blockshape[i];
+    if (dim < 0) {
       BLOSC_TRACE_ERROR("Negative blockshape");
       return BLOSC2_ERROR_FAILURE;
     }
-    nbytes *= blockshape[i];
+    if (dim == 0) {
+      nbytes = 0;
+      break;
+    }
+    if (nbytes > cap / dim) {
+      BLOSC_TRACE_ERROR("Decompressed block size exceeds the output buffer (%d bytes)", output_len);
+      return BLOSC2_ERROR_FAILURE;
+    }
+    nbytes *= dim;
   }
-  if (nbytes > (int64_t) output_len) {
+  if (nbytes > cap) {
     BLOSC_TRACE_ERROR("Decompressed size (%lld bytes) is bigger than the output buffer (%d bytes)",
                       (long long) nbytes, output_len);
     return BLOSC2_ERROR_FAILURE;
@@ -74,9 +91,9 @@ int zfp_acc_compress(const uint8_t *input, int32_t input_len, uint8_t *output,
 
   double tol = (int8_t) meta;
   int8_t ndim;
-  int64_t *shape = malloc(8 * sizeof(int64_t));
-  int32_t *chunkshape = malloc(8 * sizeof(int32_t));
-  int32_t *blockshape = malloc(8 * sizeof(int32_t));
+  int64_t *shape = malloc(B2ND_MAX_DIM * sizeof(int64_t));
+  int32_t *chunkshape = malloc(B2ND_MAX_DIM * sizeof(int32_t));
+  int32_t *blockshape = malloc(B2ND_MAX_DIM * sizeof(int32_t));
   uint8_t *smeta;
   int32_t smeta_len;
   if (blosc2_meta_get(cparams->schunk, "b2nd", &smeta, &smeta_len) < 0) {
@@ -86,11 +103,21 @@ int zfp_acc_compress(const uint8_t *input, int32_t input_len, uint8_t *output,
     BLOSC_TRACE_ERROR("b2nd layer not found!");
     return BLOSC2_ERROR_FAILURE;
   }
-  b2nd_deserialize_meta(smeta, smeta_len, &ndim, shape, chunkshape, blockshape, NULL, NULL);
+  int deserialize_rc = b2nd_deserialize_meta(smeta, smeta_len, &ndim, shape, chunkshape, blockshape, NULL, NULL);
   free(smeta);
+  if (deserialize_rc < 0 || ndim <= 0 || ndim > ZFP_MAX_DIM) {
+    free(shape);
+    free(chunkshape);
+    free(blockshape);
+    BLOSC_TRACE_ERROR("Invalid b2nd meta info (ndim %d)", ndim);
+    return BLOSC2_ERROR_FAILURE;
+  }
 
   for(int i = 0; i < ndim; i++) {
     if (blockshape[i] < 4) {
+      free(shape);
+      free(chunkshape);
+      free(blockshape);
       BLOSC_TRACE_ERROR("ZFP does not support blocks smaller than cells (4x...x4");
       return BLOSC2_ERROR_FAILURE;
     }
@@ -297,9 +324,9 @@ int zfp_prec_compress(const uint8_t *input, int32_t input_len, uint8_t *output,
   ZFP_ERROR_NULL(cparams->schunk);
 
   int8_t ndim;
-  int64_t *shape = malloc(8 * sizeof(int64_t));
-  int32_t *chunkshape = malloc(8 * sizeof(int32_t));
-  int32_t *blockshape = malloc(8 * sizeof(int32_t));
+  int64_t *shape = malloc(B2ND_MAX_DIM * sizeof(int64_t));
+  int32_t *chunkshape = malloc(B2ND_MAX_DIM * sizeof(int32_t));
+  int32_t *blockshape = malloc(B2ND_MAX_DIM * sizeof(int32_t));
   uint8_t *smeta;
   int32_t smeta_len;
   if (blosc2_meta_get(cparams->schunk, "b2nd", &smeta, &smeta_len) < 0) {
@@ -309,11 +336,21 @@ int zfp_prec_compress(const uint8_t *input, int32_t input_len, uint8_t *output,
     BLOSC_TRACE_ERROR("b2nd layer not found!");
     return BLOSC2_ERROR_FAILURE;
   }
-  b2nd_deserialize_meta(smeta, smeta_len, &ndim, shape, chunkshape, blockshape, NULL, NULL);
+  int deserialize_rc = b2nd_deserialize_meta(smeta, smeta_len, &ndim, shape, chunkshape, blockshape, NULL, NULL);
   free(smeta);
+  if (deserialize_rc < 0 || ndim <= 0 || ndim > ZFP_MAX_DIM) {
+    free(shape);
+    free(chunkshape);
+    free(blockshape);
+    BLOSC_TRACE_ERROR("Invalid b2nd meta info (ndim %d)", ndim);
+    return BLOSC2_ERROR_FAILURE;
+  }
 
   for(int i = 0; i < ndim; i++) {
     if (blockshape[i] < 4) {
+      free(shape);
+      free(chunkshape);
+      free(blockshape);
       BLOSC_TRACE_ERROR("ZFP does not support blocks smaller than cells (4x...x4");
       return BLOSC2_ERROR_FAILURE;
     }
@@ -570,9 +607,9 @@ int zfp_rate_compress(const uint8_t *input, int32_t input_len, uint8_t *output,
 
   double ratio = (double) meta / 100.0;
   int8_t ndim;
-  int64_t *shape = malloc(8 * sizeof(int64_t));
-  int32_t *chunkshape = malloc(8 * sizeof(int32_t));
-  int32_t *blockshape = malloc(8 * sizeof(int32_t));
+  int64_t *shape = malloc(B2ND_MAX_DIM * sizeof(int64_t));
+  int32_t *chunkshape = malloc(B2ND_MAX_DIM * sizeof(int32_t));
+  int32_t *blockshape = malloc(B2ND_MAX_DIM * sizeof(int32_t));
   uint8_t *smeta;
   int32_t smeta_len;
   if (blosc2_meta_get(cparams->schunk, "b2nd", &smeta, &smeta_len) < 0) {
@@ -582,11 +619,21 @@ int zfp_rate_compress(const uint8_t *input, int32_t input_len, uint8_t *output,
     BLOSC_TRACE_ERROR("b2nd layer not found!");
     return BLOSC2_ERROR_FAILURE;
   }
-  b2nd_deserialize_meta(smeta, smeta_len, &ndim, shape, chunkshape, blockshape, NULL, NULL);
+  int deserialize_rc = b2nd_deserialize_meta(smeta, smeta_len, &ndim, shape, chunkshape, blockshape, NULL, NULL);
   free(smeta);
+  if (deserialize_rc < 0 || ndim <= 0 || ndim > ZFP_MAX_DIM) {
+    free(shape);
+    free(chunkshape);
+    free(blockshape);
+    BLOSC_TRACE_ERROR("Invalid b2nd meta info (ndim %d)", ndim);
+    return BLOSC2_ERROR_FAILURE;
+  }
 
   for(int i = 0; i < ndim; i++) {
     if (blockshape[i] < 4) {
+      free(shape);
+      free(chunkshape);
+      free(blockshape);
       BLOSC_TRACE_ERROR("ZFP does not support blocks smaller than cells (4x...x4");
       return BLOSC2_ERROR_FAILURE;
     }

--- a/plugins/codecs/zfp/blosc2-zfp.c
+++ b/plugins/codecs/zfp/blosc2-zfp.c
@@ -118,7 +118,7 @@ int zfp_acc_compress(const uint8_t *input, int32_t input_len, uint8_t *output,
       free(shape);
       free(chunkshape);
       free(blockshape);
-      BLOSC_TRACE_ERROR("ZFP does not support blocks smaller than cells (4x...x4");
+      BLOSC_TRACE_ERROR("ZFP does not support blocks smaller than cells (4x...x4)");
       return BLOSC2_ERROR_FAILURE;
     }
   }
@@ -351,7 +351,7 @@ int zfp_prec_compress(const uint8_t *input, int32_t input_len, uint8_t *output,
       free(shape);
       free(chunkshape);
       free(blockshape);
-      BLOSC_TRACE_ERROR("ZFP does not support blocks smaller than cells (4x...x4");
+      BLOSC_TRACE_ERROR("ZFP does not support blocks smaller than cells (4x...x4)");
       return BLOSC2_ERROR_FAILURE;
     }
   }
@@ -634,7 +634,7 @@ int zfp_rate_compress(const uint8_t *input, int32_t input_len, uint8_t *output,
       free(shape);
       free(chunkshape);
       free(blockshape);
-      BLOSC_TRACE_ERROR("ZFP does not support blocks smaller than cells (4x...x4");
+      BLOSC_TRACE_ERROR("ZFP does not support blocks smaller than cells (4x...x4)");
       return BLOSC2_ERROR_FAILURE;
     }
   }

--- a/plugins/codecs/zfp/blosc2-zfp.c
+++ b/plugins/codecs/zfp/blosc2-zfp.c
@@ -17,6 +17,53 @@
 #include <string.h>
 
 
+/*
+ * Validate the b2nd geometry obtained from the (untrusted) "b2nd" metalayer
+ * before it is used to drive zfp_decompress(), which writes
+ * blockshape[0]*...*blockshape[ndim-1]*typesize bytes into `output`.
+ *
+ * The decompressors receive the real output-buffer capacity in `output_len`
+ * (the block size `neblock` from the chunk header), but `blockshape` comes
+ * from the metalayer, a separate attacker-controlled field of a crafted frame.
+ * Without these checks a chunk whose blockshape is larger than its block buffer
+ * makes zfp_decompress write far past `output`, a heap buffer overflow.
+ * This mirrors the guard the NDLZ codec gained after CVE-2024-3204
+ * (plugins/codecs/ndlz/ndlz4x4.c: "blockshape is bigger than the output buffer").
+ *
+ * Returns BLOSC2_ERROR_SUCCESS when the decompressed size is known to fit.
+ */
+static int zfp_check_output_size(int deserialize_rc, int8_t ndim,
+                                 const int32_t *blockshape,
+                                 int32_t typesize, int32_t output_len) {
+  if (deserialize_rc < 0) {
+    BLOSC_TRACE_ERROR("Cannot deserialize b2nd meta info");
+    return BLOSC2_ERROR_FAILURE;
+  }
+  if (ndim <= 0 || ndim > ZFP_MAX_DIM) {
+    BLOSC_TRACE_ERROR("ndim %d is out of range for ZFP", ndim);
+    return BLOSC2_ERROR_FAILURE;
+  }
+  if (output_len < 0) {
+    BLOSC_TRACE_ERROR("Negative output length");
+    return BLOSC2_ERROR_FAILURE;
+  }
+  int64_t nbytes = typesize;
+  for (int i = 0; i < ndim; i++) {
+    if (blockshape[i] < 0) {
+      BLOSC_TRACE_ERROR("Negative blockshape");
+      return BLOSC2_ERROR_FAILURE;
+    }
+    nbytes *= blockshape[i];
+  }
+  if (nbytes > (int64_t) output_len) {
+    BLOSC_TRACE_ERROR("Decompressed size (%lld bytes) is bigger than the output buffer (%d bytes)",
+                      (long long) nbytes, output_len);
+    return BLOSC2_ERROR_FAILURE;
+  }
+  return BLOSC2_ERROR_SUCCESS;
+}
+
+
 int zfp_acc_compress(const uint8_t *input, int32_t input_len, uint8_t *output,
                      int32_t output_len, uint8_t meta, blosc2_cparams *cparams, const void *chunk) {
   BLOSC_UNUSED_PARAM(chunk);
@@ -152,9 +199,9 @@ int zfp_acc_decompress(const uint8_t *input, int32_t input_len, uint8_t *output,
 
   double tol = (int8_t) meta;
   int8_t ndim;
-  int64_t *shape = malloc(8 * sizeof(int64_t));
-  int32_t *chunkshape = malloc(8 * sizeof(int32_t));
-  int32_t *blockshape = malloc(8 * sizeof(int32_t));
+  int64_t *shape = malloc(B2ND_MAX_DIM * sizeof(int64_t));
+  int32_t *chunkshape = malloc(B2ND_MAX_DIM * sizeof(int32_t));
+  int32_t *blockshape = malloc(B2ND_MAX_DIM * sizeof(int32_t));
   uint8_t *smeta;
   int32_t smeta_len;
   if (blosc2_meta_get(sc, "b2nd", &smeta, &smeta_len) < 0) {
@@ -164,8 +211,15 @@ int zfp_acc_decompress(const uint8_t *input, int32_t input_len, uint8_t *output,
     free(blockshape);
     return BLOSC2_ERROR_FAILURE;
   }
-  b2nd_deserialize_meta(smeta, smeta_len, &ndim, shape, chunkshape, blockshape, NULL, NULL);
+  int deserialize_rc = b2nd_deserialize_meta(smeta, smeta_len, &ndim, shape, chunkshape, blockshape, NULL, NULL);
   free(smeta);
+
+  if (zfp_check_output_size(deserialize_rc, ndim, blockshape, typesize, output_len) < 0) {
+    free(shape);
+    free(chunkshape);
+    free(blockshape);
+    return BLOSC2_ERROR_FAILURE;
+  }
 
   zfp_type type;     /* array scalar type */
   zfp_field *field;  /* array meta data */
@@ -391,9 +445,9 @@ int zfp_prec_decompress(const uint8_t *input, int32_t input_len, uint8_t *output
   blosc2_schunk *sc = dparams->schunk;
   int32_t typesize = sc->typesize;
   int8_t ndim;
-  int64_t *shape = malloc(8 * sizeof(int64_t));
-  int32_t *chunkshape = malloc(8 * sizeof(int32_t));
-  int32_t *blockshape = malloc(8 * sizeof(int32_t));
+  int64_t *shape = malloc(B2ND_MAX_DIM * sizeof(int64_t));
+  int32_t *chunkshape = malloc(B2ND_MAX_DIM * sizeof(int32_t));
+  int32_t *blockshape = malloc(B2ND_MAX_DIM * sizeof(int32_t));
   uint8_t *smeta;
   int32_t smeta_len;
   if (blosc2_meta_get(sc, "b2nd", &smeta, &smeta_len) < 0) {
@@ -403,8 +457,15 @@ int zfp_prec_decompress(const uint8_t *input, int32_t input_len, uint8_t *output
     free(blockshape);
     return BLOSC2_ERROR_FAILURE;
   }
-  b2nd_deserialize_meta(smeta, smeta_len, &ndim, shape, chunkshape, blockshape, NULL, NULL);
+  int deserialize_rc = b2nd_deserialize_meta(smeta, smeta_len, &ndim, shape, chunkshape, blockshape, NULL, NULL);
   free(smeta);
+
+  if (zfp_check_output_size(deserialize_rc, ndim, blockshape, typesize, output_len) < 0) {
+    free(shape);
+    free(chunkshape);
+    free(blockshape);
+    return BLOSC2_ERROR_FAILURE;
+  }
 
   zfp_type type;     /* array scalar type */
   zfp_field *field;  /* array meta data */
@@ -645,9 +706,9 @@ int zfp_rate_decompress(const uint8_t *input, int32_t input_len, uint8_t *output
 
   double ratio = (double) meta / 100.0;
   int8_t ndim;
-  int64_t *shape = malloc(8 * sizeof(int64_t));
-  int32_t *chunkshape = malloc(8 * sizeof(int32_t));
-  int32_t *blockshape = malloc(8 * sizeof(int32_t));
+  int64_t *shape = malloc(B2ND_MAX_DIM * sizeof(int64_t));
+  int32_t *chunkshape = malloc(B2ND_MAX_DIM * sizeof(int32_t));
+  int32_t *blockshape = malloc(B2ND_MAX_DIM * sizeof(int32_t));
   uint8_t *smeta;
   int32_t smeta_len;
   if (blosc2_meta_get(sc, "b2nd", &smeta, &smeta_len) < 0) {
@@ -657,8 +718,15 @@ int zfp_rate_decompress(const uint8_t *input, int32_t input_len, uint8_t *output
     free(blockshape);
     return BLOSC2_ERROR_FAILURE;
   }
-  b2nd_deserialize_meta(smeta, smeta_len, &ndim, shape, chunkshape, blockshape, NULL, NULL);
+  int deserialize_rc = b2nd_deserialize_meta(smeta, smeta_len, &ndim, shape, chunkshape, blockshape, NULL, NULL);
   free(smeta);
+
+  if (zfp_check_output_size(deserialize_rc, ndim, blockshape, typesize, output_len) < 0) {
+    free(shape);
+    free(chunkshape);
+    free(blockshape);
+    return BLOSC2_ERROR_FAILURE;
+  }
 
   zfp_type type;     /* array scalar type */
   zfp_field *field;  /* array meta data */


### PR DESCRIPTION
Prevent heap out-of-bounds writes in the ZFP codec decompressors by validating decompressed output geometry against the actual destination buffer size before calling `zfp_decompress()`.

## Root Cause

The ZFP decompressors receive the destination buffer capacity through `output_len`, but the size of the decompressed output is derived from `blockshape` values obtained from the `b2nd` metalayer.

Since the metalayer is independent from the chunk block size, a crafted frame can specify block dimensions whose decompressed size exceeds the destination buffer. In such cases, `zfp_decompress()` may write beyond the bounds of the output buffer, resulting in heap memory corruption.

## Changes

* Add a shared `zfp_check_output_size()` helper.
* Validate successful `b2nd` metadata deserialization before using decoded geometry.
* Validate `ndim` is within the supported ZFP range.
* Reject negative block dimensions.
* Verify that `blockshape[0] * ... * blockshape[ndim - 1] * typesize` does not exceed `output_len`.
* Apply validation to:

  * `zfp_acc_decompress()`
  * `zfp_prec_decompress()`
  * `zfp_rate_decompress()`
* Replace fixed-size dimension allocations (`8 * sizeof(...)`) with `B2ND_MAX_DIM`-based allocations.
* Capture and check the return value of `b2nd_deserialize_meta()`.

## Testing

* Verified that malformed metadata with oversized block dimensions is rejected before decompression.
* Confirmed that decompression returns an error instead of writing past the destination buffer.
* Verified existing ZFP compression/decompression functionality continues to operate correctly.
