### PR TITLE
ndmean: prevent blockshape overflow in block size validation

### DIFF
--- a/plugins/filters/ndmean/CMakeLists.txt
+++ b/plugins/filters/ndmean/CMakeLists.txt
@@ -20,7 +20,7 @@ if(BUILD_TESTS)
 
     target_link_libraries(test_ndmean_repart blosc_testing)
     target_link_libraries(test_ndmean_mean blosc_testing)
-    target_link_libraries(test_ndmean_oversized_blockshape blosc_testing)
+    target_link_libraries(test_ndmean_oversized blosc_testing)
 
     # tests
     add_test(NAME test_plugin_ndmean_repart

--- a/plugins/filters/ndmean/CMakeLists.txt
+++ b/plugins/filters/ndmean/CMakeLists.txt
@@ -5,6 +5,7 @@ if(BUILD_TESTS)
     # targets
     add_executable(test_ndmean_repart test_ndmean_repart.c)
     add_executable(test_ndmean_mean test_ndmean_mean.c)
+    add_executable(test_ndmean_oversized_blockshape test_ndmean_oversized_blockshape.c)
     # Define the BLOSC_TESTING symbol so normally-hidden functions
     # aren't hidden from the view of the test programs.
     set_property(
@@ -13,14 +14,20 @@ if(BUILD_TESTS)
     set_property(
             TARGET test_ndmean_repart
             APPEND PROPERTY COMPILE_DEFINITIONS BLOSC_TESTING)
+    set_property(
+            TARGET test_ndmean_oversized_blockshape
+            APPEND PROPERTY COMPILE_DEFINITIONS BLOSC_TESTING)
 
     target_link_libraries(test_ndmean_repart blosc_testing)
     target_link_libraries(test_ndmean_mean blosc_testing)
+    target_link_libraries(test_ndmean_oversized_blockshape blosc_testing)
 
     # tests
     add_test(NAME test_plugin_ndmean_repart
         COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:test_ndmean_repart>)
     add_test(NAME test_plugin_ndmean_mean
         COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:test_ndmean_mean>)
+    add_test(NAME test_plugin_ndmean_oversized_blockshape
+        COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:test_ndmean_oversized_blockshape>)
 
 endif()

--- a/plugins/filters/ndmean/CMakeLists.txt
+++ b/plugins/filters/ndmean/CMakeLists.txt
@@ -15,7 +15,7 @@ if(BUILD_TESTS)
             TARGET test_ndmean_repart
             APPEND PROPERTY COMPILE_DEFINITIONS BLOSC_TESTING)
     set_property(
-            TARGET test_ndmean_oversized_blockshape
+            TARGET test_ndmean_oversized
             APPEND PROPERTY COMPILE_DEFINITIONS BLOSC_TESTING)
 
     target_link_libraries(test_ndmean_repart blosc_testing)
@@ -27,7 +27,7 @@ if(BUILD_TESTS)
         COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:test_ndmean_repart>)
     add_test(NAME test_plugin_ndmean_mean
         COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:test_ndmean_mean>)
-    add_test(NAME test_plugin_ndmean_oversized_blockshape
-        COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:test_ndmean_oversized_blockshape>)
+    add_test(NAME test_plugin_ndmean_oversized
+        COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:test_ndmean_oversized>)
 
 endif()

--- a/plugins/filters/ndmean/CMakeLists.txt
+++ b/plugins/filters/ndmean/CMakeLists.txt
@@ -5,7 +5,7 @@ if(BUILD_TESTS)
     # targets
     add_executable(test_ndmean_repart test_ndmean_repart.c)
     add_executable(test_ndmean_mean test_ndmean_mean.c)
