### PR TITLE
Add opt-in file locking for disk-based frames shared across processes

### DIFF
--- a/README_CFRAME_FORMAT.rst
+++ b/README_CFRAME_FORMAT.rst
@@ -342,3 +342,11 @@ However, the *vlmetalayers* follows the same format as the ones stored in the he
 
 :fingerprint:
     (``uint128``) Fix storage space for the fingerprint (16 bytes), padded to the left.
+
+
+Sidecar lock file
+-----------------
+
+When the optional file locking is enabled for an on-disk cframe (via the `locking` member of `blosc2_stdio_params`, passed in the `params` member of the `blosc2_io` struct), a small sidecar file appears next to the frame file, with the same name plus a `.b2lock` suffix. It is used to serialize accesses from several handles (typically in different processes) to the same cframe: readers share the lock, mutating operations take it exclusively, and it also carries a change counter so that open handles detect mutations made through other handles. See the `file-locking.c example <https://github.com/Blosc/c-blosc2/blob/main/examples/file-locking.c>`_ for usage.
+
+The sidecar is *not* part of the cframe format: it carries no frame data, it is safe to delete whenever no process has the cframe open, and `blosc2_remove_urlpath()` removes it together with the frame file. Note that the locking is advisory (it only protects the cframe if every handle enables it) and that it is not supported on network filesystems (NFS).

--- a/README_SFRAME_FORMAT.rst
+++ b/README_SFRAME_FORMAT.rst
@@ -18,6 +18,13 @@ Each chunk follows the format described in the `chunk format <https://github.com
 
 *Note:* The real order of the chunks is in the index chunk and may not follow the order of the names. This can occur when doing an insertion or a reorder. For more information see the **Examples** section below.
 
+Sidecar lock file
+-----------------
+
+When the optional file locking is enabled (via the `locking` member of `blosc2_stdio_params`, passed in the `params` member of the `blosc2_io` struct), a small sidecar file named `.b2lock` appears inside the sframe directory. It is used to serialize accesses from several handles (typically in different processes) to the same sframe: readers share the lock, mutating operations take it exclusively, and it also carries a change counter so that open handles detect mutations made through other handles. See the `file-locking.c example <https://github.com/Blosc/c-blosc2/blob/main/examples/file-locking.c>`_ for usage.
+
+The sidecar is *not* part of the sframe format: it carries no frame data, it is safe to delete whenever no process has the sframe open, and it is removed together with the sframe directory. Note that the locking is advisory (it only protects the sframe if every handle enables it) and that it is not supported on network filesystems (NFS).
+
 Examples
 --------
 

--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -16,6 +16,7 @@ set(SOURCES_ZERO_RUNLEN zero_runlen.c)
 set(SOURCES_CFRAME create_frame.c)
 set(SOURCES_SFRAME sframe_bench.c)
 set(SOURCES_GET_SPARSE get_sparse.c)
+set(SOURCES_FRAME_LOCK frame_lock_bench.c)
 
 add_subdirectory(b2nd)
 
@@ -28,6 +29,7 @@ add_executable(zero_runlen ${SOURCES_ZERO_RUNLEN})
 add_executable(create_frame ${SOURCES_CFRAME})
 add_executable(sframe_bench ${SOURCES_SFRAME})
 add_executable(get_sparse ${SOURCES_GET_SPARSE})
+add_executable(frame_lock_bench ${SOURCES_FRAME_LOCK})
 if(UNIX AND NOT APPLE)
     # cmake is complaining about LINK_PRIVATE in original PR
     # and removing it does not seem to hurt, so be it.
@@ -40,6 +42,7 @@ if(UNIX AND NOT APPLE)
     target_link_libraries(create_frame rt)
     target_link_libraries(sframe_bench rt)
     target_link_libraries(get_sparse rt)
+    target_link_libraries(frame_lock_bench rt)
 endif()
 if(UNIX)
     if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
@@ -55,6 +58,7 @@ target_link_libraries(zero_runlen blosc_testing)
 target_link_libraries(create_frame blosc_testing)
 target_link_libraries(sframe_bench blosc_testing)
 target_link_libraries(get_sparse blosc_testing)
+target_link_libraries(frame_lock_bench blosc_testing)
 
 # tests
 if(BUILD_TESTS)

--- a/bench/frame_lock_bench.c
+++ b/bench/frame_lock_bench.c
@@ -1,0 +1,142 @@
+/*
+  Copyright (c) 2021  Blosc Development Team <blosc@blosc.org>
+  https://blosc.org
+  License: BSD 3-Clause (see LICENSE.txt)
+
+  Benchmark for the opt-in cross-process frame locking
+  (blosc2_stdio_params.locking): measures the per-operation overhead of the
+  sidecar lock by running the same workload on a disk-based sparse frame with
+  locking disabled and enabled.
+
+  To run:
+
+  $ ./frame_lock_bench
+  locking=off  get_lazychunk:    23731 ns  decompress:    64382 ns  update:   264792 ns
+  locking=on   get_lazychunk:    24303 ns  decompress:    65273 ns  update:   265234 ns
+  overhead:    get_lazychunk:    +2.4 %    decompress:     +1.4 %   update:     +0.2 %
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <blosc2.h>
+
+#define CHUNKSIZE (100 * 1000)   /* items per chunk (int64_t) */
+#define NCHUNKS (50)
+#define NREADS (20 * 1000)
+#define NUPDATES (500)
+#define URLPATH "frame_lock_bench.b2frame"
+
+
+static double elapsed_ns_per_op(blosc_timestamp_t t0, int nops) {
+  blosc_timestamp_t t1;
+  blosc_set_timestamp(&t1);
+  return blosc_elapsed_nsecs(t0, t1) / nops;
+}
+
+
+/* Run the workload with or without locking; fills results[3] with ns/op for
+   get_lazychunk, decompress_chunk and update_chunk (with a special chunk). */
+static int run(bool locking, double results[3]) {
+  blosc2_stdio_params ioparams = {.locking = true};
+  blosc2_io io = {.id = BLOSC2_IO_FILESYSTEM, .name = "filesystem", .params = &ioparams};
+  blosc2_cparams cparams = BLOSC2_CPARAMS_DEFAULTS;
+  cparams.typesize = sizeof(int64_t);
+  blosc2_storage storage = {.contiguous = false, .urlpath = URLPATH, .cparams = &cparams};
+  if (locking) {
+    storage.io = &io;
+  }
+  blosc2_remove_urlpath(URLPATH);
+
+  blosc2_schunk *schunk = blosc2_schunk_new(&storage);
+  if (schunk == NULL) {
+    return -1;
+  }
+  int64_t *data = malloc(CHUNKSIZE * sizeof(int64_t));
+  for (int nchunk = 0; nchunk < NCHUNKS; nchunk++) {
+    for (int i = 0; i < CHUNKSIZE; i++) {
+      data[i] = nchunk * CHUNKSIZE + i;
+    }
+    if (blosc2_schunk_append_buffer(schunk, data, CHUNKSIZE * sizeof(int64_t)) < 0) {
+      return -1;
+    }
+  }
+  blosc2_schunk_free(schunk);
+  schunk = locking ? blosc2_schunk_open_udio(URLPATH, &io) : blosc2_schunk_open(URLPATH);
+  if (schunk == NULL) {
+    return -1;
+  }
+
+  uint8_t *chunk;
+  bool needs_free;
+  blosc_timestamp_t t0;
+
+  // get_lazychunk (one untimed warm-up sweep first)
+  for (int pass = 0; pass < 2; pass++) {
+    blosc_set_timestamp(&t0);
+    for (int i = 0; i < NREADS; i++) {
+      int csize = blosc2_schunk_get_lazychunk(schunk, i % NCHUNKS, &chunk, &needs_free);
+      if (csize < 0) {
+        return -1;
+      }
+      if (needs_free) {
+        free(chunk);
+      }
+    }
+    results[0] = elapsed_ns_per_op(t0, NREADS);
+  }
+
+  // decompress_chunk
+  int64_t *dest = malloc(CHUNKSIZE * sizeof(int64_t));
+  const int ndecs = NREADS / 10;
+  blosc_set_timestamp(&t0);
+  for (int i = 0; i < ndecs; i++) {
+    if (blosc2_schunk_decompress_chunk(schunk, i % NCHUNKS, dest,
+                                       CHUNKSIZE * sizeof(int64_t)) < 0) {
+      return -1;
+    }
+  }
+  results[1] = elapsed_ns_per_op(t0, ndecs);
+
+  // update_chunk with an UNINIT special chunk (the cache-eviction primitive)
+  uint8_t uninit[BLOSC_EXTENDED_HEADER_LENGTH];
+  if (blosc2_chunk_uninit(*schunk->storage->cparams, CHUNKSIZE * sizeof(int64_t),
+                          uninit, sizeof(uninit)) < 0) {
+    return -1;
+  }
+  blosc_set_timestamp(&t0);
+  for (int i = 0; i < NUPDATES; i++) {
+    if (blosc2_schunk_update_chunk(schunk, i % NCHUNKS, uninit, true) < 0) {
+      return -1;
+    }
+  }
+  results[2] = elapsed_ns_per_op(t0, NUPDATES);
+
+  blosc2_schunk_free(schunk);
+  blosc2_remove_urlpath(URLPATH);
+  free(data);
+  free(dest);
+  return 0;
+}
+
+
+int main(void) {
+  blosc2_init();
+
+  double off[3], on[3];
+  if (run(false, off) < 0 || run(true, on) < 0) {
+    printf("Error running the frame lock benchmark!\n");
+    return -1;
+  }
+
+  printf("locking=off  get_lazychunk: %8.0f ns  decompress: %8.0f ns  update: %8.0f ns\n",
+         off[0], off[1], off[2]);
+  printf("locking=on   get_lazychunk: %8.0f ns  decompress: %8.0f ns  update: %8.0f ns\n",
+         on[0], on[1], on[2]);
+  printf("overhead:    get_lazychunk: %+7.1f %%   decompress: %+7.1f %%  update: %+7.1f %%\n",
+         100.0 * (on[0] - off[0]) / off[0],
+         100.0 * (on[1] - off[1]) / off[1],
+         100.0 * (on[2] - off[2]) / off[2]);
+
+  blosc2_destroy();
+  return 0;
+}

