### PR TITLE
size b2nd shape buffers to B2ND_MAX_DIM in ndmean and ndlz

### DIFF
--- a/plugins/codecs/ndlz/ndlz4x4.c
+++ b/plugins/codecs/ndlz/ndlz4x4.c
@@ -69,9 +69,9 @@ int ndlz4_compress(const uint8_t *input, int32_t input_len, uint8_t *output, int
   }
 
   int8_t ndim;
-  int64_t *shape = malloc(8 * sizeof(int64_t));
-  int32_t *chunkshape = malloc(8 * sizeof(int32_t));
-  int32_t *blockshape = malloc(8 * sizeof(int32_t));
+  int64_t *shape = malloc(B2ND_MAX_DIM * sizeof(int64_t));
+  int32_t *chunkshape = malloc(B2ND_MAX_DIM * sizeof(int32_t));
+  int32_t *blockshape = malloc(B2ND_MAX_DIM * sizeof(int32_t));
   b2nd_deserialize_meta(smeta, smeta_len, &ndim, shape, chunkshape, blockshape, NULL, NULL);
   free(smeta);
 

--- a/plugins/codecs/ndlz/ndlz8x8.c
+++ b/plugins/codecs/ndlz/ndlz8x8.c
@@ -71,9 +71,9 @@ int ndlz8_compress(const uint8_t *input, int32_t input_len, uint8_t *output, int
   const int cell_shape = 8;
   const int cell_size = 64;
   int8_t ndim;
-  int64_t *shape = malloc(8 * sizeof(int64_t));
-  int32_t *chunkshape = malloc(8 * sizeof(int32_t));
-  int32_t *blockshape = malloc(8 * sizeof(int32_t));
+  int64_t *shape = malloc(B2ND_MAX_DIM * sizeof(int64_t));
+  int32_t *chunkshape = malloc(B2ND_MAX_DIM * sizeof(int32_t));
+  int32_t *blockshape = malloc(B2ND_MAX_DIM * sizeof(int32_t));
   b2nd_deserialize_meta(smeta, smeta_len, &ndim, shape, chunkshape, blockshape, NULL, NULL);
   free(smeta);
 

--- a/plugins/filters/ndmean/ndmean.c
+++ b/plugins/filters/ndmean/ndmean.c
@@ -17,9 +17,9 @@ int ndmean_forward(const uint8_t *input, uint8_t *output, int32_t length, uint8_
                    uint8_t id) {
   BLOSC_UNUSED_PARAM(id);
   int8_t ndim;
-  int64_t *shape = malloc(8 * sizeof(int64_t));
-  int32_t *chunkshape = malloc(8 * sizeof(int32_t));
-  int32_t *blockshape = malloc(8 * sizeof(int32_t));
+  int64_t *shape = malloc(B2ND_MAX_DIM * sizeof(int64_t));
+  int32_t *chunkshape = malloc(B2ND_MAX_DIM * sizeof(int32_t));
+  int32_t *blockshape = malloc(B2ND_MAX_DIM * sizeof(int32_t));
   uint8_t *smeta;
   int32_t smeta_len;
   if (blosc2_meta_get(cparams->schunk, "b2nd", &smeta, &smeta_len) < 0) {
@@ -31,6 +31,13 @@ int ndmean_forward(const uint8_t *input, uint8_t *output, int32_t length, uint8_
   }
   b2nd_deserialize_meta(smeta, smeta_len, &ndim, shape, chunkshape, blockshape, NULL, NULL);
   free(smeta);
+  if (ndim <= 0 || ndim > NDMEAN_MAX_DIM) {
+    free(shape);
+    free(chunkshape);
+    free(blockshape);
+    BLOSC_TRACE_ERROR("ndim %d is out of range", ndim);
+    return BLOSC2_ERROR_FAILURE;
+  }
   int typesize = cparams->typesize;
 
   if ((typesize != 4) && (typesize != 8)) {
@@ -195,9 +202,9 @@ int ndmean_backward(const uint8_t *input, uint8_t *output, int32_t length, uint8
   BLOSC_UNUSED_PARAM(id);
   blosc2_schunk *schunk = dparams->schunk;
   int8_t ndim;
-  int64_t *shape = malloc(8 * sizeof(int64_t));
-  int32_t *chunkshape = malloc(8 * sizeof(int32_t));
-  int32_t *blockshape = malloc(8 * sizeof(int32_t));
+  int64_t *shape = malloc(B2ND_MAX_DIM * sizeof(int64_t));
+  int32_t *chunkshape = malloc(B2ND_MAX_DIM * sizeof(int32_t));
+  int32_t *blockshape = malloc(B2ND_MAX_DIM * sizeof(int32_t));
   uint8_t *smeta;
   int32_t smeta_len;
   if (blosc2_meta_get(schunk, "b2nd", &smeta, &smeta_len) < 0) {
@@ -209,6 +216,13 @@ int ndmean_backward(const uint8_t *input, uint8_t *output, int32_t length, uint8
   }
   b2nd_deserialize_meta(smeta, smeta_len, &ndim, shape, chunkshape, blockshape, NULL, NULL);
   free(smeta);
+  if (ndim <= 0 || ndim > NDMEAN_MAX_DIM) {
+    free(shape);
+    free(chunkshape);
+    free(blockshape);
+    BLOSC_TRACE_ERROR("ndim %d is out of range", ndim);
+    return BLOSC2_ERROR_FAILURE;
+  }
 
   int8_t cellshape[8];
   int cell_size = 1;


### PR DESCRIPTION
Repro: store a b2nd array whose metalayer declares `ndim` in `9..16`, with the `ndmean` filter (or the `ndlz` codec), then read it back. ASAN reports a heap write past the `shape`/`chunkshape`/`blockshape` buffers in `b2nd_deserialize_meta`.
Cause: `ndmean_forward`/`ndmean_backward` and `ndlz4_compress`/`ndlz8_compress` allocate those buffers with `8` slots, but `b2nd_deserialize_meta` fills up to `B2ND_MAX_DIM` (`16`) entries straight from the metalayer. `ndmean` then indexes its `NDMEAN_MAX_DIM` stack arrays with the same unchecked `ndim`.
Fix: size the buffers to `B2ND_MAX_DIM`, as `ndcell` and the `zfp` codec already do, and reject `ndim` outside `1..NDMEAN_MAX_DIM` in `ndmean` the way `ndcell` does.