### PR TITLE
check chunk size before reading the flags2 byte

### DIFF
--- a/blosc/schunk.c
+++ b/blosc/schunk.c
@@ -889,9 +889,24 @@ static int schunk_get_chunk_nbytes(blosc2_schunk *schunk, int64_t nchunk, int32_
   return rc;
 }
 
+/* The flags2 byte lives in the extended header, at offset 0x1e.  A Blosc1-style
+   chunk is only BLOSC_MIN_HEADER_LENGTH (16) bytes long and carries no flags2,
+   so report it as unset instead of reading past the end of the buffer. */
+static uint8_t get_chunk_flags2(const uint8_t *chunk, int32_t chunk_cbytes) {
+  if (chunk_cbytes < BLOSC_EXTENDED_HEADER_LENGTH) {
+    return 0;
+  }
+  return chunk[BLOSC2_CHUNK_BLOSC2_FLAGS2];
+}
+
 static int schunk_get_chunk_flags2(blosc2_schunk *schunk, int64_t nchunk, uint8_t *chunk_flags2) {
   if (schunk->frame == NULL) {
-    *chunk_flags2 = schunk->data[nchunk][BLOSC2_CHUNK_BLOSC2_FLAGS2];
+    int32_t chunk_cbytes;
+    int rc = blosc2_cbuffer_sizes(schunk->data[nchunk], NULL, &chunk_cbytes, NULL);
+    if (rc < 0) {
+      return rc;
+    }
+    *chunk_flags2 = get_chunk_flags2(schunk->data[nchunk], chunk_cbytes);
     return 0;
   }
 
@@ -901,7 +916,7 @@ static int schunk_get_chunk_flags2(blosc2_schunk *schunk, int64_t nchunk, uint8_
   if (rc < 0) {
     return rc;
   }
-  *chunk_flags2 = chunk[BLOSC2_CHUNK_BLOSC2_FLAGS2];
+  *chunk_flags2 = get_chunk_flags2(chunk, rc);
   if (needs_free) {
     free(chunk);
   }
@@ -913,12 +928,13 @@ static int64_t schunk_append_chunk_unlocked(blosc2_schunk *schunk, uint8_t *chun
   int32_t chunk_nbytes;
   int32_t chunk_cbytes;
   int64_t nchunks = schunk->nchunks;
-  bool chunk_vlblocks = (chunk[BLOSC2_CHUNK_BLOSC2_FLAGS2] & BLOSC2_VL_BLOCKS) != 0;
 
   int rc = blosc2_cbuffer_sizes(chunk, &chunk_nbytes, &chunk_cbytes, NULL);
   if (rc < 0) {
     return rc;
   }
+  uint8_t flags2 = get_chunk_flags2(chunk, chunk_cbytes);
+  bool chunk_vlblocks = (flags2 & BLOSC2_VL_BLOCKS) != 0;
   if (nchunks > 0) {
     uint8_t first_flags2;
     rc = schunk_get_chunk_flags2(schunk, 0, &first_flags2);
@@ -931,7 +947,7 @@ static int64_t schunk_append_chunk_unlocked(blosc2_schunk *schunk, uint8_t *chun
     }
   }
   else {
-    schunk->flags2 = chunk[BLOSC2_CHUNK_BLOSC2_FLAGS2];
+    schunk->flags2 = flags2;
   }
 
   int32_t chunksize = schunk->chunksize;
@@ -1041,12 +1057,13 @@ static int64_t schunk_insert_chunk_unlocked(blosc2_schunk *schunk, int64_t nchun
   int32_t chunk_nbytes;
   int32_t chunk_cbytes;
   int64_t nchunks = schunk->nchunks;
-  bool chunk_vlblocks = (chunk[BLOSC2_CHUNK_BLOSC2_FLAGS2] & BLOSC2_VL_BLOCKS) != 0;
 
   rc = blosc2_cbuffer_sizes(chunk, &chunk_nbytes, &chunk_cbytes, NULL);
   if (rc < 0) {
     return rc;
   }
+  uint8_t flags2 = get_chunk_flags2(chunk, chunk_cbytes);
+  bool chunk_vlblocks = (flags2 & BLOSC2_VL_BLOCKS) != 0;
   if (nchunks > 0) {
     uint8_t first_flags2;
     rc = schunk_get_chunk_flags2(schunk, 0, &first_flags2);
@@ -1059,7 +1076,7 @@ static int64_t schunk_insert_chunk_unlocked(blosc2_schunk *schunk, int64_t nchun
     }
   }
   else {
-    schunk->flags2 = chunk[BLOSC2_CHUNK_BLOSC2_FLAGS2];
+    schunk->flags2 = flags2;
   }
 
   int32_t chunksize = schunk->chunksize;
@@ -1174,12 +1191,13 @@ static int64_t schunk_update_chunk_unlocked(blosc2_schunk *schunk, int64_t nchun
 
   int32_t chunk_nbytes;
   int32_t chunk_cbytes;
-  bool chunk_vlblocks = (chunk[BLOSC2_CHUNK_BLOSC2_FLAGS2] & BLOSC2_VL_BLOCKS) != 0;
 
   rc = blosc2_cbuffer_sizes(chunk, &chunk_nbytes, &chunk_cbytes, NULL);
   if (rc < 0) {
     return rc;
   }
+  uint8_t flags2 = get_chunk_flags2(chunk, chunk_cbytes);
+  bool chunk_vlblocks = (flags2 & BLOSC2_VL_BLOCKS) != 0;
   if (schunk->nchunks > 1 || (schunk->nchunks == 1 && nchunk != 0)) {
     int64_t ref_nchunk = (nchunk == 0) ? 1 : 0;
     uint8_t ref_flags2;
@@ -1193,7 +1211,7 @@ static int64_t schunk_update_chunk_unlocked(blosc2_schunk *schunk, int64_t nchun
     }
   }
   else {
-    schunk->flags2 = chunk[BLOSC2_CHUNK_BLOSC2_FLAGS2];
+    schunk->flags2 = flags2;
   }
 
   int32_t chunksize = schunk->chunksize;

--- a/tests/test_schunk_min_header_chunk.c
+++ b/tests/test_schunk_min_header_chunk.c
@@ -1,0 +1,114 @@
+/*
+  Copyright (c) 2026  Blosc Development Team <blosc@blosc.org>
+  https://blosc.org
+  License: BSD 3-Clause (see LICENSE.txt)
+
+  Regression test for an out-of-bounds read of the flags2 byte in
+  schunk.c. The Blosc2 flags2 byte sits at offset 0x1e, inside the
+  extended header, but a Blosc1-style chunk is only
+  BLOSC_MIN_HEADER_LENGTH (16) bytes long. Appending, inserting or
+  updating with such a chunk read 15 bytes past the end of the buffer.
+*/
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "test_common.h"
+
+int tests_run = 0;
+
+/* Build a minimal but valid Blosc1-style chunk of exactly
+   BLOSC_MIN_HEADER_LENGTH bytes. read_chunk_header() accepts
+   cbytes == BLOSC_MIN_HEADER_LENGTH, so this is a well-formed chunk. */
+static uint8_t *make_min_header_chunk(void) {
+  uint8_t *chunk = malloc(BLOSC_MIN_HEADER_LENGTH);
+  if (chunk == NULL) {
+    return NULL;
+  }
+  memset(chunk, 0, BLOSC_MIN_HEADER_LENGTH);
+  chunk[0] = BLOSC2_VERSION_FORMAT;
+  chunk[1] = 1;
+  /* Not shuffle+bitshuffle, so no extended header is expected. */
+  chunk[2] = BLOSC_MEMCPYED;
+  chunk[3] = 1;
+  int32_t nbytes = 0;
+  int32_t blocksize = 1;
+  int32_t cbytes = BLOSC_MIN_HEADER_LENGTH;
+  memcpy(chunk + 4, &nbytes, sizeof(nbytes));
+  memcpy(chunk + 8, &blocksize, sizeof(blocksize));
+  memcpy(chunk + 12, &cbytes, sizeof(cbytes));
+  return chunk;
+}
+
+
+static char* test_min_header_chunk(void) {
+  blosc2_init();
+
+  /* The chunk is well-formed as far as the header parser is concerned. */
+  uint8_t *probe = make_min_header_chunk();
+  mu_assert("cannot allocate chunk", probe != NULL);
+  int32_t nbytes, cbytes;
+  int rc = blosc2_cbuffer_sizes(probe, &nbytes, &cbytes, NULL);
+  mu_assert("min-header chunk rejected by blosc2_cbuffer_sizes", rc >= 0);
+  mu_assert("unexpected cbytes", cbytes == BLOSC_MIN_HEADER_LENGTH);
+  free(probe);
+
+  blosc2_storage storage = BLOSC2_STORAGE_DEFAULTS;
+  blosc2_schunk *schunk = blosc2_schunk_new(&storage);
+  mu_assert("cannot create schunk", schunk != NULL);
+
+  /* Reads flags2 out of the caller-supplied buffer. */
+  uint8_t *chunk = make_min_header_chunk();
+  mu_assert("cannot allocate chunk", chunk != NULL);
+  int64_t nchunks = blosc2_schunk_append_chunk(schunk, chunk, true);
+  free(chunk);
+  mu_assert("cannot append min-header chunk", nchunks == 1);
+
+  /* Reads flags2 back out of the stored chunk 0 to compare against. */
+  chunk = make_min_header_chunk();
+  mu_assert("cannot allocate chunk", chunk != NULL);
+  nchunks = blosc2_schunk_append_chunk(schunk, chunk, true);
+  free(chunk);
+  mu_assert("cannot append second min-header chunk", nchunks == 2);
+
+  chunk = make_min_header_chunk();
+  mu_assert("cannot allocate chunk", chunk != NULL);
+  nchunks = blosc2_schunk_update_chunk(schunk, 0, chunk, true);
+  free(chunk);
+  mu_assert("cannot update with min-header chunk", nchunks >= 0);
+
+  chunk = make_min_header_chunk();
+  mu_assert("cannot allocate chunk", chunk != NULL);
+  nchunks = blosc2_schunk_insert_chunk(schunk, 1, chunk, true);
+  free(chunk);
+  mu_assert("cannot insert min-header chunk", nchunks == 3);
+
+  blosc2_schunk_free(schunk);
+  blosc2_destroy();
+
+  return EXIT_SUCCESS;
+}
+
+
+static char *all_tests(void) {
+  mu_run_test(test_min_header_chunk);
+  return EXIT_SUCCESS;
+}
+
+
+int main(void) {
+  char *result;
+
+  result = all_tests();
+  if (result != EXIT_SUCCESS) {
+    printf(" (%s)\n", result);
+  }
+  else {
+    printf(" ALL TESTS PASSED");
+  }
+  printf("\tTests run: %d\n", tests_run);
+
+  return result != EXIT_SUCCESS;
+}

--- a/tests/test_schunk_min_header_chunk.c
+++ b/tests/test_schunk_min_header_chunk.c
@@ -19,6 +19,16 @@
 
 int tests_run = 0;
 
+/* Write a 32-bit int to the chunk header in little-endian order.
+ * Chunk headers are always little-endian, regardless of host endianness. */
+static void put_i32_le(uint8_t* dst, int32_t value) {
+  uint32_t uvalue = (uint32_t)value;
+  dst[0] = (uint8_t)(uvalue & 0xffu);
+  dst[1] = (uint8_t)((uvalue >> 8) & 0xffu);
+  dst[2] = (uint8_t)((uvalue >> 16) & 0xffu);
+  dst[3] = (uint8_t)((uvalue >> 24) & 0xffu);
+}
+
 /* Build a minimal but valid Blosc1-style chunk of exactly
    BLOSC_MIN_HEADER_LENGTH bytes. read_chunk_header() accepts
    cbytes == BLOSC_MIN_HEADER_LENGTH, so this is a well-formed chunk. */
@@ -36,9 +46,9 @@ static uint8_t *make_min_header_chunk(void) {
   int32_t nbytes = 0;
   int32_t blocksize = 1;
   int32_t cbytes = BLOSC_MIN_HEADER_LENGTH;
-  memcpy(chunk + 4, &nbytes, sizeof(nbytes));
-  memcpy(chunk + 8, &blocksize, sizeof(blocksize));
-  memcpy(chunk + 12, &cbytes, sizeof(cbytes));
+  put_i32_le(chunk + BLOSC2_CHUNK_NBYTES, nbytes);
+  put_i32_le(chunk + BLOSC2_CHUNK_BLOCKSIZE, blocksize);
+  put_i32_le(chunk + BLOSC2_CHUNK_CBYTES, cbytes);
   return chunk;
 }
 


### PR DESCRIPTION
The flags2 byte that records whether a chunk uses variable-length blocks sits at offset 0x1e, which is inside the extended header. A Blosc1-style chunk is only BLOSC_MIN_HEADER_LENGTH bytes long and read_chunk_header() treats cbytes == 16 as valid, so such a chunk has no flags2 byte at all. The append, insert and update paths in schunk.c read chunk[BLOSC2_CHUNK_BLOSC2_FLAGS2] to test for BLOSC2_VL_BLOCKS before they call blosc2_cbuffer_sizes(), so handing a 16-byte chunk to blosc2_schunk_append_chunk() reads 15 bytes past the end of the caller's buffer. I ran into it under ASAN while pushing minimal chunks through the public append API, and then found schunk_get_chunk_flags2() has the same problem on chunks already stored in the schunk, so patching only the append site moves the same over-read to the second append instead of removing it. Routing all of them through one helper that reports flags2 as unset below BLOSC_EXTENDED_HEADER_LENGTH keeps the size lookup ahead of the read. Chunks carrying a real extended header always have the byte, so their behaviour is unchanged, and the added test covers the four entry points.