--- a/blosc/blosc2.c
+++ b/blosc/blosc2.c
@@ -6910,6 +6910,8 @@ const char *blosc2_error_string(int error_code) {
       return "Wrong type for frame";
     case BLOSC2_ERROR_FILE_TRUNCATE:
       return "File truncate failure";
+    case BLOSC2_ERROR_LOCK:
+      return "Frame lock failure";
     case BLOSC2_ERROR_THREAD_CREATE:
       return "Thread or thread context creation failure";
     case BLOSC2_ERROR_POSTFILTER:

--- a/blosc/directories.c
+++ b/blosc/directories.c
@@ -226,6 +226,14 @@ int blosc2_remove_urlpath(const char* urlpath){
       BLOSC_TRACE_ERROR("Could not remove %s", urlpath);
       return BLOSC2_ERROR_FILE_REMOVE;
     }
+    // Also remove the sidecar lock file of a cframe, if any
+    char* lockpath = malloc(strlen(urlpath) + strlen(".b2lock") + 1);
+    if (lockpath != NULL) {
+      strcpy(lockpath, urlpath);
+      strcat(lockpath, ".b2lock");
+      remove(lockpath);  // best-effort; may not exist
+      free(lockpath);
+    }
   }
   return BLOSC2_ERROR_SUCCESS;
 }

--- a/blosc/frame.c
+++ b/blosc/frame.c
@@ -8,6 +8,14 @@
   See LICENSE.txt for details about copyright and rights to use.
 **********************************************************************/
 
+#if !defined(_WIN32)
+// Make flock() and O_CLOEXEC visible despite -D_XOPEN_SOURCE=600 (as in blosc2-stdio.c)
+#if !defined(_GNU_SOURCE)
+#define _GNU_SOURCE
+#endif
+#define _DARWIN_C_SOURCE
+#endif
+
 #include "frame.h"
 #include "sframe.h"
 #include "context.h"
@@ -20,6 +28,14 @@
 #include <malloc.h>
 // See https://github.com/Blosc/python-blosc2/issues/359#issuecomment-2625380236
 #define stat _stat64
+#else
+#include <errno.h>
+#include <fcntl.h>
+#include <sys/file.h>
+#include <unistd.h>
+#if !defined(O_CLOEXEC)
+#define O_CLOEXEC 0
+#endif
 #endif  /* _WIN32 */
 
 #include <inttypes.h>
@@ -55,8 +71,211 @@ blosc2_frame_s* frame_new(const char* urlpath) {
 }
 
 