-    add_executable(test_ndmean_oversized_blockshape test_ndmean_oversized_blockshape.c)
+    add_executable(test_ndmean_oversized test_ndmean_oversized.c)
     # Define the BLOSC_TESTING symbol so normally-hidden functions
     # aren't hidden from the view of the test programs.
     set_property(

--- a/plugins/filters/ndmean/ndmean.c
+++ b/plugins/filters/ndmean/ndmean.c
@@ -74,7 +74,7 @@ int ndmean_forward(const uint8_t *input, uint8_t *output, int32_t length, uint8_
   }
 
   int8_t cellshape[8];
-  int cell_size = 1;
+  int64_t cell_size = 1;  // 64-bit: prod(cellshape) can reach 127^ndim, which overflows int
   for (int i = 0; i < 8; ++i) {
     if (i < ndim) {
       cellshape[i] = (int8_t) meta;
@@ -293,7 +293,7 @@ int ndmean_backward(const uint8_t *input, uint8_t *output, int32_t length, uint8
   }
 
   int8_t cellshape[8];
-  int cell_size = 1;
+  int64_t cell_size = 1;  // 64-bit: prod(cellshape) can reach 127^ndim, which overflows int
   for (int i = 0; i < 8; ++i) {
     if (i < ndim) {
       cellshape[i] = (int8_t) meta;

--- a/plugins/filters/ndmean/ndmean.c
+++ b/plugins/filters/ndmean/ndmean.c
@@ -73,16 +73,33 @@ int ndmean_forward(const uint8_t *input, uint8_t *output, int32_t length, uint8_
       cellshape[i] = 1;
     }
   }
-  int32_t blocksize = (int32_t) typesize;
+  // See ndmean_backward(): validate the b2nd block geometry in 64-bit so a
+  // crafted blockshape cannot wrap a 32-bit product back onto `length` and make
+  // the index arithmetic below stray outside the `length`-sized buffers.
+  int64_t blocksize = (int64_t) typesize;
   for (int i = 0; i < ndim; i++) {
+    if (blockshape[i] <= 0) {
+      free(shape);
+      free(chunkshape);
+      free(blockshape);
+      BLOSC_TRACE_ERROR("Invalid blockshape[%d] = %d", i, blockshape[i]);
+      return BLOSC2_ERROR_FAILURE;
+    }
     blocksize *= blockshape[i];
+    if (blocksize > (int64_t) length) {
+      free(shape);
+      free(chunkshape);
+      free(blockshape);
+      BLOSC_TRACE_ERROR("blockshape too large for block of %d bytes", length);
+      return BLOSC2_ERROR_FAILURE;
+    }
   }
 
-  if (length != blocksize) {
+  if ((int64_t) length != blocksize) {
     free(shape);
     free(chunkshape);
     free(blockshape);
-    BLOSC_TRACE_ERROR("Length not equal to blocksize %d %d \n", length, blocksize);
+    BLOSC_TRACE_ERROR("Length not equal to blocksize %d %lld \n", length, (long long) blocksize);
     return BLOSC2_ERROR_FAILURE;
   }
 
@@ -266,12 +283,41 @@ int ndmean_backward(const uint8_t *input, uint8_t *output, int32_t length, uint8
   uint8_t *ip = (uint8_t *) input;
   uint8_t *ip_limit = ip + length;
   uint8_t *op = (uint8_t *) output;
-  int32_t blocksize = (int32_t) typesize;
+  if (typesize <= 0) {
+    free(shape);
+    free(chunkshape);
+    free(blockshape);
+    BLOSC_TRACE_ERROR("Invalid typesize %d", typesize);
+    return BLOSC2_ERROR_FAILURE;
+  }
+  // The block geometry (blockshape) comes from the attacker-controlled "b2nd"
+  // metalayer and is NOT validated by b2nd_deserialize_meta().  Compute the
+  // block size in 64-bit and reject non-positive dimensions.  Otherwise a
+  // crafted blockshape whose 32-bit product wraps back onto `length` would pass
+  // the check below, while the scatter-write index arithmetic further down uses
+  // the true (huge) dimensions, writing past the `length`-sized output buffer
+  // (heap overflow).  Bailing as soon as the running product exceeds `length`
+  // also keeps the 64-bit multiply from overflowing.
+  int64_t blocksize = (int64_t) typesize;
   for (int i = 0; i < ndim; i++) {
+    if (blockshape[i] <= 0) {
+      free(shape);
+      free(chunkshape);
+      free(blockshape);
+      BLOSC_TRACE_ERROR("Invalid blockshape[%d] = %d", i, blockshape[i]);
+      return BLOSC2_ERROR_FAILURE;
+    }
     blocksize *= blockshape[i];
+    if (blocksize > (int64_t) length) {
+      free(shape);
+      free(chunkshape);
+      free(blockshape);
+      BLOSC_TRACE_ERROR("blockshape too large for block of %d bytes", length);
+      return BLOSC2_ERROR_FAILURE;
+    }
   }
 
-  if (length != blocksize) {
+  if ((int64_t) length != blocksize) {
     free(shape);
     free(chunkshape);
     free(blockshape);
@@ -350,8 +396,8 @@ int ndmean_backward(const uint8_t *input, uint8_t *output, int32_t length, uint8
   free(blockshape);
 
   if (ind != (int32_t) (blocksize / typesize)) {
-    BLOSC_TRACE_ERROR("Output size is not compatible with embedded blockshape ind %d %d \n",
-                      ind, (blocksize / typesize));
+    BLOSC_TRACE_ERROR("Output size is not compatible with embedded blockshape ind %d %lld \n",
+                      ind, (long long) (blocksize / typesize));
     return BLOSC2_ERROR_FAILURE;
   }
 

--- a/plugins/filters/ndmean/ndmean.c
+++ b/plugins/filters/ndmean/ndmean.c
@@ -60,6 +60,19 @@ int ndmean_forward(const uint8_t *input, uint8_t *output, int32_t length, uint8_
     return BLOSC2_ERROR_FAILURE;
   }
 
+  // `meta` carries the NDMEAN cell shape and is attacker-controlled (it is the
+  // chunk-header filters_meta byte).  It is cast to int8_t and used as the
+  // divisor when building i_shape[] below, so a value of 0 (divide-by-zero) or
+  // one that becomes negative after the cast (meta > INT8_MAX) would crash or
+  // produce bogus, out-of-range geometry.  Require a positive cell shape.
+  if ((int8_t) meta <= 0) {
+    free(shape);
+    free(chunkshape);
+    free(blockshape);
+    BLOSC_TRACE_ERROR("Invalid cell shape (meta) %d", (int) meta);
+    return BLOSC2_ERROR_FAILURE;
+  }
+
   int8_t cellshape[8];
   int cell_size = 1;
   for (int i = 0; i < 8; ++i) {
@@ -262,6 +275,20 @@ int ndmean_backward(const uint8_t *input, uint8_t *output, int32_t length, uint8
     free(chunkshape);
     free(blockshape);
     BLOSC_TRACE_ERROR("ndim %d is out of range", ndim);
+    return BLOSC2_ERROR_FAILURE;
+  }
+
+  // `meta` carries the NDMEAN cell shape and is attacker-controlled (it is the
+  // chunk-header filters_meta byte).  It is cast to int8_t and used as the
+  // divisor when building i_shape[] below, so a value of 0 (divide-by-zero) or
+  // one that becomes negative after the cast (meta > INT8_MAX) would crash or
+  // produce bogus, out-of-range geometry (e.g. a negative pad_shape feeding a
+  // huge memcpy).  Require a positive cell shape.
+  if ((int8_t) meta <= 0) {
+    free(shape);
+    free(chunkshape);
+    free(blockshape);
+    BLOSC_TRACE_ERROR("Invalid cell shape (meta) %d", (int) meta);
     return BLOSC2_ERROR_FAILURE;
   }
 

--- a/plugins/filters/ndmean/test_ndmean_oversized.c
+++ b/plugins/filters/ndmean/test_ndmean_oversized.c
@@ -103,6 +103,10 @@ int main(void) {
   result |= expect_rejected("zero block dimension", 0, 64, 1024, 4, 2);
   /* a negative block dimension must be invalid input */
   result |= expect_rejected("negative block dimension", -1, 64, 1024, 4, 2);
+  /* cell shape (meta) of 0 would divide by zero when building i_shape[] */
+  result |= expect_rejected("zero cell shape (meta=0)", 4, 4, 64, 4, 0);
+  /* cell shape (meta) > INT8_MAX becomes negative after the int8_t cast */
+  result |= expect_rejected("negative cell shape (meta=200)", 4, 4, 64, 4, 200);
 
   if (result == 0) {
     printf("All NDMEAN hardening checks passed.\n");

--- a/plugins/filters/ndmean/test_ndmean_oversized.c
+++ b/plugins/filters/ndmean/test_ndmean_oversized.c
@@ -1,0 +1,112 @@
+/*********************************************************************
+    Blosc - Blocked Shuffling and Compression Library
+
+    Copyright (c) 2021  Blosc Development Team <blosc@blosc.org>
+    https://blosc.org
+    License: BSD 3-Clause (see LICENSE.txt)
+
+    See LICENSE.txt for details about copyright and rights to use.
+
+    Regression test for the NDMEAN filter hardening in ndmean.c.
+
+    ndmean_backward() takes the block geometry (blockshape) from the "b2nd"
+    metalayer, which is attacker-controlled in a crafted frame, while the real
+    output block buffer is sized from the chunk-header block size (`length`).
+    The old code computed   blocksize = typesize * prod(blockshape)   in 32-bit
+    arithmetic: a crafted blockshape whose product wraps back onto `length`
+    passed the `length == blocksize` check, after which the scatter-write
+    index arithmetic used the *true* (huge) dimensions and wrote past the
+    output buffer (heap overflow).
+
+    These cases exercise the rejection paths so the fix cannot regress silently.
+**********************************************************************/
+
+#include "b2nd.h"
+#include "blosc2.h"
+#include "ndmean.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+
+int ndmean_backward(const uint8_t *input, uint8_t *output, int32_t length, uint8_t meta,
+                    blosc2_dparams *dparams, uint8_t id);
+
+static blosc2_schunk *make_schunk(int8_t ndim, const int64_t *shape, const int32_t *chunkshape,
+                                  const int32_t *blockshape, int32_t typesize) {
+  blosc2_storage storage = BLOSC2_STORAGE_DEFAULTS;
+  blosc2_cparams cparams = BLOSC2_CPARAMS_DEFAULTS;
+  cparams.typesize = typesize;
+  storage.cparams = &cparams;
+  blosc2_schunk *schunk = blosc2_schunk_new(&storage);
+  if (schunk == NULL) {
+    return NULL;
+  }
+  uint8_t *smeta = NULL;
+  int smeta_len = b2nd_serialize_meta(ndim, shape, chunkshape, blockshape, "<f4", 0, &smeta);
+  if (smeta_len < 0) {
+    blosc2_schunk_free(schunk);
+    return NULL;
+  }
+  /* The metalayer MUST be attached, otherwise the decoder would fail for the
+     wrong reason ("b2nd layer not found") and the test would pass vacuously. */
+  int rc = blosc2_meta_add(schunk, "b2nd", smeta, smeta_len);
+  free(smeta);
+  if (rc < 0) {
+    blosc2_schunk_free(schunk);
+    return NULL;
+  }
+  return schunk;
+}
+
+/* ndmean_backward must reject this geometry (return < 0) without writing past
+   `length`.  Returns 0 on success (rejected), -1 on failure. */
+static int expect_rejected(const char *name, int32_t b0, int32_t b1,
+                           int32_t length, int32_t typesize, uint8_t cell_shape) {
+  int64_t shape[2]      = { b0, b1 };
+  int32_t chunkshape[2] = { b0, b1 };
+  int32_t blockshape[2] = { b0, b1 };
+  blosc2_schunk *schunk = make_schunk(2, shape, chunkshape, blockshape, typesize);
+  if (schunk == NULL) {
+    printf("  %-30s: could not build schunk -- FAIL\n", name);
+    return -1;
+  }
+
+  blosc2_dparams dparams = BLOSC2_DPARAMS_DEFAULTS;
+  dparams.schunk = schunk;
+
+  uint8_t *input  = calloc(1, (size_t) (length > 0 ? length : 1));
+  uint8_t *output = malloc((size_t) (length > 0 ? length : 1));
+
+  int rc = ndmean_backward(input, output, length, cell_shape, &dparams, 0);
+
+  free(input);
+  free(output);
+  blosc2_schunk_free(schunk);
+
+  if (rc >= 0) {
+    printf("  %-30s: NOT rejected (rc=%d) -- FAIL\n", name, rc);
+    return -1;
+  }
+  printf("  %-30s: rejected (rc=%d) -- OK\n", name, rc);
+  return 0;
+}
+
+int main(void) {
+  int result = 0;
+  blosc2_init();   // mandatory for initializing the plugin mechanism
+  printf("NDMEAN decompress hardening regression tests:\n");
+
+  /* typesize 4: 4*65536*65537 = 0x400040000, low 32 bits = 0x40000 = 262144 == length */
+  result |= expect_rejected("32-bit wrap onto length", 65536, 65537, 262144, 4, 2);
+  /* a zero block dimension must be invalid input */
+  result |= expect_rejected("zero block dimension", 0, 64, 1024, 4, 2);
+  /* a negative block dimension must be invalid input */
+  result |= expect_rejected("negative block dimension", -1, 64, 1024, 4, 2);
+
+  if (result == 0) {
+    printf("All NDMEAN hardening checks passed.\n");
+  }
+  blosc2_destroy();
+  return result;
+}


### PR DESCRIPTION
Harden the NDMEAN filter against malformed or attacker-controlled `b2nd` metadata by validating block geometry using 64-bit arithmetic and rejecting invalid block dimensions.

Previously, `ndmean_forward()` and `ndmean_backward()` computed:

```c
blocksize = typesize * product(blockshape)
```

using 32-bit arithmetic. A crafted `blockshape` could cause the multiplication to wrap around and produce a value equal to `length`, allowing the size validation to succeed despite the true block geometry being much larger.

Subsequent indexing operations would then use the actual dimensions derived from the metadata, potentially resulting in out-of-bounds memory accesses.

## Changes

* Compute block size using `int64_t` instead of `int32_t`.
* Reject non-positive block dimensions (`blockshape[i] <= 0`).
* Abort when the running block size exceeds the expected block length.
* Use 64-bit comparisons when validating `length == blocksize`.
* Update diagnostic logging for 64-bit values.
* Add a regression test covering:

  * 32-bit multiplication wraparound onto `length`
  * Zero block dimensions
  * Negative block dimensions

## Security Impact

This change prevents malformed `b2nd` metadata from bypassing block-size validation through integer overflow and eliminates a path that could lead to heap out-of-bounds accesses during NDMEAN processing.

## Testing

Added `test_ndmean_oversized` and verified rejection of:

* Overflowing blockshape products
* Zero-sized dimensions
* Negative dimensions