+void frame_set_locking(blosc2_frame_s* frame, const blosc2_io* io) {
+  if (io != NULL && io->id == BLOSC2_IO_FILESYSTEM && io->params != NULL &&
+      ((blosc2_stdio_params*)io->params)->locking && frame->urlpath != NULL) {
+    frame->locking = true;
+    frame->lock_fd = -1;
+  }
+}
+
+
+/* Path of the sidecar lock file: inside the directory for sframes (removed for
+   free by blosc2_remove_dir), alongside the file for cframes. */
+static char* frame_lock_path(blosc2_frame_s* frame) {
+  const char* suffix = frame->sframe ? "/.b2lock" : ".b2lock";
+  char* path = malloc(strlen(frame->urlpath) + strlen(suffix) + 1);
+  if (path == NULL) {
+    return NULL;
+  }
+  strcpy(path, frame->urlpath);
+  strcat(path, suffix);
+  return path;
+}
+
+
+// Where the generation counter lives in the sidecar (past the byte range
+// locked by LockFileEx on Windows)
+#define FRAME_LOCK_SEQ_OFFSET 8
+
+
+static int frame_os_lock(blosc2_frame_s* frame, bool exclusive) {
+#if defined(_WIN32)
+  OVERLAPPED ov;
+  memset(&ov, 0, sizeof(ov));
+  if (!LockFileEx((HANDLE)frame->lock_fd, exclusive ? LOCKFILE_EXCLUSIVE_LOCK : 0,
+                  0, 1, 0, &ov)) {
+    return BLOSC2_ERROR_LOCK;
+  }
+#else
+  int rc;
+  do {
+    rc = flock((int)frame->lock_fd, exclusive ? LOCK_EX : LOCK_SH);
+  } while (rc != 0 && errno == EINTR);
+  if (rc != 0) {
+    return BLOSC2_ERROR_LOCK;
+  }
+#endif
+  return BLOSC2_ERROR_SUCCESS;
+}
+
+
+static int frame_os_unlock(blosc2_frame_s* frame) {
+#if defined(_WIN32)
+  OVERLAPPED ov;
+  memset(&ov, 0, sizeof(ov));
+  if (!UnlockFileEx((HANDLE)frame->lock_fd, 0, 1, 0, &ov)) {
+    return BLOSC2_ERROR_LOCK;
+  }
+#else
+  if (flock((int)frame->lock_fd, LOCK_UN) != 0) {
+    return BLOSC2_ERROR_LOCK;
+  }
+#endif
+  return BLOSC2_ERROR_SUCCESS;
+}
+
+
+/* Read the sidecar's generation counter (must be called with the lock held).
+   A fresh (short) sidecar reads as 0. */
+static int frame_lock_read_seq(blosc2_frame_s* frame, uint64_t* seq) {
+  *seq = 0;
+#if defined(_WIN32)
+  OVERLAPPED ov;
+  memset(&ov, 0, sizeof(ov));
+  ov.Offset = FRAME_LOCK_SEQ_OFFSET;
+  DWORD nread = 0;
+  if (!ReadFile((HANDLE)frame->lock_fd, seq, sizeof(*seq), &nread, &ov)) {
+    if (GetLastError() != ERROR_HANDLE_EOF) {
+      return BLOSC2_ERROR_LOCK;
+    }
+  }
+  if (nread != sizeof(*seq)) {
+    *seq = 0;
+  }
+#else
+  int64_t nread = pread((int)frame->lock_fd, seq, sizeof(*seq), FRAME_LOCK_SEQ_OFFSET);
+  if (nread < 0) {
+    return BLOSC2_ERROR_LOCK;
+  }
+  if (nread != (int64_t)sizeof(*seq)) {
+    *seq = 0;
+  }
+#endif
+  return BLOSC2_ERROR_SUCCESS;
+}
+
+
+/* Write the sidecar's generation counter (must be called with the exclusive
+   lock held). */
+static int frame_lock_write_seq(blosc2_frame_s* frame, uint64_t seq) {
+#if defined(_WIN32)
+  OVERLAPPED ov;
+  memset(&ov, 0, sizeof(ov));
+  ov.Offset = FRAME_LOCK_SEQ_OFFSET;
+  DWORD nwritten = 0;
+  if (!WriteFile((HANDLE)frame->lock_fd, &seq, sizeof(seq), &nwritten, &ov) ||
+      nwritten != sizeof(seq)) {
+    return BLOSC2_ERROR_LOCK;
+  }
+#else
+  if (pwrite((int)frame->lock_fd, &seq, sizeof(seq), FRAME_LOCK_SEQ_OFFSET) !=
+      (int64_t)sizeof(seq)) {
+    return BLOSC2_ERROR_LOCK;
+  }
+#endif
+  return BLOSC2_ERROR_SUCCESS;
+}
+
+
+int frame_lock(blosc2_frame_s* frame, bool exclusive) {
+  if (frame == NULL || !frame->locking) {
+    return BLOSC2_ERROR_SUCCESS;
+  }
+  if (frame->lock_depth > 0) {
+    // Already held by this handle (a nested call); the outer lock covers us
+    frame->lock_depth++;
+    return BLOSC2_ERROR_SUCCESS;
+  }
+  if (frame->lock_fd == -1) {
+    // Lazily open the sidecar, kept for the frame's lifetime
+    char* path = frame_lock_path(frame);
+    if (path == NULL) {
+      return BLOSC2_ERROR_MEMORY_ALLOC;
+    }
+#if defined(_WIN32)
+    HANDLE h = CreateFileA(path, GENERIC_READ | GENERIC_WRITE,
+                           FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                           NULL, OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
+    if (h == INVALID_HANDLE_VALUE) {
+      BLOSC_TRACE_ERROR("Cannot open the lock file in: %s", path);
+      free(path);
+      return BLOSC2_ERROR_LOCK;
+    }
+    frame->lock_fd = (intptr_t)h;
+#else
+    int fd = open(path, O_CREAT | O_RDWR | O_CLOEXEC, 0666);
+    if (fd < 0) {
+      BLOSC_TRACE_ERROR("Cannot open the lock file in: %s", path);
+      free(path);
+      return BLOSC2_ERROR_LOCK;
+    }
+    frame->lock_fd = fd;
+#endif
+    free(path);
+  }
+  if (frame_os_lock(frame, exclusive) < 0) {
+    BLOSC_TRACE_ERROR("Cannot lock the frame.");
+    return BLOSC2_ERROR_LOCK;
+  }
+  // Generation counter: writers bump it, everyone compares it with the last
+  // value it saw.  This detects mutations by other handles exactly, even when
+  // the frame length on disk ends up unchanged (which the length-based
+  // staleness check in frame_refresh_if_stale() cannot see).
+  uint64_t seq;
+  if (frame_lock_read_seq(frame, &seq) < 0 ||
+      (exclusive && frame_lock_write_seq(frame, seq + 1) < 0)) {
+    BLOSC_TRACE_ERROR("Cannot access the frame lock generation counter.");
+    frame_os_unlock(frame);
+    return BLOSC2_ERROR_LOCK;
+  }
+  if (seq != frame->lock_seq) {
+    frame->force_refresh = true;
+  }
+  if (exclusive) {
+    seq++;
+  }
+  frame->lock_seq = seq;
+  frame->lock_depth = 1;
+  return BLOSC2_ERROR_SUCCESS;
+}
+
+
+int frame_unlock(blosc2_frame_s* frame) {
+  if (frame == NULL || !frame->locking || frame->lock_depth == 0) {
+    return BLOSC2_ERROR_SUCCESS;
+  }
+  if (--frame->lock_depth > 0) {
+    return BLOSC2_ERROR_SUCCESS;
+  }
+  if (frame_os_unlock(frame) < 0) {
+    BLOSC_TRACE_ERROR("Cannot unlock the frame.");
+    return BLOSC2_ERROR_LOCK;
+  }
+  return BLOSC2_ERROR_SUCCESS;
+}
+
+
 /* Free memory from a frame. */
 int frame_free(blosc2_frame_s* frame) {
+
+  if (frame->locking && frame->lock_fd != -1) {
+#if defined(_WIN32)
+    CloseHandle((HANDLE)frame->lock_fd);
+#else
+    close((int)frame->lock_fd);
+#endif
+  }
 
   if (frame->cframe != NULL && !frame->avoid_cframe_free) {
     free(frame->cframe);
@@ -573,9 +792,13 @@ int64_t get_trailer_offset(blosc2_frame_s *frame, int32_t header_len, bool has_c
  * this way, and single-handle flows always match, so this is a no-op for them.
  * Returns 1 if a refresh took place, 0 if none was needed, or a negative error. */
 static int frame_refresh_if_stale(blosc2_frame_s *frame, int64_t frame_len_on_disk) {
-  if (frame->cframe != NULL || frame->schunk == NULL || frame_len_on_disk == frame->len) {
+  if (frame->cframe != NULL || frame->schunk == NULL ||
+      (!frame->force_refresh && frame_len_on_disk == frame->len)) {
     return 0;
   }
+  // The lock generation counter (see frame_lock) may have flagged a mutation
+  // that left the frame length unchanged; the refresh below covers it
+  frame->force_refresh = false;
 
   if (frame_len_on_disk < FRAME_HEADER_MINLEN + FRAME_TRAILER_MINLEN) {
     BLOSC_TRACE_ERROR("Invalid on-disk frame length (%" PRId64 ").", frame_len_on_disk);
@@ -1134,6 +1357,7 @@ blosc2_frame_s* frame_from_file_offset(const char* urlpath, const blosc2_io *io,
       return NULL;
     }
     frame->trailer_len = trailer_len;
+    frame_set_locking(frame, io);
 
     return frame;
 }

--- a/blosc/frame.h
+++ b/blosc/frame.h
@@ -71,6 +71,11 @@ typedef struct {
   bool sframe;              //!< Whether the frame is sparse (true) or not
   blosc2_schunk *schunk;    //!< The schunk associated
   int64_t file_offset;      //!< The offset where the frame starts inside the file
+  bool locking;             //!< Whether accesses are serialized via a sidecar lock file
+  intptr_t lock_fd;         //!< The fd (POSIX) or HANDLE (Windows) of the sidecar; -1 if not open
+  int32_t lock_depth;       //!< Lock re-entrancy depth; only depth 0 acquires/releases
+  uint64_t lock_seq;        //!< Last seen value of the sidecar's generation counter
+  bool force_refresh;       //!< Force a refresh of the cached frame state on the next access
 } blosc2_frame_s;
 
 
@@ -171,6 +176,32 @@ int frame_decompress_chunk(blosc2_context* dctx, blosc2_frame_s* frame, int64_t 
 
 int frame_update_header(blosc2_frame_s* frame, blosc2_schunk* schunk, bool new);
 int frame_update_trailer(blosc2_frame_s* frame, blosc2_schunk* schunk);
+
+/**
+ * @brief Acquire the frame's cross-process advisory lock (shared for reads,
+ * exclusive for mutations), blocking until available.  A no-op unless locking
+ * was requested at open/creation time (or when @p frame is NULL, for non-frame
+ * schunks).  Re-entrant on the same frame handle via a depth counter, so an
+ * exclusive section can nest shared ones.
+ *
+ * @return 0 if succeeds; BLOSC2_ERROR_LOCK otherwise.
+ */
+int frame_lock(blosc2_frame_s* frame, bool exclusive);
+
+/**
+ * @brief Release one level of the frame's advisory lock (the OS lock is
+ * released when the depth reaches zero).  A no-op when locking is off.
+ *
+ * @return 0 if succeeds; BLOSC2_ERROR_LOCK otherwise.
+ */
+int frame_unlock(blosc2_frame_s* frame);
+
+/**
+ * @brief Enable sidecar locking on @p frame when @p io requests it (default
+ * filesystem backend with blosc2_stdio_params.locking set).  Only meaningful
+ * for disk-based frames.
+ */
+void frame_set_locking(blosc2_frame_s* frame, const blosc2_io* io);
 
 int64_t frame_fill_special(blosc2_frame_s* frame, int64_t nitems, int special_value,
                        int32_t chunksize, blosc2_schunk* schunk);

--- a/blosc/schunk.c
+++ b/blosc/schunk.c
@@ -201,6 +201,7 @@ blosc2_schunk* blosc2_schunk_new(blosc2_storage *storage) {
       return NULL;
     }
     frame->sframe = true;
+    frame_set_locking(frame, schunk->storage->io);
     // Initialize frame (basically, encode the header)
     frame->schunk = schunk;
     int64_t frame_len = frame_from_schunk(schunk, frame);
@@ -224,6 +225,7 @@ blosc2_schunk* blosc2_schunk_new(blosc2_storage *storage) {
       return NULL;
     }
     frame->sframe = false;
+    frame_set_locking(frame, schunk->storage->io);
     // Initialize frame (basically, encode the header)
     frame->schunk = schunk;
     int64_t frame_len = frame_from_schunk(schunk, frame);
@@ -383,11 +385,19 @@ blosc2_schunk* blosc2_schunk_open_offset_udio(const char* urlpath, int64_t offse
     }
     return NULL;
   }
+  // Guard the initial read of the frame against concurrent writers
+  if (frame_lock(frame, false) < 0) {
+    frame_free(frame);
+    return NULL;
+  }
   blosc2_schunk* schunk = frame_to_schunk(frame, false, udio);
   if (schunk == NULL) {
     BLOSC_TRACE_ERROR("Error converting frame to super-chunk");
+    // frame_to_schunk() has already freed the frame on failure; closing its
+    // lock fd released the OS lock, so no frame_unlock() here
     return NULL;
   }
+  frame_unlock(frame);
 
   // Set the storage with proper defaults
   size_t pathlen = strlen(urlpath);
@@ -743,7 +753,15 @@ int64_t blosc2_schunk_fill_special(blosc2_schunk* schunk, int64_t nitems, int sp
     schunk->chunksize = chunksize;
     schunk->nchunks = nchunks;
     schunk->nbytes = nitems * typesize;
+    int rc = frame_lock(frame, true);
+    if (rc < 0) {
+      schunk->chunksize = old_chunksize;
+      schunk->nchunks = old_nchunks;
+      schunk->nbytes = old_nbytes;
+      return rc;
+    }
     int64_t frame_len = frame_fill_special(frame, nitems, special_value, chunksize, schunk);
+    frame_unlock(frame);
     if (frame_len < 0) {
       schunk->chunksize = old_chunksize;
       schunk->nchunks = old_nchunks;
@@ -795,7 +813,7 @@ static int schunk_get_chunk_flags2(blosc2_schunk *schunk, int64_t nchunk, uint8_
 }
 
 /* Append an existing chunk into a super-chunk. */
-int64_t blosc2_schunk_append_chunk(blosc2_schunk *schunk, uint8_t *chunk, bool copy) {
+static int64_t schunk_append_chunk_unlocked(blosc2_schunk *schunk, uint8_t *chunk, bool copy) {
   int32_t chunk_nbytes;
   int32_t chunk_cbytes;
   int64_t nchunks = schunk->nchunks;
@@ -896,8 +914,21 @@ int64_t blosc2_schunk_append_chunk(blosc2_schunk *schunk, uint8_t *chunk, bool c
 }
 
 
+/* Append an existing @p chunk to a super-chunk. */
+int64_t blosc2_schunk_append_chunk(blosc2_schunk *schunk, uint8_t *chunk, bool copy) {
+  blosc2_frame_s* frame = (blosc2_frame_s*)schunk->frame;
+  int rc = frame_lock(frame, true);
+  if (rc < 0) {
+    return rc;
+  }
+  int64_t nchunks = schunk_append_chunk_unlocked(schunk, chunk, copy);
+  frame_unlock(frame);
+  return nchunks;
+}
+
+
 /* Insert an existing @p chunk in a specified position on a super-chunk */
-int64_t blosc2_schunk_insert_chunk(blosc2_schunk *schunk, int64_t nchunk, uint8_t *chunk, bool copy) {
+static int64_t schunk_insert_chunk_unlocked(blosc2_schunk *schunk, int64_t nchunk, uint8_t *chunk, bool copy) {
   int rc = validate_nchunk(schunk, nchunk, true, "blosc2_schunk_insert_chunk");
   if (rc < 0) {
     return rc;
@@ -1011,7 +1042,20 @@ int64_t blosc2_schunk_insert_chunk(blosc2_schunk *schunk, int64_t nchunk, uint8_
 }
 
 
-int64_t blosc2_schunk_update_chunk(blosc2_schunk *schunk, int64_t nchunk, uint8_t *chunk, bool copy) {
+/* Insert an existing @p chunk in a specified position on a super-chunk. */
+int64_t blosc2_schunk_insert_chunk(blosc2_schunk *schunk, int64_t nchunk, uint8_t *chunk, bool copy) {
+  blosc2_frame_s* frame = (blosc2_frame_s*)schunk->frame;
+  int rc = frame_lock(frame, true);
+  if (rc < 0) {
+    return rc;
+  }
+  int64_t nchunks = schunk_insert_chunk_unlocked(schunk, nchunk, chunk, copy);
+  frame_unlock(frame);
+  return nchunks;
+}
+
+
+static int64_t schunk_update_chunk_unlocked(blosc2_schunk *schunk, int64_t nchunk, uint8_t *chunk, bool copy) {
   int rc = validate_nchunk(schunk, nchunk, false, "blosc2_schunk_update_chunk");
   if (rc < 0) {
     return rc;
@@ -1137,7 +1181,20 @@ int64_t blosc2_schunk_update_chunk(blosc2_schunk *schunk, int64_t nchunk, uint8_
   return schunk->nchunks;
 }
 
-int64_t blosc2_schunk_delete_chunk(blosc2_schunk *schunk, int64_t nchunk) {
+/* Update the chunk at a specified position of a super-chunk. */
+int64_t blosc2_schunk_update_chunk(blosc2_schunk *schunk, int64_t nchunk, uint8_t *chunk, bool copy) {
+  blosc2_frame_s* frame = (blosc2_frame_s*)schunk->frame;
+  int rc = frame_lock(frame, true);
+  if (rc < 0) {
+    return rc;
+  }
+  int64_t nchunks = schunk_update_chunk_unlocked(schunk, nchunk, chunk, copy);
+  frame_unlock(frame);
+  return nchunks;
+}
+
+
+static int64_t schunk_delete_chunk_unlocked(blosc2_schunk *schunk, int64_t nchunk) {
   int rc = validate_nchunk(schunk, nchunk, false, "blosc2_schunk_delete_chunk");
   if (rc < 0) {
     return rc;
@@ -1207,6 +1264,19 @@ int64_t blosc2_schunk_delete_chunk(blosc2_schunk *schunk, int64_t nchunk) {
 }
 
 
+/* Delete the chunk at a specified position of a super-chunk. */
+int64_t blosc2_schunk_delete_chunk(blosc2_schunk *schunk, int64_t nchunk) {
+  blosc2_frame_s* frame = (blosc2_frame_s*)schunk->frame;
+  int rc = frame_lock(frame, true);
+  if (rc < 0) {
+    return rc;
+  }
+  int64_t nchunks = schunk_delete_chunk_unlocked(schunk, nchunk);
+  frame_unlock(frame);
+  return nchunks;
+}
+
+
 /* Append a data buffer to a super-chunk. */
 int64_t blosc2_schunk_append_buffer(blosc2_schunk *schunk, const void *src, int32_t nbytes) {
   uint8_t* chunk = malloc(nbytes + BLOSC2_MAX_OVERHEAD);
@@ -1268,7 +1338,12 @@ int blosc2_schunk_decompress_chunk(blosc2_schunk *schunk, int64_t nchunk,
       return BLOSC2_ERROR_FAILURE;
     }
   } else {
+    rc = frame_lock(frame, false);
+    if (rc < 0) {
+      return rc;
+    }
     chunksize = frame_decompress_chunk(schunk->dctx, frame, nchunk, dest, nbytes);
+    frame_unlock(frame);
     if (chunksize < 0) {
       return chunksize;
     }
@@ -1303,7 +1378,13 @@ int blosc2_schunk_get_chunk(blosc2_schunk *schunk, int64_t nchunk, uint8_t **chu
   }
   blosc2_frame_s* frame = (blosc2_frame_s*)schunk->frame;
   if (frame != NULL) {
-    return frame_get_chunk(frame, nchunk, chunk, needs_free);
+    rc = frame_lock(frame, false);
+    if (rc < 0) {
+      return rc;
+    }
+    rc = frame_get_chunk(frame, nchunk, chunk, needs_free);
+    frame_unlock(frame);
+    return rc;
   }
 
   *chunk = schunk->data[nchunk];
@@ -1348,7 +1429,13 @@ int blosc2_schunk_get_lazychunk(blosc2_schunk *schunk, int64_t nchunk, uint8_t *
   }
   blosc2_frame_s* frame = (blosc2_frame_s*)schunk->frame;
   if (schunk->frame != NULL) {
-    return frame_get_lazychunk(frame, nchunk, chunk, needs_free);
+    rc = frame_lock(frame, false);
+    if (rc < 0) {
+      return rc;
+    }
+    rc = frame_get_lazychunk(frame, nchunk, chunk, needs_free);
+    frame_unlock(frame);
+    return rc;
   }
 
   *chunk = schunk->data[nchunk];
@@ -1978,7 +2065,13 @@ int blosc2_schunk_reorder_offsets(blosc2_schunk *schunk, int64_t *offsets_order)
 
   blosc2_frame_s* frame = (blosc2_frame_s*)schunk->frame;
   if (frame != NULL) {
-    return frame_reorder_offsets(frame, offsets_order, schunk);
+    int rc = frame_lock(frame, true);
+    if (rc < 0) {
+      return rc;
+    }
+    rc = frame_reorder_offsets(frame, offsets_order, schunk);
+    frame_unlock(frame);
+    return rc;
   }
   uint8_t **offsets = schunk->data;
 
@@ -2029,16 +2122,23 @@ int metalayer_flush(blosc2_schunk* schunk) {
   if (frame == NULL) {
     return rc;
   }
+  rc = frame_lock(frame, true);
+  if (rc < 0) {
+    return rc;
+  }
   rc = frame_update_header(frame, schunk, true);
   if (rc < 0) {
     BLOSC_TRACE_ERROR("Unable to update metalayers into frame.");
+    frame_unlock(frame);
     return rc;
   }
   rc = frame_update_trailer(frame, schunk);
   if (rc < 0) {
     BLOSC_TRACE_ERROR("Unable to update trailer into frame.");
+    frame_unlock(frame);
     return rc;
   }
+  frame_unlock(frame);
   return rc;
 }
 
@@ -2175,16 +2275,23 @@ int vlmetalayer_flush(blosc2_schunk* schunk) {
   if (frame == NULL) {
     return rc;
   }
+  rc = frame_lock(frame, true);
+  if (rc < 0) {
+    return rc;
+  }
   rc = frame_update_header(frame, schunk, false);
   if (rc < 0) {
     BLOSC_TRACE_ERROR("Unable to update metalayers into frame.");
+    frame_unlock(frame);
     return rc;
   }
   rc = frame_update_trailer(frame, schunk);
   if (rc < 0) {
     BLOSC_TRACE_ERROR("Unable to update trailer into frame.");
+    frame_unlock(frame);
     return rc;
   }
+  frame_unlock(frame);
   return rc;
 }
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -2,7 +2,7 @@
 set(EXAMPLES contexts instrument_codec delta_schunk_ex multithread simple frame_metalayers
     noinit find_roots schunk_simple frame_simple schunk_postfilter urcodecs urfilters frame_vlmetalayers
     sframe_simple frame_backed_schunk compress_file decompress_file frame_offset frame_roundtrip get_set_slice get_blocksize
-    vlblocks)
+    vlblocks file-locking)
 
 add_subdirectory(b2nd)
 

--- a/examples/file-locking.c
+++ b/examples/file-locking.c
@@ -1,0 +1,141 @@
+/*
+  Copyright (c) 2021  Blosc Development Team <blosc@blosc.org>
+  https://blosc.org
+  License: BSD 3-Clause (see LICENSE.txt)
+
+  Example program demonstrating the opt-in file locking for disk-based frames.
+
+  When several handles — typically in different processes — operate on the same
+  on-disk frame (e.g. one process evicting chunks from a cache while others
+  read it), enable `locking` in the I/O parameters of every handle.  Blosc2
+  then serializes the accesses through a small sidecar lock file next to the
+  frame (`<dir>/.b2lock` for sparse frames, `<file>.b2lock` for contiguous
+  ones): readers share the lock, mutating operations take it exclusively, and
+  a stale handle re-syncs its view of the frame automatically.
+
+  Things to know:
+
+  - Locking is *advisory*: it only protects the frame if every handle on it
+    enables it.  Handles opened without `locking` bypass the lock entirely.
+  - It is off by default, and only supported for the default filesystem I/O
+    (BLOSC2_IO_FILESYSTEM); not on network filesystems (NFS).
+  - The lock is held per operation, and it is crash-safe: the OS releases it
+    when a process dies.
+  - Lock failures surface as BLOSC2_ERROR_LOCK.
+
+  To compile this program:
+
+  $ gcc file-locking.c -o file-locking -lblosc2
+
+  To run:
+
+  $ ./file-locking
+  Both handles enabled locking on: file-locking.b2frame
+  Handle 2 read chunk 0 (before eviction): 371 bytes
+  Handle 1 evicted chunk 0 (replaced with an UNINIT special chunk)
+  Handle 2 read chunk 0 (after eviction): 32 bytes (special chunk, re-synced)
+  Success!
+
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <blosc2.h>
+
+#define CHUNKSIZE (1000)    /* items per chunk (int64_t) */
+#define NCHUNKS (10)
+#define URLPATH "file-locking.b2frame"
+
+
+int main(void) {
+  blosc2_init();
+
+  // Opt in to locking: pass blosc2_stdio_params with `locking` set through
+  // the `params` member of the (default filesystem) blosc2_io struct.
+  // These structs must outlive the super-chunks opened with them.
+  blosc2_stdio_params ioparams = {.locking = true};
+  blosc2_io io = {.id = BLOSC2_IO_FILESYSTEM, .name = "filesystem", .params = &ioparams};
+
+  // Create a sparse frame on-disk, with locking enabled from the start
+  blosc2_cparams cparams = BLOSC2_CPARAMS_DEFAULTS;
+  cparams.typesize = sizeof(int64_t);
+  blosc2_storage storage = {.contiguous = false, .urlpath = URLPATH,
+                            .cparams = &cparams, .io = &io};
+  blosc2_remove_urlpath(URLPATH);
+  blosc2_schunk *schunk = blosc2_schunk_new(&storage);
+  if (schunk == NULL) {
+    printf("Cannot create the super-chunk!\n");
+    return -1;
+  }
+  int64_t data[CHUNKSIZE];
+  for (int nchunk = 0; nchunk < NCHUNKS; nchunk++) {
+    for (int i = 0; i < CHUNKSIZE; i++) {
+      data[i] = nchunk * CHUNKSIZE + i;
+    }
+    if (blosc2_schunk_append_buffer(schunk, data, sizeof(data)) < 0) {
+      printf("Cannot append data to the super-chunk!\n");
+      return -1;
+    }
+  }
+  blosc2_schunk_free(schunk);
+
+  // Two independent handles on the same frame, as two cooperating processes
+  // would have (here in a single process for the sake of the example; the
+  // behavior across processes is the same).  Every handle enables locking.
+  blosc2_schunk *h1 = blosc2_schunk_open_udio(URLPATH, &io);
+  blosc2_schunk *h2 = blosc2_schunk_open_udio(URLPATH, &io);
+  if (h1 == NULL || h2 == NULL) {
+    printf("Cannot open the super-chunk!\n");
+    return -1;
+  }
+  printf("Both handles enabled locking on: %s\n", URLPATH);
+
+  // h2 reads chunk 0 (and caches its view of the frame)
+  uint8_t *chunk;
+  bool needs_free;
+  int csize = blosc2_schunk_get_chunk(h2, 0, &chunk, &needs_free);
+  if (csize < 0) {
+    printf("Cannot read a chunk: %s\n", blosc2_error_string(csize));
+    return -1;
+  }
+  if (needs_free) {
+    free(chunk);
+  }
+  printf("Handle 2 read chunk 0 (before eviction): %d bytes\n", csize);
+
+  // h1 mutates the frame behind h2's back: replace chunk 0 with an UNINIT
+  // special chunk (the typical cache-eviction primitive, as this reclaims
+  // the chunk storage on-disk for sparse frames)
+  uint8_t uninit[BLOSC_EXTENDED_HEADER_LENGTH];
+  csize = blosc2_chunk_uninit(*h1->storage->cparams, CHUNKSIZE * sizeof(int64_t),
+                              uninit, sizeof(uninit));
+  if (csize < 0 || blosc2_schunk_update_chunk(h1, 0, uninit, true) < 0) {
+    printf("Cannot evict the chunk!\n");
+    return -1;
+  }
+  printf("Handle 1 evicted chunk 0 (replaced with an UNINIT special chunk)\n");
+
+  // h2 reads again: the operation takes the shared lock (so it cannot land in
+  // the middle of h1's rewrite) and re-syncs its now-stale view of the frame
+  csize = blosc2_schunk_get_chunk(h2, 0, &chunk, &needs_free);
+  if (csize < 0) {
+    printf("Cannot read the mutated chunk: %s\n", blosc2_error_string(csize));
+    return -1;
+  }
+  if (needs_free) {
+    free(chunk);
+  }
+  printf("Handle 2 read chunk 0 (after eviction): %d bytes (special chunk, re-synced)\n",
+         csize);
+  if (csize != BLOSC_EXTENDED_HEADER_LENGTH) {
+    printf("Unexpected chunk size!\n");
+    return -1;
+  }
+
+  printf("Success!\n");
+  blosc2_schunk_free(h1);
+  blosc2_schunk_free(h2);
+  blosc2_remove_urlpath(URLPATH);
+  blosc2_destroy();
+  return 0;
+}

--- a/include/blosc2.h
+++ b/include/blosc2.h
@@ -488,6 +488,7 @@ enum {
   BLOSC2_ERROR_METALAYER_NOT_FOUND = -34,   //!< Metalayer has not been found
   BLOSC2_ERROR_MAX_BUFSIZE_EXCEEDED = -35,  //!< Max buffer size exceeded
   BLOSC2_ERROR_TUNER = -36,           //!< Tuner failure
+  BLOSC2_ERROR_LOCK = -37,            //!< Frame lock failure
 };
 
 

--- a/include/blosc2/blosc2-stdio.h
+++ b/include/blosc2/blosc2-stdio.h
@@ -36,6 +36,26 @@ typedef struct {
   FILE *file;
 } blosc2_stdio_file;
 
+/**
+ * @brief Parameters for the default filesystem I/O (#BLOSC2_IO_FILESYSTEM).
+ * Pass a pointer to this struct in the params member of the #blosc2_io struct;
+ * a NULL params keeps all the defaults. The struct must outlive the super-chunks
+ * opened with it.
+ */
+typedef struct {
+  bool locking;
+  //!< Serialize accesses to a disk-based frame against other handles and other
+  //!< processes, via a sidecar lock file next to the frame (advisory locking:
+  //!< it only protects the frame if every handle on it enables this too).
+  //!< Readers share the lock; mutating operations take it exclusively. Not
+  //!< supported on network filesystems (NFS), nor by other I/O backends.
+} blosc2_stdio_params;
+
+/**
+ * @brief Default filesystem I/O parameters for user initialization.
+ */
+static const blosc2_stdio_params BLOSC2_STDIO_PARAMS_DEFAULTS = {false};
+
 BLOSC_EXPORT void *blosc2_stdio_open(const char *urlpath, const char *mode, void* params);
 BLOSC_EXPORT int blosc2_stdio_close(void *stream);
 BLOSC_EXPORT int64_t blosc2_stdio_size(void *stream);

--- a/tests/test_frame_lock.c
+++ b/tests/test_frame_lock.c
@@ -1,0 +1,291 @@
+/*
+  Copyright (c) 2021  Blosc Development Team <blosc@blosc.org>
+  https://blosc.org
+  License: BSD 3-Clause (see LICENSE.txt)
+
+  See LICENSE.txt for details about copyright and rights to use.
+
+  Test the opt-in cross-process locking for disk-based frames (sidecar lock
+  file via flock/LockFileEx; see blosc2_stdio_params.locking).  The fork-based
+  reader-vs-writer hammer only runs on POSIX systems.
+*/
+
+#include <stdio.h>
+#include "test_common.h"
+
+#if !defined(_WIN32)
+#include <sys/wait.h>
+#include <unistd.h>
+#endif
+
+#define CHUNKSIZE (1000)    /* items per chunk (int32_t) */
+#define NCHUNKS (20)
+#define URLPATH "test_frame_lock.b2frame"
+
+/* Global vars */
+int tests_run = 0;
+
+
+static bool path_exists(const char* path) {
+  FILE* f = fopen(path, "rb");
+  if (f != NULL) {
+    fclose(f);
+    return true;
+  }
+  return false;
+}
+
+
+static blosc2_io* locking_io(void) {
+  static blosc2_stdio_params ioparams = {.locking = true};
+  static blosc2_io io = {.id = BLOSC2_IO_FILESYSTEM, .name = "filesystem", .params = &ioparams};
+  return &io;
+}
+
+
+static int64_t fill_frame(bool contiguous, bool locking) {
+  static int32_t data[CHUNKSIZE];
+  blosc2_cparams cparams = BLOSC2_CPARAMS_DEFAULTS;
+  cparams.typesize = sizeof(int32_t);
+  blosc2_storage storage = {.contiguous = contiguous, .urlpath = URLPATH, .cparams = &cparams};
+  if (locking) {
+    storage.io = locking_io();
+  }
+  blosc2_remove_urlpath(URLPATH);
+
+  blosc2_schunk* schunk = blosc2_schunk_new(&storage);
+  if (schunk == NULL) {
+    return -1;
+  }
+  int64_t nchunks = 0;
+  for (int nchunk = 0; nchunk < NCHUNKS; nchunk++) {
+    for (int i = 0; i < CHUNKSIZE; i++) {
+      data[i] = nchunk * CHUNKSIZE + i;
+    }
+    nchunks = blosc2_schunk_append_buffer(schunk, data, CHUNKSIZE * sizeof(int32_t));
+  }
+  blosc2_schunk_free(schunk);
+  return nchunks;
+}
+
+
+static int evict_chunk(blosc2_schunk* schunk, int64_t nchunk) {
+  uint8_t uninit_chunk[BLOSC_EXTENDED_HEADER_LENGTH];
+  int csize = blosc2_chunk_uninit(*schunk->storage->cparams, CHUNKSIZE * (int32_t)sizeof(int32_t),
+                                  uninit_chunk, sizeof(uninit_chunk));
+  if (csize < 0) {
+    return csize;
+  }
+  int64_t nchunks_ = blosc2_schunk_update_chunk(schunk, nchunk, uninit_chunk, true);
+  return nchunks_ < 0 ? (int)nchunks_ : 0;
+}
+
+
+/* With locking disabled (the default), no sidecar must ever appear. */
+static char* test_locking_off(void) {
+  mu_assert("ERROR: cannot create the frame", fill_frame(false, false) == NCHUNKS);
+  blosc2_schunk* schunk = blosc2_schunk_open(URLPATH);
+  mu_assert("ERROR: cannot open the schunk", schunk != NULL);
+
+  uint8_t* chunk;
+  bool needs_free;
+  int csize = blosc2_schunk_get_chunk(schunk, 0, &chunk, &needs_free);
+  mu_assert("ERROR: cannot read a chunk", csize > 0);
+  if (needs_free) {
+    free(chunk);
+  }
+  mu_assert("ERROR: cannot evict a chunk", evict_chunk(schunk, 0) == 0);
+  mu_assert("ERROR: a sidecar lock file appeared with locking off",
+            !path_exists(URLPATH ".b2lock"));
+
+  blosc2_schunk_free(schunk);
+  blosc2_remove_urlpath(URLPATH);
+  return EXIT_SUCCESS;
+}
+
+
+/* Two locked handles in one process: the stale-handle re-sync must keep
+   working under locking, and the sidecar must appear. */
+static char* test_two_handles(void) {
+  mu_assert("ERROR: cannot create the frame", fill_frame(false, true) == NCHUNKS);
+
+  blosc2_schunk* h1 = blosc2_schunk_open_udio(URLPATH, locking_io());
+  blosc2_schunk* h2 = blosc2_schunk_open_udio(URLPATH, locking_io());
+  mu_assert("ERROR: cannot open the schunk twice", h1 != NULL && h2 != NULL);
+
+  // Warm h2's cached view
+  uint8_t* chunk;
+  bool needs_free;
+  int old_size = blosc2_schunk_get_chunk(h2, 0, &chunk, &needs_free);
+  mu_assert("ERROR: cannot read chunk 0 before the mutation", old_size > 0);
+  if (needs_free) {
+    free(chunk);
+  }
+
+  // The sidecar shows up after the first locked operation (sframe: inside the dir)
+  mu_assert("ERROR: the sidecar lock file did not appear",
+            path_exists(URLPATH "/.b2lock"));
+
+  mu_assert("ERROR: cannot evict chunk 0", evict_chunk(h1, 0) == 0);
+
+  int gsize = blosc2_schunk_get_chunk(h2, 0, &chunk, &needs_free);
+  mu_assert("ERROR: stale handle did not re-sync under locking",
+            gsize == BLOSC_EXTENDED_HEADER_LENGTH);
+  if (needs_free) {
+    free(chunk);
+  }
+  int lsize = blosc2_schunk_get_lazychunk(h2, 0, &chunk, &needs_free);
+  mu_assert("ERROR: get_lazychunk disagrees with get_chunk on the stale handle",
+            lsize == BLOSC_EXTENDED_HEADER_LENGTH);
+  if (needs_free) {
+    free(chunk);
+  }
+
+  blosc2_schunk_free(h1);
+  blosc2_schunk_free(h2);
+  blosc2_remove_urlpath(URLPATH);
+  return EXIT_SUCCESS;
+}
+
+
+/* The sidecar of a cframe must be removed along with the frame. */
+static char* test_sidecar_cleanup(void) {
+  mu_assert("ERROR: cannot create the frame", fill_frame(true, true) == NCHUNKS);
+
+  blosc2_schunk* schunk = blosc2_schunk_open_udio(URLPATH, locking_io());
+  mu_assert("ERROR: cannot open the schunk", schunk != NULL);
+  mu_assert("ERROR: cannot evict a chunk", evict_chunk(schunk, 0) == 0);
+  mu_assert("ERROR: the sidecar lock file did not appear",
+            path_exists(URLPATH ".b2lock"));
+  blosc2_schunk_free(schunk);
+
+  blosc2_remove_urlpath(URLPATH);
+  mu_assert("ERROR: the frame was not removed", !path_exists(URLPATH));
+  mu_assert("ERROR: the sidecar lock file was not removed",
+            !path_exists(URLPATH ".b2lock"));
+  return EXIT_SUCCESS;
+}
+
+
+#if !defined(_WIN32)
+/* The real test: a child process keeps rewriting chunks while the parent
+   reads all of them; with locking on, no read may ever fail (without it,
+   torn reads intermittently yield BLOSC2_ERROR_FILE_READ). */
+static char* test_fork_hammer(void) {
+  static int32_t data[CHUNKSIZE];
+  static int32_t data_dest[CHUNKSIZE];
+  const int child_iters = 300;
+
+  mu_assert("ERROR: cannot create the frame", fill_frame(false, true) == NCHUNKS);
+
+  pid_t pid = fork();
+  mu_assert("ERROR: cannot fork", pid >= 0);
+
+  if (pid == 0) {
+    /* Child: the evictor/writer.  Open our own handle (a handle inherited
+       through fork would share the parent's lock). */
+    blosc2_schunk* sc = blosc2_schunk_open_udio(URLPATH, locking_io());
+    if (sc == NULL) {
+      _exit(1);
+    }
+    for (int i = 0; i < child_iters; i++) {
+      int64_t nchunk = i % NCHUNKS;
+      if (i % 2 == 0) {
+        // Evict: replace with an UNINIT special chunk (truncates the chunk file)
+        if (evict_chunk(sc, nchunk) != 0) {
+          _exit(2);
+        }
+      }
+      else {
+        // Re-fill: replace with a freshly compressed regular chunk
+        for (int j = 0; j < CHUNKSIZE; j++) {
+          data[j] = i + j;
+        }
+        uint8_t* chunk = malloc(CHUNKSIZE * sizeof(int32_t) + BLOSC2_MAX_OVERHEAD);
+        int csize = blosc2_compress_ctx(sc->cctx, data, CHUNKSIZE * sizeof(int32_t),
+                                        chunk, CHUNKSIZE * sizeof(int32_t) + BLOSC2_MAX_OVERHEAD);
+        if (csize < 0) {
+          _exit(3);
+        }
+        int64_t nchunks_ = blosc2_schunk_update_chunk(sc, nchunk, chunk, false);
+        if (nchunks_ < 0) {
+          _exit(4);
+        }
+      }
+    }
+    blosc2_schunk_free(sc);
+    _exit(0);
+  }
+
+  /* Parent: the reader.  Sweep all chunks through all three read entry points
+     until the child finishes; every single read must succeed. */
+  blosc2_schunk* sc = blosc2_schunk_open_udio(URLPATH, locking_io());
+  mu_assert("ERROR: cannot open the schunk in the parent", sc != NULL);
+
+  int status = 0;
+  bool child_done = false;
+  long nreads = 0;
+  while (!child_done) {
+    if (waitpid(pid, &status, WNOHANG) == pid) {
+      child_done = true;  // do one final sweep below before checking status
+    }
+    for (int64_t nchunk = 0; nchunk < NCHUNKS; nchunk++) {
+      uint8_t* chunk;
+      bool needs_free;
+      int csize = blosc2_schunk_get_chunk(sc, nchunk, &chunk, &needs_free);
+      mu_assert("ERROR: get_chunk failed during concurrent writes", csize > 0);
+      if (needs_free) {
+        free(chunk);
+      }
+      csize = blosc2_schunk_get_lazychunk(sc, nchunk, &chunk, &needs_free);
+      mu_assert("ERROR: get_lazychunk failed during concurrent writes", csize > 0);
+      if (needs_free) {
+        free(chunk);
+      }
+      int dsize = blosc2_schunk_decompress_chunk(sc, nchunk, data_dest, sizeof(data_dest));
+      mu_assert("ERROR: decompress_chunk failed during concurrent writes", dsize >= 0);
+      nreads += 3;
+    }
+  }
+  printf("(%ld reads against %d writes) ", nreads, child_iters);
+  mu_assert("ERROR: the writer child failed",
+            WIFEXITED(status) && WEXITSTATUS(status) == 0);
+
+  blosc2_schunk_free(sc);
+  blosc2_remove_urlpath(URLPATH);
+  return EXIT_SUCCESS;
+}
+#endif  /* !_WIN32 */
+
+
+static char *all_tests(void) {
+  mu_run_test(test_locking_off);
+  mu_run_test(test_two_handles);
+  mu_run_test(test_sidecar_cleanup);
+#if !defined(_WIN32)
+  mu_run_test(test_fork_hammer);
+#endif
+  return EXIT_SUCCESS;
+}
+
+
+int main(void) {
+  char* result;
+
+  install_blosc_callback_test(); /* optionally install callback test */
+  blosc2_init();
+
+  /* Run all the suite */
+  result = all_tests();
+  if (result != EXIT_SUCCESS) {
+    printf(" (%s)\n", result);
+  }
+  else {
+    printf(" ALL TESTS PASSED");
+  }
+  printf("\tTests run: %d\n", tests_run);
+
+  blosc2_destroy();
+
+  return result != EXIT_SUCCESS;
+}


### PR DESCRIPTION
Several handles on the same on-disk frame (e.g. a cache evictor plus concurrent readers in different processes, as in Caterva2's peer cache) previously required external serialization: a reader landing mid-write could see a torn state, and two writers could clobber each other's updates to the offsets index.

Enable it by passing the new blosc2_stdio_params with `locking` set through blosc2_io.params (default filesystem I/O only; advisory, so every handle on the frame must opt in; not supported on NFS).  Off by default: zero cost and zero behavior change when not requested.

* frame.c: frame_lock()/frame_unlock() take a whole-frame advisory lock on a sidecar file next to the frame (<dir>/.b2lock for sframes, <file>.b2lock for cframes) via flock() on POSIX and LockFileEx() on Windows: shared for reads, exclusive for mutations, held per operation, re-entrant on the same handle via a depth counter, and crash-safe (the OS releases it on process death).
* The sidecar also carries a generation counter that exclusive lockers bump and every acquirer compares with the last value it saw, forcing a re-sync of the cached frame state on mismatch.  This makes the staleness detection exact, closing the blind spot of the length-based check (mutations that leave the on-disk frame length unchanged, e.g. evict+refill cycles restoring a previous length).
* schunk.c: read entry points take the shared lock around the frame access; mutating ones (append/insert/update/delete, fill_special, reorder_offsets, metalayer flushes) take the exclusive lock for the whole operation so their read-modify-write of the offsets index and counters is atomic.
* New BLOSC2_ERROR_LOCK error code.
* blosc2_remove_urlpath() also removes the cframe sidecar.

Also: tests/test_frame_lock.c (including a fork-based reader-vs-writer stress: ~50k reads against 300 concurrent rewrites, zero failures), bench/frame_lock_bench.c (measured overhead: ~0.6 us per operation, within noise except a few percent on the cheapest reads), the examples/file-locking.c walkthrough, and sidecar notes in the cframe and sframe format READMEs.